### PR TITLE
Cloud Azure: Virtual Machine detectors

### DIFF
--- a/cloud/azure/virtual-machine/detectors-virtual-machine.tf
+++ b/cloud/azure/virtual-machine/detectors-virtual-machine.tf
@@ -1,0 +1,79 @@
+resource "signalfx_detector" "heartbeat" {
+  name = "${join("", formatlist("[%s]", var.prefixes))}[${var.environment}] Azure Virtual Machine heartbeat"
+
+  program_text = <<-EOF
+        from signalfx.detectors.not_reporting import not_reporting
+        base_filter = filter('resource_type', 'Microsoft.Compute/virtualMachines') and filter('primary_aggregation_type', 'true') and (not filter('azure_power_state', 'PowerState/stopping', 'PowerState/stopped', 'PowerState/deallocating', 'PowerState/deallocated'))
+        signal = data('Percentage CPU', filter=base_filter and ${module.filter-tags.filter_custom}).publish('signal')
+        not_reporting.detector(stream=signal, resource_identifier=['azure_resource_id'], duration='${var.heartbeat_timeframe}').publish('CRIT')
+    EOF
+
+  rule {
+    description           = "has not reported in ${var.heartbeat_timeframe}"
+    severity              = "Critical"
+    detect_label          = "CRIT"
+    disabled              = coalesce(var.heartbeat_disabled, var.detectors_disabled)
+    notifications         = coalescelist(var.heartbeat_notifications, var.notifications)
+    parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
+  }
+}
+
+resource "signalfx_detector" "cpu_usage" {
+  name = "${join("", formatlist("[%s]", var.prefixes))}[${var.environment}] Azure Virtual Machine CPU usage"
+
+  program_text = <<-EOF
+        base_filter = filter('resource_type', 'Microsoft.Compute/virtualMachines') and filter('primary_aggregation_type', 'true') and (not filter('azure_power_state', 'PowerState/stopping', 'PowerState/stopped', 'PowerState/deallocating', 'PowerState/deallocated'))
+        signal = data('Percentage CPU', filter=base_filter and ${module.filter-tags.filter_custom})${var.cpu_usage_aggregation_function}.publish('signal')
+        detect(when(signal > threshold(${var.cpu_usage_threshold_critical}), lasting="${var.cpu_usage_timer}")).publish('CRIT')
+        detect(when(signal > threshold(${var.cpu_usage_threshold_warning}), lasting="${var.cpu_usage_timer}") and when(signal <= ${var.cpu_usage_threshold_critical})).publish('WARN')
+    EOF
+
+  rule {
+    description           = "is too high > ${var.cpu_usage_threshold_critical}%"
+    severity              = "Critical"
+    detect_label          = "CRIT"
+    disabled              = coalesce(var.cpu_usage_disabled_critical, var.cpu_usage_disabled, var.detectors_disabled)
+    notifications         = coalescelist(var.cpu_usage_notifications_critical, var.cpu_usage_notifications, var.notifications)
+    parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
+  }
+
+  rule {
+    description           = "is too high > ${var.cpu_usage_threshold_warning}%"
+    severity              = "Warning"
+    detect_label          = "WARN"
+    disabled              = coalesce(var.cpu_usage_disabled_warning, var.cpu_usage_disabled, var.detectors_disabled)
+    notifications         = coalescelist(var.cpu_usage_notifications_warning, var.cpu_usage_notifications, var.notifications)
+    parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
+  }
+}
+
+resource "signalfx_detector" "credit_cpu" {
+  name = "${join("", formatlist("[%s]", var.prefixes))}[${var.environment}] Azure Virtual Machine remaining CPU credit"
+
+  program_text = <<-EOF
+        base_filter = filter('resource_type', 'Microsoft.Compute/virtualMachines') and filter('primary_aggregation_type', 'true') and (not filter('azure_power_state', 'PowerState/stopping', 'PowerState/stopped', 'PowerState/deallocating', 'PowerState/deallocated'))
+        A = data('CPU Credits Remaining', filter=base_filter and ${module.filter-tags.filter_custom})${var.credit_cpu_aggregation_function}
+        B = data('CPU Credits Consumed', filter=base_filter and ${module.filter-tags.filter_custom})${var.credit_cpu_aggregation_function}
+        signal = ((A/(A+B))*100).fill(100).${var.credit_cpu_transformation_function}(over='${var.credit_cpu_timer}').publish('signal')
+        detect(when(signal < threshold(${var.credit_cpu_threshold_critical}), lasting="${var.credit_cpu_timer}")).publish('CRIT')
+        detect(when(signal < threshold(${var.credit_cpu_threshold_warning}), lasting="${var.credit_cpu_timer}") and when(signal >= ${var.credit_cpu_threshold_critical})).publish('WARN')
+    EOF
+
+  rule {
+    description           = "is too low < ${var.credit_cpu_threshold_critical}%"
+    severity              = "Critical"
+    detect_label          = "CRIT"
+    disabled              = coalesce(var.credit_cpu_disabled_critical, var.credit_cpu_disabled, var.detectors_disabled)
+    notifications         = coalescelist(var.credit_cpu_notifications_critical, var.credit_cpu_notifications, var.notifications)
+    parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
+  }
+
+  rule {
+    description           = "is too low < ${var.credit_cpu_threshold_warning}%"
+    severity              = "Warning"
+    detect_label          = "WARN"
+    disabled              = coalesce(var.credit_cpu_disabled_warning, var.credit_cpu_disabled, var.detectors_disabled)
+    notifications         = coalescelist(var.credit_cpu_notifications_warning, var.credit_cpu_notifications, var.notifications)
+    parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
+  }
+}

