### PR TITLE
Add Haproxy detectors

### DIFF
--- a/middleware/haproxy/README.md
+++ b/middleware/haproxy/README.md
@@ -1,0 +1,128 @@
+# MIDDLEWARE HAPROXY SignalFx detectors
+
+## How to use this module
+
+```hcl
+module "signalfx-detectors-middleware-haproxy" {
+  source      = "github.com/claranet/terraform-signalfx-detectors.git//middleware/haproxy?ref={revision}"
+
+  environment = var.environment
+  notifications = var.notifications
+}
+```
+
+In order to work properly, this module needs some [extraMetrics](https://docs.signalfx.com/en/latest/integrations/agent/monitors/haproxy.html#non-default-metrics-version-4-7-0), the agent needs a least the following configuration for the [haproxy](https://docs.signalfx.com/en/latest/integrations/agent/monitors/haproxy.html) monitor :
+
+```
+monitors:
+  - type: haproxy
+    extraMetrics:
+      - haproxy_session_limit
+      - haproxy_session_total
+      - haproxy_status
+      - haproxy_request_total
+```
+
+## Purpose
+
+Creates SignalFx detectors with the following checks:
+
+* Haproxy heartbeat
+* Haproxy server status
+* Haproxy backend status
+* Haproxy session limit (on frontend, backend and server)
+* Haproxy 4xx response rate (on frontend and backend with http mode)
+* Haproxy 5xx response rate (on frontend and backend with http mode)
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| backend\_status\_aggregation\_function | Aggregation function and group by for backend status detector (i.e. ".mean(by=['host']).") | `string` | `""` | no |
+| backend\_status\_disabled | Disable all alerting rules for backend status detector | `bool` | `null` | no |
+| backend\_status\_disabled\_critical | Disable critical alerting rule for backend status detector | `bool` | `null` | no |
+| backend\_status\_notifications | Notification recipients list for every alerting rules of backend status detector | `list` | `[]` | no |
+| backend\_status\_notifications\_critical | Notification recipients list for critical alerting rule of backend status detector | `list` | `[]` | no |
+| backend\_status\_transformation\_function | Transformation function for backend status detector (mean, min, max) | `string` | `"min"` | no |
+| backend\_status\_transformation\_window | Transformation window for backend status detector (i.e. 5m, 20m, 1h, 1d) | `string` | `"5m"` | no |
+| detectors\_disabled | Disable all detectors in this module | `bool` | `false` | no |
+| environment | Infrastructure environment | `string` | n/a | yes |
+| filter\_custom\_excludes | List of tags to exclude when custom filtering is used | `list` | `[]` | no |
+| filter\_custom\_includes | List of tags to include when custom filtering is used | `list` | `[]` | no |
+| heartbeat\_disabled | Disable all alerting rules for heartbeat detector | `bool` | `null` | no |
+| heartbeat\_notifications | Notification recipients list for every alerting rules of heartbeat detector | `list` | `[]` | no |
+| heartbeat\_timeframe | Timeframe for system not reporting detector (i.e. "10m") | `string` | `"20m"` | no |
+| http\_4xx\_response\_aggregation\_function | Aggregation function and group by for http\_4xx\_response detector (i.e. ".mean(by=['host']).") | `string` | `""` | no |
+| http\_4xx\_response\_disabled | Disable all alerting rules for http\_4xx\_response detector | `bool` | `null` | no |
+| http\_4xx\_response\_disabled\_critical | Disable critical alerting rule for http\_4xx\_response detector | `bool` | `null` | no |
+| http\_4xx\_response\_disabled\_warning | Disable warning alerting rule for http\_4xx\_response detector | `bool` | `null` | no |
+| http\_4xx\_response\_notifications | Notification recipients list for every alerting rules of http\_4xx\_response detector | `list` | `[]` | no |
+| http\_4xx\_response\_notifications\_critical | Notification recipients list for critical alerting rule of http\_4xx\_response detector | `list` | `[]` | no |
+| http\_4xx\_response\_notifications\_warning | Notification recipients list for warning alerting rule of http\_4xx\_response detector | `list` | `[]` | no |
+| http\_4xx\_response\_threshold\_critical | Critical threshold for http\_4xx\_response detector | `number` | `80` | no |
+| http\_4xx\_response\_threshold\_warning | Critical threshold for http\_4xx\_response detector | `number` | `50` | no |
+| http\_4xx\_response\_transformation\_function | Transformation function for http\_4xx\_response detector (mean, min, max) | `string` | `"min"` | no |
+| http\_4xx\_response\_transformation\_window | Transformation window for http\_4xx\_response detector (i.e. 5m, 20m, 1h, 1d) | `string` | `"10m"` | no |
+| http\_5xx\_response\_aggregation\_function | Aggregation function and group by for http\_5xx\_response detector (i.e. ".mean(by=['host']).") | `string` | `""` | no |
+| http\_5xx\_response\_disabled | Disable all alerting rules for http\_5xx\_response detector | `bool` | `null` | no |
+| http\_5xx\_response\_disabled\_critical | Disable critical alerting rule for http\_5xx\_response detector | `bool` | `null` | no |
+| http\_5xx\_response\_disabled\_warning | Disable warning alerting rule for http\_5xx\_response detector | `bool` | `null` | no |
+| http\_5xx\_response\_notifications | Notification recipients list for every alerting rules of http\_5xx\_response detector | `list` | `[]` | no |
+| http\_5xx\_response\_notifications\_critical | Notification recipients list for critical alerting rule of http\_5xx\_response detector | `list` | `[]` | no |
+| http\_5xx\_response\_notifications\_warning | Notification recipients list for warning alerting rule of http\_5xx\_response detector | `list` | `[]` | no |
+| http\_5xx\_response\_threshold\_critical | Critical threshold for http\_5xx\_response detector | `number` | `80` | no |
+| http\_5xx\_response\_threshold\_warning | Critical threshold for http\_5xx\_response detector | `number` | `50` | no |
+| http\_5xx\_response\_transformation\_function | Transformation function for http\_5xx\_response detector (mean, min, max) | `string` | `"min"` | no |
+| http\_5xx\_response\_transformation\_window | Transformation window for http\_5xx\_response detector (i.e. 5m, 20m, 1h, 1d) | `string` | `"10m"` | no |
+| notifications | Notification recipients list for every detectors | `list` | n/a | yes |
+| prefixes | Prefixes list to prepend between brackets on every monitors names before environment | `list` | `[]` | no |
+| server\_status\_aggregation\_function | Aggregation function and group by for server status detector (i.e. ".mean(by=['host']).") | `string` | `""` | no |
+| server\_status\_disabled | Disable all alerting rules for server status detector | `bool` | `null` | no |
+| server\_status\_disabled\_critical | Disable critical alerting rule for server status detector | `bool` | `null` | no |
+| server\_status\_notifications | Notification recipients list for every alerting rules of server status detector | `list` | `[]` | no |
+| server\_status\_notifications\_critical | Notification recipients list for critical alerting rule of server status detector | `list` | `[]` | no |
+| server\_status\_transformation\_function | Transformation function for server status detector (mean, min, max) | `string` | `"min"` | no |
+| server\_status\_transformation\_window | Transformation window for server status detector (i.e. 5m, 20m, 1h, 1d) | `string` | `"5m"` | no |
+| session\_limit\_aggregation\_function | Aggregation function and group by for session limit detector (i.e. ".mean(by=['host']).") | `string` | `""` | no |
+| session\_limit\_disabled | Disable all alerting rules for session limit detector | `bool` | `null` | no |
+| session\_limit\_disabled\_critical | Disable critical alerting rule for session limit detector | `bool` | `null` | no |
+| session\_limit\_disabled\_warning | Disable warning alerting rule for session limit detector | `bool` | `null` | no |
+| session\_limit\_notifications | Notification recipients list for every alerting rules of session limit detector | `list` | `[]` | no |
+| session\_limit\_notifications\_critical | Notification recipients list for critical alerting rule of session limit detector | `list` | `[]` | no |
+| session\_limit\_notifications\_warning | Notification recipients list for warning alerting rule of session limit detector | `list` | `[]` | no |
+| session\_limit\_threshold\_critical | Critical threshold for session limit detector | `number` | `90` | no |
+| session\_limit\_threshold\_warning | Critical threshold for session limit detector | `number` | `80` | no |
+| session\_limit\_transformation\_function | Transformation function for session limit detector (mean, min, max) | `string` | `"min"` | no |
+| session\_limit\_transformation\_window | Transformation window for session limit detector (i.e. 5m, 20m, 1h, 1d) | `string` | `"10m"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| backend\_status\_id | id for detector backend\_status |
+| heartbeat\_id | id for detector heartbeat |
+| http\_4xx\_response\_id | id for detector http\_4xx\_response |
+| http\_5xx\_response\_id | id for detector http\_5xx\_response |
+| server\_status\_id | id for detector server\_status |
+| session\_limit\_id | id for detector session\_limit |
+
+## Related documentation
+
+[Official documentation](https://docs.signalfx.com/en/latest/integrations/agent/monitors/haproxy.html)
+[Haproxy blog post on the stats page](https://www.haproxy.com/fr/blog/exploring-the-haproxy-stats-page/)
+[Haproxy documentation](https://cbonte.github.io/haproxy-dconv/2.0/configuration.html)
+
+## Notes
+
+In order to work properly, this module needs some [extraMetrics](https://docs.signalfx.com/en/latest/integrations/agent/monitors/haproxy.html#non-default-metrics-version-4-7-0), the agent needs a least the following configuration for the [haproxy](https://docs.signalfx.com/en/latest/integrations/agent/monitors/haproxy.html) monitor :
+
+```
+monitors:
+  - type: haproxy
+    extraMetrics:
+      - haproxy_session_limit
+      - haproxy_session_total
+      - haproxy_status
+      - haproxy_request_total
+```
+

--- a/middleware/haproxy/detectors-haproxy.tf
+++ b/middleware/haproxy/detectors-haproxy.tf
@@ -1,0 +1,144 @@
+resource "signalfx_detector" "heartbeat" {
+  name = "${join("", formatlist("[%s]", var.prefixes))}[${var.environment}] Haproxy heartbeat"
+
+  program_text = <<-EOF
+		from signalfx.detectors.not_reporting import not_reporting
+		signal = data('haproxy_session_current', filter=filter('aws_state', 'running') and filter('gcp_status', '*RUNNING}') and filter('azure_power_state', 'PowerState/running') and ${module.filter-tags.filter_custom}).publish('signal')
+		not_reporting.detector(stream=signal, resource_identifier=['host'], duration='${var.heartbeat_timeframe}').publish('CRIT')
+  EOF
+
+  rule {
+    description           = "has not reported in ${var.heartbeat_timeframe}"
+    severity              = "Critical"
+    detect_label          = "CRIT"
+    disabled              = coalesce(var.heartbeat_disabled, var.detectors_disabled)
+    notifications         = coalescelist(var.heartbeat_notifications, var.notifications)
+    parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
+  }
+}
+
+resource "signalfx_detector" "server_status" {
+  name = "${join("", formatlist("[%s]", var.prefixes))}[${var.environment}] Haproxy server status"
+
+  program_text = <<-EOF
+		signal = data('haproxy_status', filter=filter('type', '2') and ${module.filter-tags.filter_custom})${var.server_status_aggregation_function}.${var.server_status_transformation_function}(over='${var.server_status_transformation_window}').publish('signal')
+		detect(when(signal < 1)).publish('CRIT')
+  EOF
+
+  rule {
+    description           = "is down or in maintenance"
+    severity              = "Critical"
+    detect_label          = "CRIT"
+    disabled              = coalesce(var.server_status_disabled_critical, var.server_status_disabled, var.detectors_disabled)
+    notifications         = coalescelist(var.server_status_notifications_critical, var.server_status_notifications, var.notifications)
+    parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
+  }
+}
+
+resource "signalfx_detector" "backend_status" {
+  name = "${join("", formatlist("[%s]", var.prefixes))}[${var.environment}] Haproxy backend status"
+
+  program_text = <<-EOF
+		signal = data('haproxy_status', filter=filter('type', '1') and ${module.filter-tags.filter_custom})${var.backend_status_aggregation_function}.${var.backend_status_transformation_function}(over='${var.backend_status_transformation_window}').publish('signal')
+		detect(when(signal < 1)).publish('CRIT')
+  EOF
+
+  rule {
+    description           = "is down (no available server left)"
+    severity              = "Critical"
+    detect_label          = "CRIT"
+    disabled              = coalesce(var.backend_status_disabled_critical, var.backend_status_disabled, var.detectors_disabled)
+    notifications         = coalescelist(var.backend_status_notifications_critical, var.backend_status_notifications, var.notifications)
+    parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
+  }
+}
+
+resource "signalfx_detector" "session_limit" {
+  name = "${join("", formatlist("[%s]", var.prefixes))}[${var.environment}] Haproxy session"
+
+  program_text = <<-EOF
+        A = data('haproxy_session_current', filter=${module.filter-tags.filter_custom})${var.session_limit_aggregation_function}
+        B = data('haproxy_session_limit', filter=${module.filter-tags.filter_custom})${var.session_limit_aggregation_function}
+        signal = (A/B).scale(100).${var.session_limit_transformation_function}(over='${var.session_limit_transformation_window}').publish('signal')
+        detect(when(signal > ${var.session_limit_threshold_critical})).publish('CRIT')
+        detect(when(signal > ${var.session_limit_threshold_warning}) and when(signal <= ${var.session_limit_threshold_critical})).publish('WARN')
+  EOF
+
+  rule {
+    description           = "is approaching the limit > ${var.session_limit_threshold_critical}%"
+    severity              = "Critical"
+    detect_label          = "CRIT"
+    disabled              = coalesce(var.session_limit_disabled_critical, var.session_limit_disabled, var.detectors_disabled)
+    notifications         = coalescelist(var.session_limit_notifications_critical, var.session_limit_notifications, var.notifications)
+    parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
+  }
+
+  rule {
+    description           = "is approaching the limit > ${var.session_limit_threshold_warning}%"
+    severity              = "Warning"
+    detect_label          = "WARN"
+    disabled              = coalesce(var.session_limit_disabled_warning, var.session_limit_disabled, var.detectors_disabled)
+    notifications         = coalescelist(var.session_limit_notifications_warning, var.session_limit_notifications, var.notifications)
+    parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
+  }
+}
+
+resource "signalfx_detector" "http_5xx_response" {
+  name = "${join("", formatlist("[%s]", var.prefixes))}[${var.environment}] Haproxy 5xx response rate"
+
+  program_text = <<-EOF
+        A = data('haproxy_response_5xx', filter=${module.filter-tags.filter_custom})${var.http_5xx_response_aggregation_function}
+        B = data('haproxy_request_total', filter=${module.filter-tags.filter_custom})${var.http_5xx_response_aggregation_function}
+        signal = (A/B).scale(100).${var.http_5xx_response_transformation_function}(over='${var.http_5xx_response_transformation_window}').publish('signal')
+        detect(when(signal > ${var.http_5xx_response_threshold_critical})).publish('CRIT')
+        detect(when(signal > ${var.http_5xx_response_threshold_warning}) and when(signal <= ${var.http_5xx_response_threshold_critical})).publish('WARN')
+  EOF
+
+  rule {
+    description           = "is too high > ${var.http_5xx_response_threshold_critical}%"
+    severity              = "Critical"
+    detect_label          = "CRIT"
+    disabled              = coalesce(var.http_5xx_response_disabled_critical, var.http_5xx_response_disabled, var.detectors_disabled)
+    notifications         = coalescelist(var.http_5xx_response_notifications_critical, var.http_5xx_response_notifications, var.notifications)
+    parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
+  }
+
+  rule {
+    description           = "is too high > ${var.http_5xx_response_threshold_warning}%"
+    severity              = "Warning"
+    detect_label          = "WARN"
+    disabled              = coalesce(var.http_5xx_response_disabled_warning, var.http_5xx_response_disabled, var.detectors_disabled)
+    notifications         = coalescelist(var.http_5xx_response_notifications_warning, var.http_5xx_response_notifications, var.notifications)
+    parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
+  }
+}
+
+resource "signalfx_detector" "http_4xx_response" {
+  name = "${join("", formatlist("[%s]", var.prefixes))}[${var.environment}] Haproxy 4xx response rate"
+
+  program_text = <<-EOF
+        A = data('haproxy_response_4xx', filter=${module.filter-tags.filter_custom})${var.http_4xx_response_aggregation_function}
+        B = data('haproxy_request_total', filter=${module.filter-tags.filter_custom})${var.http_4xx_response_aggregation_function}
+        signal = (A/B).scale(100).${var.http_4xx_response_transformation_function}(over='${var.http_4xx_response_transformation_window}').publish('signal')
+        detect(when(signal > ${var.http_4xx_response_threshold_critical})).publish('CRIT')
+        detect(when(signal > ${var.http_4xx_response_threshold_warning}) and when(signal <= ${var.http_4xx_response_threshold_critical})).publish('WARN')
+  EOF
+
+  rule {
+    description           = "is too high > ${var.http_4xx_response_threshold_critical}%"
+    severity              = "Critical"
+    detect_label          = "CRIT"
+    disabled              = coalesce(var.http_4xx_response_disabled_critical, var.http_4xx_response_disabled, var.detectors_disabled)
+    notifications         = coalescelist(var.http_4xx_response_notifications_critical, var.http_4xx_response_notifications, var.notifications)
+    parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
+  }
+
+  rule {
+    description           = "is too high > ${var.http_4xx_response_threshold_warning}%"
+    severity              = "Warning"
+    detect_label          = "WARN"
+    disabled              = coalesce(var.http_4xx_response_disabled_warning, var.http_4xx_response_disabled, var.detectors_disabled)
+    notifications         = coalescelist(var.http_4xx_response_notifications_warning, var.http_4xx_response_notifications, var.notifications)
+    parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
+  }
+}

--- a/middleware/haproxy/modules.tf
+++ b/middleware/haproxy/modules.tf
@@ -1,0 +1,8 @@
+module "filter-tags" {
+  source = "github.com/claranet/terraform-signalfx-detectors.git//common/filter-tags"
+
+  filter_defaults        = "filter('env', '${var.environment}') and filter('sfx_monitored', 'true')"
+  filter_custom_includes = var.filter_custom_includes
+  filter_custom_excludes = var.filter_custom_excludes
+}
+

--- a/middleware/haproxy/outputs.tf
+++ b/middleware/haproxy/outputs.tf
@@ -1,0 +1,29 @@
+output "server_status_id" {
+  description = "id for detector server_status"
+  value       = signalfx_detector.server_status.id
+}
+
+output "backend_status_id" {
+  description = "id for detector backend_status"
+  value       = signalfx_detector.backend_status.id
+}
+
+output "session_limit_id" {
+  description = "id for detector session_limit"
+  value       = signalfx_detector.session_limit.id
+}
+
+output "http_5xx_response_id" {
+  description = "id for detector http_5xx_response"
+  value       = signalfx_detector.http_5xx_response.id
+}
+
+output "http_4xx_response_id" {
+  description = "id for detector http_4xx_response"
+  value       = signalfx_detector.http_4xx_response.id
+}
+
+output "heartbeat_id" {
+  description = "id for detector heartbeat"
+  value       = signalfx_detector.heartbeat.id
+}

--- a/middleware/haproxy/variables.tf
+++ b/middleware/haproxy/variables.tf
@@ -1,0 +1,339 @@
+# Global
+
+variable "environment" {
+  description = "Infrastructure environment"
+  type        = string
+}
+
+# SignalFx module specific
+
+variable "notifications" {
+  description = "Notification recipients list for every detectors"
+  type        = list
+}
+
+variable "prefixes" {
+  description = "Prefixes list to prepend between brackets on every monitors names before environment"
+  type        = list
+  default     = []
+}
+
+variable "filter_custom_includes" {
+  description = "List of tags to include when custom filtering is used"
+  type        = list
+  default     = []
+}
+
+variable "filter_custom_excludes" {
+  description = "List of tags to exclude when custom filtering is used"
+  type        = list
+  default     = []
+}
+
+variable "detectors_disabled" {
+  description = "Disable all detectors in this module"
+  type        = bool
+  default     = false
+}
+
+# Haproxy detectors specific
+
+variable "heartbeat_disabled" {
+  description = "Disable all alerting rules for heartbeat detector"
+  type        = bool
+  default     = null
+}
+
+variable "heartbeat_notifications" {
+  description = "Notification recipients list for every alerting rules of heartbeat detector"
+  type        = list
+  default     = []
+}
+
+variable "heartbeat_timeframe" {
+  description = "Timeframe for system not reporting detector (i.e. \"10m\")"
+  type        = string
+  default     = "20m"
+}
+
+variable "server_status_disabled" {
+  description = "Disable all alerting rules for server status detector"
+  type        = bool
+  default     = null
+}
+
+variable "server_status_disabled_critical" {
+  description = "Disable critical alerting rule for server status detector"
+  type        = bool
+  default     = null
+}
+
+variable "server_status_notifications" {
+  description = "Notification recipients list for every alerting rules of server status detector"
+  type        = list
+  default     = []
+}
+
+variable "server_status_notifications_critical" {
+  description = "Notification recipients list for critical alerting rule of server status detector"
+  type        = list
+  default     = []
+}
+
+variable "server_status_aggregation_function" {
+  description = "Aggregation function and group by for server status detector (i.e. \".mean(by=['host']).\")"
+  type        = string
+  default     = ""
+}
+
+variable "server_status_transformation_function" {
+  description = "Transformation function for server status detector (mean, min, max)"
+  type        = string
+  default     = "min"
+}
+
+variable "server_status_transformation_window" {
+  description = "Transformation window for server status detector (i.e. 5m, 20m, 1h, 1d)"
+  type        = string
+  default     = "5m"
+}
+
+variable "backend_status_disabled" {
+  description = "Disable all alerting rules for backend status detector"
+  type        = bool
+  default     = null
+}
+
+variable "backend_status_disabled_critical" {
+  description = "Disable critical alerting rule for backend status detector"
+  type        = bool
+  default     = null
+}
+
+variable "backend_status_notifications" {
+  description = "Notification recipients list for every alerting rules of backend status detector"
+  type        = list
+  default     = []
+}
+
+variable "backend_status_notifications_critical" {
+  description = "Notification recipients list for critical alerting rule of backend status detector"
+  type        = list
+  default     = []
+}
+
+variable "backend_status_aggregation_function" {
+  description = "Aggregation function and group by for backend status detector (i.e. \".mean(by=['host']).\")"
+  type        = string
+  default     = ""
+}
+
+variable "backend_status_transformation_function" {
+  description = "Transformation function for backend status detector (mean, min, max)"
+  type        = string
+  default     = "min"
+}
+
+variable "backend_status_transformation_window" {
+  description = "Transformation window for backend status detector (i.e. 5m, 20m, 1h, 1d)"
+  type        = string
+  default     = "5m"
+}
+
+variable "session_limit_disabled" {
+  description = "Disable all alerting rules for session limit detector"
+  type        = bool
+  default     = null
+}
+
+variable "session_limit_disabled_warning" {
+  description = "Disable warning alerting rule for session limit detector"
+  type        = bool
+  default     = null
+}
+
+variable "session_limit_disabled_critical" {
+  description = "Disable critical alerting rule for session limit detector"
+  type        = bool
+  default     = null
+}
+
+variable "session_limit_notifications" {
+  description = "Notification recipients list for every alerting rules of session limit detector"
+  type        = list
+  default     = []
+}
+
+variable "session_limit_notifications_warning" {
+  description = "Notification recipients list for warning alerting rule of session limit detector"
+  type        = list
+  default     = []
+}
+
+variable "session_limit_notifications_critical" {
+  description = "Notification recipients list for critical alerting rule of session limit detector"
+  type        = list
+  default     = []
+}
+
+variable "session_limit_aggregation_function" {
+  description = "Aggregation function and group by for session limit detector (i.e. \".mean(by=['host']).\")"
+  type        = string
+  default     = ""
+}
+
+variable "session_limit_transformation_function" {
+  description = "Transformation function for session limit detector (mean, min, max)"
+  type        = string
+  default     = "min"
+}
+
+variable "session_limit_transformation_window" {
+  description = "Transformation window for session limit detector (i.e. 5m, 20m, 1h, 1d)"
+  type        = string
+  default     = "10m"
+}
+
+variable "session_limit_threshold_warning" {
+  description = "Critical threshold for session limit detector"
+  type        = number
+  default     = 80
+}
+
+variable "session_limit_threshold_critical" {
+  description = "Critical threshold for session limit detector"
+  type        = number
+  default     = 90
+}
+
+variable "http_5xx_response_disabled" {
+  description = "Disable all alerting rules for http_5xx_response detector"
+  type        = bool
+  default     = null
+}
+
+variable "http_5xx_response_disabled_warning" {
+  description = "Disable warning alerting rule for http_5xx_response detector"
+  type        = bool
+  default     = null
+}
+
+variable "http_5xx_response_disabled_critical" {
+  description = "Disable critical alerting rule for http_5xx_response detector"
+  type        = bool
+  default     = null
+}
+
+variable "http_5xx_response_notifications" {
+  description = "Notification recipients list for every alerting rules of http_5xx_response detector"
+  type        = list
+  default     = []
+}
+
+variable "http_5xx_response_notifications_warning" {
+  description = "Notification recipients list for warning alerting rule of http_5xx_response detector"
+  type        = list
+  default     = []
+}
+
+variable "http_5xx_response_notifications_critical" {
+  description = "Notification recipients list for critical alerting rule of http_5xx_response detector"
+  type        = list
+  default     = []
+}
+
+variable "http_5xx_response_aggregation_function" {
+  description = "Aggregation function and group by for http_5xx_response detector (i.e. \".mean(by=['host']).\")"
+  type        = string
+  default     = ""
+}
+
+variable "http_5xx_response_transformation_function" {
+  description = "Transformation function for http_5xx_response detector (mean, min, max)"
+  type        = string
+  default     = "min"
+}
+
+variable "http_5xx_response_transformation_window" {
+  description = "Transformation window for http_5xx_response detector (i.e. 5m, 20m, 1h, 1d)"
+  type        = string
+  default     = "10m"
+}
+
+variable "http_5xx_response_threshold_warning" {
+  description = "Critical threshold for http_5xx_response detector"
+  type        = number
+  default     = 50
+}
+
+variable "http_5xx_response_threshold_critical" {
+  description = "Critical threshold for http_5xx_response detector"
+  type        = number
+  default     = 80
+}
+
+variable "http_4xx_response_disabled" {
+  description = "Disable all alerting rules for http_4xx_response detector"
+  type        = bool
+  default     = null
+}
+
+variable "http_4xx_response_disabled_warning" {
+  description = "Disable warning alerting rule for http_4xx_response detector"
+  type        = bool
+  default     = null
+}
+
+variable "http_4xx_response_disabled_critical" {
+  description = "Disable critical alerting rule for http_4xx_response detector"
+  type        = bool
+  default     = null
+}
+
+variable "http_4xx_response_notifications" {
+  description = "Notification recipients list for every alerting rules of http_4xx_response detector"
+  type        = list
+  default     = []
+}
+
+variable "http_4xx_response_notifications_warning" {
+  description = "Notification recipients list for warning alerting rule of http_4xx_response detector"
+  type        = list
+  default     = []
+}
+
+variable "http_4xx_response_notifications_critical" {
+  description = "Notification recipients list for critical alerting rule of http_4xx_response detector"
+  type        = list
+  default     = []
+}
+
+variable "http_4xx_response_aggregation_function" {
+  description = "Aggregation function and group by for http_4xx_response detector (i.e. \".mean(by=['host']).\")"
+  type        = string
+  default     = ""
+}
+
+variable "http_4xx_response_transformation_function" {
+  description = "Transformation function for http_4xx_response detector (mean, min, max)"
+  type        = string
+  default     = "min"
+}
+
+variable "http_4xx_response_transformation_window" {
+  description = "Transformation window for http_4xx_response detector (i.e. 5m, 20m, 1h, 1d)"
+  type        = string
+  default     = "10m"
+}
+
+variable "http_4xx_response_threshold_warning" {
+  description = "Critical threshold for http_4xx_response detector"
+  type        = number
+  default     = 50
+}
+
+variable "http_4xx_response_threshold_critical" {
+  description = "Critical threshold for http_4xx_response detector"
+  type        = number
+  default     = 80
+}


### PR DESCRIPTION
Add Haproxy detectors :

* Haproxy heartbeat
* Haproxy server status
* Haproxy backend status
* Haproxy session limit (on frontend, backend and server)
* Haproxy 4xx response rate (on frontend and backend with http mode)
* Haproxy 5xx response rate (on frontend and backend with http mode)

https://github.com/signalfx/signalfx-agent/pull/1357 is needed to merge this as `haproxy_session_limit` was not reported by the agent.