### PR TITLE
AWS SQS heartbeat: use NumberOfMessagesReceived instead of SentMessag…

### DIFF
--- a/cloud/aws/sqs/detectors-sqs.tf
+++ b/cloud/aws/sqs/detectors-sqs.tf
@@ -3,7 +3,7 @@ resource "signalfx_detector" "heartbeat" {
 
   program_text = <<-EOF
 		from signalfx.detectors.not_reporting import not_reporting
-		signal = data('SentMessageSize', filter=filter('stat', 'mean') and filter('namespace', 'AWS/SQS') and ${module.filter-tags.filter_custom}).publish('signal')
+		signal = data('NumberOfMessagesReceived', filter=filter('stat', 'mean') and filter('namespace', 'AWS/SQS') and ${module.filter-tags.filter_custom}).publish('signal')
 		not_reporting.detector(stream=signal, resource_identifier=['QueueName'], duration='${var.heartbeat_timeframe}').publish('CRIT')
 	EOF
 


### PR DESCRIPTION
…eSize

SentMessageSize doesn't report when there is no data in the queue
(contrary to NumberOfMessagesReceived)