--- a/cloud/azure/virtual-machine/modules.tf
+++ b/cloud/azure/virtual-machine/modules.tf
@@ -1,0 +1,7 @@
+module "filter-tags" {
+  source = "github.com/claranet/terraform-signalfx-detectors.git//common/filter-tags"
+
+  filter_defaults        = "filter('azure_tag_env', '${var.environment}') and filter('azure_tag_sfx_monitored', 'true')"
+  filter_custom_includes = var.filter_custom_includes
+  filter_custom_excludes = var.filter_custom_excludes
+}

--- a/cloud/azure/virtual-machine/outputs.tf
+++ b/cloud/azure/virtual-machine/outputs.tf
@@ -1,0 +1,14 @@
+output "heartbeat_id" {
+  description = "id for detector heartbeat"
+  value       = signalfx_detector.heartbeat.*.id
+}
+
+output "cpu_usage_id" {
+  description = "id for detector cpu_usage"
+  value       = signalfx_detector.cpu_usage.*.id
+}
+
+output "credit_cpu_id" {
+  description = "id for detector credit_cpu"
+  value       = signalfx_detector.credit_cpu.*.id
+}

--- a/cloud/azure/virtual-machine/variables.tf
+++ b/cloud/azure/virtual-machine/variables.tf
@@ -1,0 +1,187 @@
+# Global
+
+variable "environment" {
+  description = "Infrastructure environment"
+  type        = string
+}
+
+# SignalFx module specific
+
+variable "notifications" {
+  description = "Notification recipients list for every detectors"
+  type        = list(string)
+}
+
+variable "prefixes" {
+  description = "Prefixes list to prepend between brackets on every monitors names before environment"
+  type        = list(string)
+  default     = []
+}
+
+variable "filter_custom_includes" {
+  description = "List of tags to include when custom filtering is used"
+  type        = list(string)
+  default     = []
+}
+
+variable "filter_custom_excludes" {
+  description = "List of tags to exclude when custom filtering is used"
+  type        = list(string)
+  default     = []
+}
+
+variable "detectors_disabled" {
+  description = "Disable all detectors in this module"
+  type        = bool
+  default     = false
+}
+
+# Azure virtual machine detectors specific
+
+variable "heartbeat_disabled" {
+  description = "Disable all alerting rules for heartbeat detector"
+  type        = bool
+  default     = null
+}
+
+variable "heartbeat_notifications" {
+  description = "Notification recipients list for every alerting rules of heartbeat detector"
+  type        = list(string)
+  default     = []
+}
+
+variable "heartbeat_timeframe" {
+  description = "Timeframe for system not reporting detector (i.e. \"10m\")"
+  type        = string
+  default     = "20m"
+}
+
+# CPU_usage detectors
+
+variable "cpu_usage_disabled" {
+  description = "Disable all alerting rules for cpu_usage detector"
+  type        = bool
+  default     = null
+}
+
+variable "cpu_usage_disabled_critical" {
+  description = "Disable critical alerting rule for cpu_usage detector"
+  type        = bool
+  default     = null
+}
+
+variable "cpu_usage_disabled_warning" {
+  description = "Disable warning alerting rule for cpu_usage detector"
+  type        = bool
+  default     = null
+}
+
+variable "cpu_usage_notifications" {
+  description = "Notification recipients list for every alerting rules of cpu_usage detector"
+  type        = list(string)
+  default     = []
+}
+
+variable "cpu_usage_notifications_warning" {
+  description = "Notification recipients list for warning alerting rule of cpu_usage detector"
+  type        = list(string)
+  default     = []
+}
+
+variable "cpu_usage_notifications_critical" {
+  description = "Notification recipients list for critical alerting rule of cpu_usage detector"
+  type        = list(string)
+  default     = []
+}
+
+variable "cpu_usage_aggregation_function" {
+  description = "Aggregation function and group by for cpu_usage detector (i.e. \".mean(by=['host'])\")"
+  type        = string
+  default     = ".mean(by=['azure_resource_name', 'azure_resource_group_name', 'azure_region'])"
+}
+
+variable "cpu_usage_timer" {
+  description = "Evaluation window for cpu_usage detector (i.e. 5m, 20m, 1h, 1d)"
+  type        = string
+  default     = "15m"
+}
+
+variable "cpu_usage_threshold_critical" {
+  description = "Critical threshold for cpu_usage detector"
+  type        = number
+  default     = 90
+}
+
+variable "cpu_usage_threshold_warning" {
+  description = "Warning threshold for cpu_usage detector"
+  type        = number
+  default     = 80
+}
+
+# Credit_cpu detectors
+
+variable "credit_cpu_disabled" {
+  description = "Disable all alerting rules for credit_cpu detector"
+  type        = bool
+  default     = null
+}
+
+variable "credit_cpu_disabled_critical" {
+  description = "Disable critical alerting rule for credit_cpu detector"
+  type        = bool
+  default     = null
+}
+
+variable "credit_cpu_disabled_warning" {
+  description = "Disable warning alerting rule for credit_cpu detector"
+  type        = bool
+  default     = null
+}
+
+variable "credit_cpu_notifications" {
+  description = "Notification recipients list for every alerting rules of credit_cpu detector"
+  type        = list(string)
+  default     = []
+}
+
+variable "credit_cpu_notifications_warning" {
+  description = "Notification recipients list for warning alerting rule of credit_cpu detector"
+  type        = list(string)
+  default     = []
+}
+
+variable "credit_cpu_notifications_critical" {
+  description = "Notification recipients list for critical alerting rule of credit_cpu detector"
+  type        = list(string)
+  default     = []
+}
+
+variable "credit_cpu_aggregation_function" {
+  description = "Aggregation function and group by for credit_cpu detector (i.e. \".mean(by=['host'])\")"
+  type        = string
+  default     = ".mean(by=['azure_resource_name', 'azure_resource_group_name', 'azure_region'])"
+}
+
+variable "credit_cpu_transformation_function" {
+  description = "Transformation function for credit_cpu detector (mean, min, max)"
+  type        = string
+  default     = "min"
+}
+
+variable "credit_cpu_timer" {
+  description = "Evaluation window for credit_cpu detector (i.e. 5m, 20m, 1h, 1d)"
+  type        = string
+  default     = "5m"
+}
+
+variable "credit_cpu_threshold_critical" {
+  description = "Critical threshold for credit_cpu detector"
+  type        = number
+  default     = 15
+}
+
+variable "credit_cpu_threshold_warning" {
+  description = "Warning threshold for credit_cpu detector"
+  type        = number
+  default     = 30
+}

--- a/cloud/azure/virtual-machine/versions.tf
+++ b/cloud/azure/virtual-machine/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    signalfx = {
+      source  = "terraform-providers/signalfx"
+      version = ">= 4.26.4"
+    }
+  }
+  required_version = ">= 0.12.26"
+}


### PR DESCRIPTION
Detectors `virtualmachine_ram_reserved`, `virtualmachine_disk_space` & `virtualmachine_requests_failed` cannot be migrated due to different implementation. Will be studied later.

Module call
```
module "signalfx-detectors-cloud-azure-virtual-machine" {
  source = "github.com/claranet/terraform-signalfx-detectors.git//cloud/azure/virtual-machine?ref=cloud_azure_vm"

  environment   = var.environment
  notifications = local.notifications
}
```