### PR TITLE
fix: wrong apache busy worker detector definition

### DIFF
--- a/middleware/apache/detectors-apache.tf
+++ b/middleware/apache/detectors-apache.tf
@@ -21,9 +21,7 @@ resource "signalfx_detector" "apache_workers" {
   name = "${join("", formatlist("[%s]", var.prefixes))}[${var.environment}] Apache busy workers"
 
   program_text = <<-EOF
-    A = data('apache_connections', ${module.filter-tags.filter_custom})${var.apache_workers_aggregation_function}${var.apache_workers_transformation_function}
-    B = data('apache_idle_workers', ${module.filter-tags.filter_custom})${var.apache_workers_aggregation_function}${var.apache_workers_transformation_function}
-    signal = ((A / (A+B)).scale(100)).publish('signal')
+    signal = data('apache_connections', ${module.filter-tags.filter_custom})${var.apache_workers_aggregation_function}${var.apache_workers_transformation_function}
     detect(when(signal > ${var.apache_workers_threshold_critical})).publish('CRIT')
     detect(when(signal > ${var.apache_workers_threshold_warning}) and when(signal <= ${var.apache_workers_threshold_critical})).publish('WARN')
 EOF


### PR DESCRIPTION
Hello,

according to signalfx documentation: [Apache integration](https://docs.signalfx.com/en/latest/integrations/integrations-reference/integrations.apache.html), `apache_connection` metric is `The number of connections that are being served by Apache. This is also equal to the number of busy worker threads, where ‘busy’ means any worker thread which has been started successfully and is not slated for idle cleanup.`

Definition of detector is simplified then and graphes are similar to datadog ones.