### PR TITLE
Fix velero detectors: remove aggregation by kubernetes_name

### DIFF
--- a/container/kubernetes/velero/variables.tf
+++ b/container/kubernetes/velero/variables.tf
@@ -55,7 +55,7 @@ variable "velero_scheduled_backup_missing_notifications" {
 variable "velero_scheduled_backup_missing_aggregation_function" {
   description = "Aggregation function and group by for velero_scheduled_backup_missing detector (i.e. \".mean(by=['host'])\")"
   type        = string
-  default     = ".sum(by=['kubernetes_cluster', 'kubernetes_namespace', 'schedule'])"
+  default     = ".sum(by=['kubernetes_cluster', 'schedule'])"
 }
 
 variable "velero_scheduled_backup_missing_transformation_function" {


### PR DESCRIPTION
Kubernetes_name dimension doesn't exist.