### PR TITLE
use prometheus exporter for kong instead of collectd

### DIFF
--- a/middleware/kong/README.md
+++ b/middleware/kong/README.md
@@ -53,4 +53,30 @@ Creates SignalFx detectors with the following checks:
 
 ## Related documentation
 
-[Official documentation](https://docs.signalfx.com/en/latest/integrations/integrations-reference/integrations.kong.html)
+[Official documentation](https://docs.signalfx.com/en/latest/integrations/agent/monitors/prometheus-exporter.html)
+
+## Notes
+
+We use the [Prometheus exporter monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/prometheus-exporter.html) instead of [official Kong integration](https://docs.signalfx.com/en/latest/integrations/integrations-reference/integrations.kong.html) based on collectd while it requires to install a lua module on Kong server which could be problematic.
+
+Check [the official Kong documentation](https://docs.konghq.com/hub/kong-inc/prometheus/#enabling-the-plugin-on-a-service) to enable Prometheus metrics on Kong server(s).
+
+Here is a sample configuration for the SignalFx Smart Agent:
+
+```yaml
+  - type: prometheus-exporter
+    host: 127.0.0.1
+    port: 8444
+    useHTTPS: true
+    skipVerify: true
+    datapointsToExclude:
+      - metricNames:
+        - '*'
+        - '!kong_datastore_reachable'
+        - '!kong_http_status'
+        - '!kong_latency'
+        - '!kong_nginx_http_current_connections'
+        - '!kong_nginx_metric_errors_total'
+```
+
+_Note_: do not forget to filter while Promehteus format leads to lot of metrics which will be considered as custom by SignalFx and reach the limit (or cause over-billing).

--- a/middleware/kong/detectors-kong.tf
+++ b/middleware/kong/detectors-kong.tf
@@ -21,8 +21,8 @@ resource "signalfx_detector" "treatment_limit" {
   name = "${join("", formatlist("[%s]", var.prefixes))}[${var.environment}] Kong treatment limit"
 
   program_text = <<-EOF
-    A = data('counter.kong.connections.handled', filter=${module.filter-tags.filter_custom})${var.treatment_limit_aggregation_function}
-    B = data('counter.kong.connections.accepted', filter=${module.filter-tags.filter_custom})${var.treatment_limit_aggregation_function}
+    A = data('kong_nginx_http_current_connections', filter=filter('state', 'handled') and ${module.filter-tags.filter_custom})${var.treatment_limit_aggregation_function}
+    B = data('kong_nginx_http_current_connections', filter=filter('state', 'accepted') and ${module.filter-tags.filter_custom})${var.treatment_limit_aggregation_function}
     signal = ((A-B)/A).scale(100).${var.treatment_limit_transformation_function}(over='${var.treatment_limit_transformation_window}').publish('signal')
     detect(when(signal > ${var.treatment_limit_threshold_critical})).publish('CRIT')
     detect(when(signal > ${var.treatment_limit_threshold_warning}) and when(signal <= ${var.treatment_limit_threshold_critical})).publish('WARN')


### PR DESCRIPTION
official kong monitor requires to install https://github.com/signalfx/kong-plugin-signalfx which is not the easiest way to do especially when the customer manage himself kong and claranet could not install it for him. Using promehteus is far easier even if it means we do not have the preset dashboard from signalfx official monitor https://docs.signalfx.com/en/latest/integrations/integrations-reference/integrations.kong.html#usage we could probably add a custom one in https://github.com/claranet/terraform-signalfx-dashboards/ in future