### PR TITLE
exlcude jobs and cronjobs from pod phase status

### DIFF
--- a/container/kubernetes/common/detectors-kubernetes-common.tf
+++ b/container/kubernetes/common/detectors-kubernetes-common.tf
@@ -49,7 +49,7 @@ resource "signalfx_detector" "pod_phase_status" {
   name = "${join("", formatlist("[%s]", var.prefixes))}[${var.environment}] Kubernetes pod status phase"
 
   program_text = <<-EOF
-    signal = data('kubernetes.pod_phase', filter=${module.filter-tags.filter_custom})${var.pod_phase_status_aggregation_function}${var.pod_phase_status_transformation_function}.fill(2).publish('signal')
+    signal = data('kubernetes.pod_phase', filter=(not filter('job', '*')) and (not filter('cronjob', '*')) and ${module.filter-tags.filter_custom})${var.pod_phase_status_aggregation_function}${var.pod_phase_status_transformation_function}.fill(2).publish('signal')
     detect(when(signal < threshold(2), lasting='${var.pod_phase_status_lasting_duration_seconds}s') or when(signal > threshold(3), lasting='${var.pod_phase_status_lasting_duration_seconds}s')).publish('WARN')
 EOF
 


### PR DESCRIPTION
this is redundant with job detector which is better suited because raise alert only for job failed (and not every pod failed inside a job)