### PR TITLE
Heartbeat beanstalk

### DIFF
--- a/cloud/aws/beanstalk/README.md
+++ b/cloud/aws/beanstalk/README.md
@@ -1,0 +1,16 @@
+# AWS Beanstalk SignalFx detectors
+
+## How to use this module
+
+```hcl
+module "signalfx-detectors-aws-beanstalk" {
+  source      = "github.com/claranet/terraform-signalfx-detectors.git//cloud/aws/beanstalk?ref=master"
+
+  prefixes      = [var.app_name]
+  environment   = var.env
+  filter_custom_includes =  [format("EnvironmentName:%s", var.app_name)]
+  notifications = var.notifications 
+}
+```
+
+**Note :** for now, SignalFx does not sync AWS Beanstalk tags so the default filtering with the `env` tag is not working. The best way to use this module is to filter with your AWS Beanstalk environment name. You will need to instantiate this module for each Beanstalk environment.

--- a/cloud/aws/beanstalk/detectors-beanstalk.tf
+++ b/cloud/aws/beanstalk/detectors-beanstalk.tf
@@ -3,8 +3,8 @@ resource "signalfx_detector" "heartbeat" {
 
   program_text = <<-EOF
 		from signalfx.detectors.not_reporting import not_reporting
-		signal = data('InstanceHealth', filter=filter('stat', 'mean') and filter('namespace', 'AWS/ElasticBeanstalk') and ${module.filter-tags.filter_custom}).publish('signal')
-		not_reporting.detector(stream=signal, resource_identifier=['InstanceId'], duration='${var.heartbeat_timeframe}').publish('CRIT')
+		signal = data('EnvironmentHealth', filter=filter('stat', 'upper') and filter('namespace', 'AWS/ElasticBeanstalk') and ${module.filter-tags.filter_custom}).publish('signal')
+		not_reporting.detector(stream=signal, resource_identifier=['EnvironmentName'], duration='${var.heartbeat_timeframe}').publish('CRIT')
 	EOF
 
   rule {

--- a/cloud/aws/vpn/README.md
+++ b/cloud/aws/vpn/README.md
@@ -1,0 +1,16 @@
+# AWS VPN SignalFx detectors
+
+## How to use this module
+
+```hcl
+module "signalfx-detectors-aws-vpn" {
+  source      = "github.com/claranet/terraform-signalfx-detectors.git//cloud/aws/vpn?ref=master"
+
+  prefixes      = [var.vpn_id]
+  environment   = var.env
+  filter_custom_includes =  [format("VpnId:%s", var.vpn_id)]
+  notifications = var.notifications 
+}
+```
+
+**Note :** for now, SignalFx does not sync AWS VPN tags so the default filtering with the `env` tag is not working. The best way to use this module is to filter for each VPN connections with its id. You will need to instantiate this module for each VPN connections.


### PR DESCRIPTION
* Change AWS Beanstalk module heartbeat to use `EnvironmentHealth` instead of `InstanceHealth` which trigger alerts when shuting down environment at night for example
* Add small README for AWS Beanstalk to warn about tags syncing not working
* Add small README for AWS VPN to warn about tags syncing not working