### PR TITLE
Add supervisor detector

### DIFF
--- a/middleware/supervisor/README.md
+++ b/middleware/supervisor/README.md
@@ -53,4 +53,5 @@ Creates SignalFx detectors with the following checks:
 
 ## Related documentation
 
+[Official documentation for supervisor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/supervisor.html)
 [Supervisor state definition](http://supervisord.org/subprocess.html#process-states)

--- a/middleware/supervisor/README.md
+++ b/middleware/supervisor/README.md
@@ -1,0 +1,56 @@
+# MIDDLEWARE SUPERVISOR SignalFx detectors
+
+## How to use this module
+
+```hcl
+module "signalfx-detectors-middleware-supervisor" {
+  source      = "github.com/claranet/terraform-signalfx-detectors.git//middleware/supervisor?ref={revision}"
+
+  environment = var.environment
+  notifications = var.notifications
+}
+
+```
+
+## Purpose
+
+Creates SignalFx detectors with the following checks:
+
+- Supervisor process state
+- Supervisor heartbeat
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| detectors\_disabled | Disable all detectors in this module | bool | `"false"` | no |
+| environment | Infrastructure environment | string | n/a | yes |
+| filter\_custom\_excludes | List of tags to exclude when custom filtering is used | list | `[]` | no |
+| filter\_custom\_includes | List of tags to include when custom filtering is used | list | `[]` | no |
+| heartbeat\_disabled | Disable all alerting rules for heartbeat detector | bool | `"null"` | no |
+| heartbeat\_notifications | Notification recipients list for every alerting rules of heartbeat detector | list | `[]` | no |
+| heartbeat\_timeframe | Timeframe for system not reporting detector \(i.e. "10m"\) | string | `"20m"` | no |
+| notifications | Notification recipients list for every detectors | list | n/a | yes |
+| prefixes | Prefixes list to prepend between brackets on every monitors names before environment | list | `[]` | no |
+| process\_state\_aggregation\_function | Aggregation function and group by for process state detector \(i.e. ".mean\(by=\['host'\]\)."\) | string | `""` | no |
+| process\_state\_disabled | Disable all alerting rules for process state detector | bool | `"null"` | no |
+| process\_state\_disabled\_critical | Disable critical alerting rule for process state detector | bool | `"null"` | no |
+| process\_state\_disabled\_warning | Disable warning alerting rule for process state detector | bool | `"null"` | no |
+| process\_state\_notifications | Notification recipients list for every alerting rules of process state detector | list | `[]` | no |
+| process\_state\_notifications\_critical | Notification recipients list for critical alerting rule of process state detector | list | `[]` | no |
+| process\_state\_notifications\_warning | Notification recipients list for warning alerting rule of process state detector | list | `[]` | no |
+| process\_state\_threshold\_critical | Critical threshold for process state detector, see http://supervisord.org/subprocess.html#process-states\) | number | `"20"` | no |
+| process\_state\_threshold\_warning | Warning threshold for process state detector \(default to be less then 20 \(process has been stopped manually or is starting\), see http://supervisord.org/subprocess.html#process-states | number | `"20"` | no |
+| process\_state\_transformation\_function | Transformation function for process state detector \(mean, min, max\) | string | `"min"` | no |
+| process\_state\_transformation\_window | Transformation window for process state detector \(i.e. 5m, 20m, 1h, 1d\) | string | `"10m"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| heartbeat\_id | id for detector heartbeat |
+| process\_state\_id | id for detector process state |
+
+## Related documentation
+
+[Supervisor state definition](http://supervisord.org/subprocess.html#process-states)

--- a/middleware/supervisor/detectors-supervisor.tf
+++ b/middleware/supervisor/detectors-supervisor.tf
@@ -1,0 +1,47 @@
+resource "signalfx_detector" "heartbeat" {
+  name = "${join("", formatlist("[%s]", var.prefixes))}[${var.environment}] Supervisor heartbeat"
+
+  program_text = <<-EOF
+		from signalfx.detectors.not_reporting import not_reporting
+		signal = data('supervisor.state', filter=${module.filter-tags.filter_custom}).publish('signal')
+		not_reporting.detector(stream=signal, resource_identifier=['host'], duration='${var.heartbeat_timeframe}').publish('CRIT')
+  EOF
+
+  rule {
+    description           = "has not reported in ${var.heartbeat_timeframe}"
+    severity              = "Critical"
+    detect_label          = "CRIT"
+    disabled              = coalesce(var.heartbeat_disabled, var.detectors_disabled)
+    notifications         = coalescelist(var.heartbeat_notifications, var.notifications)
+    parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
+  }
+}
+
+resource "signalfx_detector" "process_state" {
+  name = "${join("", formatlist("[%s]", var.prefixes))}[${var.environment}] Supervisor process"
+
+  program_text = <<-EOF
+		signal = data('supervisor.state', filter=${module.filter-tags.filter_custom})${var. process_state_aggregation_function}.${var. process_state_transformation_function}(over='${var.process_state_transformation_window}').publish('signal')
+		detect(when(signal > ${var.process_state_threshold_critical})).publish('CRIT')
+		detect(when(signal < ${var.process_state_threshold_warning})).publish('WARN')
+  EOF
+
+  rule {
+    description           = "is not running (and not stopped)"
+    severity              = "Critical"
+    detect_label          = "CRIT"
+    disabled              = coalesce(var.process_state_disabled_critical, var.process_state_disabled, var.detectors_disabled)
+    notifications         = coalescelist(var.process_state_notifications_critical, var.process_state_notifications, var.notifications)
+    parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
+  }
+
+  rule {
+    description           = "is stopped"
+    severity              = "Warning"
+    detect_label          = "WARN"
+    disabled              = coalesce(var.process_state_disabled_warning, var.process_state_disabled, var.detectors_disabled)
+    notifications         = coalescelist(var.process_state_notifications_warning, var.process_state_notifications, var.notifications)
+    parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
+  }
+}
+

--- a/middleware/supervisor/detectors-supervisor.tf
+++ b/middleware/supervisor/detectors-supervisor.tf
@@ -3,7 +3,7 @@ resource "signalfx_detector" "heartbeat" {
 
   program_text = <<-EOF
 		from signalfx.detectors.not_reporting import not_reporting
-		signal = data('supervisor.state', filter=${module.filter-tags.filter_custom}).publish('signal')
+		signal = data('supervisor.state', filter=filter('aws_state', 'running') and filter('gcp_status', '*RUNNING}') and filter('azure_power_state', 'PowerState/running') and ${module.filter-tags.filter_custom}).publish('signal')
 		not_reporting.detector(stream=signal, resource_identifier=['host'], duration='${var.heartbeat_timeframe}').publish('CRIT')
   EOF
 

--- a/middleware/supervisor/modules.tf
+++ b/middleware/supervisor/modules.tf
@@ -1,0 +1,8 @@
+module "filter-tags" {
+  source = "github.com/claranet/terraform-signalfx-detectors.git//common/filter-tags"
+
+  filter_defaults        = "filter('env', '${var.environment}') and filter('sfx_monitored', 'true')"
+  filter_custom_includes = var.filter_custom_includes
+  filter_custom_excludes = var.filter_custom_excludes
+}
+

--- a/middleware/supervisor/outputs.tf
+++ b/middleware/supervisor/outputs.tf
@@ -1,0 +1,10 @@
+output "process_state_id" {
+  description = "id for detector process state"
+  value       = signalfx_detector.process_state.*.id
+}
+
+output "heartbeat_id" {
+  description = "id for detector heartbeat"
+  value       = signalfx_detector.heartbeat.*.id
+}
+

--- a/middleware/supervisor/variables.tf
+++ b/middleware/supervisor/variables.tf
@@ -1,0 +1,124 @@
+# Global
+
+variable "environment" {
+  description = "Infrastructure environment"
+  type        = string
+}
+
+# SignalFx module specific
+
+variable "notifications" {
+  description = "Notification recipients list for every detectors"
+  type        = list
+}
+
+variable "prefixes" {
+  description = "Prefixes list to prepend between brackets on every monitors names before environment"
+  type        = list
+  default     = []
+}
+
+variable "filter_custom_includes" {
+  description = "List of tags to include when custom filtering is used"
+  type        = list
+  default     = []
+}
+
+variable "filter_custom_excludes" {
+  description = "List of tags to exclude when custom filtering is used"
+  type        = list
+  default     = []
+}
+
+variable "detectors_disabled" {
+  description = "Disable all detectors in this module"
+  type        = bool
+  default     = false
+}
+
+# Supervisor detectors specific
+
+variable "heartbeat_disabled" {
+  description = "Disable all alerting rules for heartbeat detector"
+  type        = bool
+  default     = null
+}
+
+variable "heartbeat_notifications" {
+  description = "Notification recipients list for every alerting rules of heartbeat detector"
+  type        = list
+  default     = []
+}
+
+variable "heartbeat_timeframe" {
+  description = "Timeframe for system not reporting detector (i.e. \"10m\")"
+  type        = string
+  default     = "20m"
+}
+
+variable "process_state_disabled" {
+  description = "Disable all alerting rules for process state detector"
+  type        = bool
+  default     = null
+}
+
+variable "process_state_disabled_critical" {
+  description = "Disable critical alerting rule for process state detector"
+  type        = bool
+  default     = null
+}
+
+variable "process_state_disabled_warning" {
+  description = "Disable warning alerting rule for process state detector"
+  type        = bool
+  default     = null
+}
+
+variable "process_state_notifications" {
+  description = "Notification recipients list for every alerting rules of process state detector"
+  type        = list
+  default     = []
+}
+
+variable "process_state_notifications_warning" {
+  description = "Notification recipients list for warning alerting rule of process state detector"
+  type        = list
+  default     = []
+}
+
+variable "process_state_notifications_critical" {
+  description = "Notification recipients list for critical alerting rule of process state detector"
+  type        = list
+  default     = []
+}
+
+variable "process_state_aggregation_function" {
+  description = "Aggregation function and group by for process state detector (i.e. \".mean(by=['host']).\")"
+  type        = string
+  default     = ""
+}
+
+variable "process_state_transformation_function" {
+  description = "Transformation function for process state detector (mean, min, max)"
+  type        = string
+  default     = "min"
+}
+
+variable "process_state_transformation_window" {
+  description = "Transformation window for process state detector (i.e. 5m, 20m, 1h, 1d)"
+  type        = string
+  default     = "10m"
+}
+
+variable "process_state_threshold_critical" {
+  description = "Critical threshold for process state detector, see http://supervisord.org/subprocess.html#process-states)"
+  type        = number
+  default     = 20
+}
+
+variable "process_state_threshold_warning" {
+  description = "Warning threshold for process state detector (default to be less then 20 (process has been stopped manually or is starting), see http://supervisord.org/subprocess.html#process-states "
+  type        = number
+  default     = 20
+}
+


### PR DESCRIPTION
Add `supervisor` detector now that the monitor is available in agent v5.2.

The default behavior is to :
* Alert CRITICAL when the process is not running and not stopped
* Alert WARNING when the process has been stopped manually