### PR TITLE
Safer and easier notifications using rich types

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Setup Terraform
-      uses: hashicorp/setup-terraform@v1
+      uses: hashicorp/setup-terraform@v1.2.0
       with:
         terraform_version: 0.13.3
         terraform_wrapper: false

--- a/cloud/aws/alb/detectors-alb.tf
+++ b/cloud/aws/alb/detectors-alb.tf
@@ -12,7 +12,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.heartbeat_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.heartbeat_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.heartbeat_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
 }
@@ -33,7 +33,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.no_healthy_instances_disabled_critical, var.no_healthy_instances_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.no_healthy_instances_notifications_critical, var.no_healthy_instances_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.no_healthy_instances_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -42,7 +42,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.no_healthy_instances_disabled_warning, var.no_healthy_instances_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.no_healthy_instances_notifications_warning, var.no_healthy_instances_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.no_healthy_instances_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -61,7 +61,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.latency_disabled_critical, var.latency_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.latency_notifications_critical, var.latency_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.latency_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -70,7 +70,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.latency_disabled_warning, var.latency_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.latency_notifications_warning, var.latency_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.latency_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -91,7 +91,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.alb_5xx_disabled_critical, var.alb_5xx_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.alb_5xx_notifications_critical, var.alb_5xx_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.alb_5xx_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -100,7 +100,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.alb_5xx_disabled_warning, var.alb_5xx_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.alb_5xx_notifications_warning, var.alb_5xx_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.alb_5xx_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -121,7 +121,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.alb_4xx_disabled_critical, var.alb_4xx_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.alb_4xx_notifications_critical, var.alb_4xx_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.alb_4xx_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -130,7 +130,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.alb_4xx_disabled_warning, var.alb_4xx_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.alb_4xx_notifications_warning, var.alb_4xx_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.alb_4xx_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -151,7 +151,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.target_5xx_disabled_critical, var.target_5xx_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.target_5xx_notifications_critical, var.target_5xx_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.target_5xx_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -160,7 +160,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.target_5xx_disabled_warning, var.target_5xx_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.target_5xx_notifications_warning, var.target_5xx_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.target_5xx_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -181,7 +181,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.target_4xx_disabled_critical, var.target_4xx_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.target_4xx_notifications_critical, var.target_4xx_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.target_4xx_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -190,7 +190,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.target_4xx_disabled_warning, var.target_4xx_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.target_4xx_notifications_warning, var.target_4xx_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.target_4xx_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/aws/alb/variables.tf
+++ b/cloud/aws/alb/variables.tf
@@ -8,8 +8,14 @@ variable "environment" {
 # SignalFx module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -51,9 +57,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_notifications" {
-  description = "Notification recipients list for every alerting rules of heartbeat detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for heartbeat detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "heartbeat_timeframe" {
@@ -83,21 +89,9 @@ variable "no_healthy_instances_disabled_warning" {
 }
 
 variable "no_healthy_instances_notifications" {
-  description = "Notification recipients list for every alerting rules of No_healthy_instances detector"
-  type        = list
-  default     = []
-}
-
-variable "no_healthy_instances_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of No_healthy_instances detector"
-  type        = list
-  default     = []
-}
-
-variable "no_healthy_instances_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of No_healthy_instances detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for No_healthy_instances detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "no_healthy_instances_aggregation_function" {
@@ -145,21 +139,9 @@ variable "latency_disabled_warning" {
 }
 
 variable "latency_notifications" {
-  description = "Notification recipients list for every alerting rules of latency detector"
-  type        = list
-  default     = []
-}
-
-variable "latency_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of latency detector"
-  type        = list
-  default     = []
-}
-
-variable "latency_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of latency detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for latency detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "latency_aggregation_function" {
@@ -219,21 +201,9 @@ variable "alb_5xx_disabled_warning" {
 }
 
 variable "alb_5xx_notifications" {
-  description = "Notification recipients list for every alerting rules of alb_5xx detector"
-  type        = list
-  default     = []
-}
-
-variable "alb_5xx_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of alb_5xx detector"
-  type        = list
-  default     = []
-}
-
-variable "alb_5xx_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of alb_5xx detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for alb_5xx detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "alb_5xx_aggregation_function" {
@@ -293,21 +263,9 @@ variable "alb_4xx_disabled_warning" {
 }
 
 variable "alb_4xx_notifications" {
-  description = "Notification recipients list for every alerting rules of alb_4xx detector"
-  type        = list
-  default     = []
-}
-
-variable "alb_4xx_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of alb_4xx detector"
-  type        = list
-  default     = []
-}
-
-variable "alb_4xx_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of alb_4xx detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for alb_4xx detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "alb_4xx_aggregation_function" {
@@ -367,21 +325,9 @@ variable "target_5xx_disabled_warning" {
 }
 
 variable "target_5xx_notifications" {
-  description = "Notification recipients list for every alerting rules of target_5xx detector"
-  type        = list
-  default     = []
-}
-
-variable "target_5xx_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of target_5xx detector"
-  type        = list
-  default     = []
-}
-
-variable "target_5xx_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of target_5xx detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for target_5xx detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "target_5xx_aggregation_function" {
@@ -441,21 +387,9 @@ variable "target_4xx_disabled_warning" {
 }
 
 variable "target_4xx_notifications" {
-  description = "Notification recipients list for every alerting rules of target_4xx detector"
-  type        = list
-  default     = []
-}
-
-variable "target_4xx_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of target_4xx detector"
-  type        = list
-  default     = []
-}
-
-variable "target_4xx_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of target_4xx detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for target_4xx detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "target_4xx_aggregation_function" {

--- a/cloud/aws/apigateway/detectors-api.tf
+++ b/cloud/aws/apigateway/detectors-api.tf
@@ -13,7 +13,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.latency_disabled_critical, var.latency_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.latency_notifications_critical, var.latency_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.latency_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -22,7 +22,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.latency_disabled_warning, var.latency_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.latency_notifications_warning, var.latency_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.latency_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -44,7 +44,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.http_5xx_disabled_critical, var.http_5xx_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.http_5xx_notifications_critical, var.http_5xx_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.http_5xx_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -53,7 +53,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.http_5xx_disabled_warning, var.http_5xx_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.http_5xx_notifications_warning, var.http_5xx_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.http_5xx_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -75,7 +75,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.http_4xx_disabled_critical, var.http_4xx_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.http_4xx_notifications_critical, var.http_4xx_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.http_4xx_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -84,7 +84,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.http_4xx_disabled_warning, var.http_4xx_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.http_4xx_notifications_warning, var.http_4xx_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.http_4xx_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/aws/apigateway/variables.tf
+++ b/cloud/aws/apigateway/variables.tf
@@ -8,8 +8,14 @@ variable "environment" {
 # SignalFx module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -65,21 +71,9 @@ variable "latency_disabled_warning" {
 }
 
 variable "latency_notifications" {
-  description = "Notification recipients list for every alerting rules of latency detector"
-  type        = list
-  default     = []
-}
-
-variable "latency_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of latency detector"
-  type        = list
-  default     = []
-}
-
-variable "latency_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of latency detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for latency detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "latency_aggregation_function" {
@@ -139,21 +133,9 @@ variable "http_5xx_disabled_warning" {
 }
 
 variable "http_5xx_notifications" {
-  description = "Notification recipients list for every alerting rules of http_5xx detector"
-  type        = list
-  default     = []
-}
-
-variable "http_5xx_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of http_5xx detector"
-  type        = list
-  default     = []
-}
-
-variable "http_5xx_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of http_5xx detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for http_5xx detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "http_5xx_aggregation_function" {
@@ -213,21 +195,9 @@ variable "http_4xx_disabled_warning" {
 }
 
 variable "http_4xx_notifications" {
-  description = "Notification recipients list for every alerting rules of http_4xx detector"
-  type        = list
-  default     = []
-}
-
-variable "http_4xx_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of http_4xx detector"
-  type        = list
-  default     = []
-}
-
-variable "http_4xx_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of http_4xx detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for http_4xx detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "http_4xx_aggregation_function" {

--- a/cloud/aws/beanstalk/detectors-beanstalk.tf
+++ b/cloud/aws/beanstalk/detectors-beanstalk.tf
@@ -12,7 +12,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.heartbeat_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.heartbeat_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.heartbeat_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
 }
@@ -31,7 +31,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.health_disabled_critical, var.health_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.health_notifications_critical, var.health_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.health_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -40,7 +40,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.health_disabled_warning, var.health_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.health_notifications_warning, var.health_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.health_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -59,7 +59,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.latency_p90_disabled_critical, var.latency_p90_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.latency_p90_notifications_critical, var.latency_p90_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.latency_p90_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -68,7 +68,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.latency_p90_disabled_warning, var.latency_p90_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.latency_p90_notifications_warning, var.latency_p90_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.latency_p90_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -89,7 +89,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.app_5xx_error_rate_disabled_critical, var.app_5xx_error_rate_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.app_5xx_error_rate_notifications_critical, var.app_5xx_error_rate_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.app_5xx_error_rate_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -98,7 +98,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.app_5xx_error_rate_disabled_warning, var.app_5xx_error_rate_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.app_5xx_error_rate_notifications_warning, var.app_5xx_error_rate_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.app_5xx_error_rate_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -118,7 +118,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.root_filesystem_usage_disabled_critical, var.root_filesystem_usage_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.root_filesystem_usage_notifications_critical, var.root_filesystem_usage_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.root_filesystem_usage_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -127,7 +127,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.root_filesystem_usage_disabled_warning, var.root_filesystem_usage_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.root_filesystem_usage_notifications_warning, var.root_filesystem_usage_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.root_filesystem_usage_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/aws/beanstalk/variables.tf
+++ b/cloud/aws/beanstalk/variables.tf
@@ -8,8 +8,14 @@ variable "environment" {
 # SignalFx module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -45,9 +51,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_notifications" {
-  description = "Notification recipients list for every alerting rules of heartbeat detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for heartbeat detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "heartbeat_timeframe" {
@@ -77,21 +83,9 @@ variable "health_disabled_warning" {
 }
 
 variable "health_notifications" {
-  description = "Notification recipients list for every alerting rules of health detector"
-  type        = list
-  default     = []
-}
-
-variable "health_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of health detector"
-  type        = list
-  default     = []
-}
-
-variable "health_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of health detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for health detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "health_aggregation_function" {
@@ -139,21 +133,9 @@ variable "latency_p90_disabled_warning" {
 }
 
 variable "latency_p90_notifications" {
-  description = "Notification recipients list for every alerting rules of latency_p90 detector"
-  type        = list
-  default     = []
-}
-
-variable "latency_p90_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of latency_p90 detector"
-  type        = list
-  default     = []
-}
-
-variable "latency_p90_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of latency_p90 detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for latency_p90 detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "latency_p90_aggregation_function" {
@@ -201,21 +183,9 @@ variable "app_5xx_error_rate_disabled_warning" {
 }
 
 variable "app_5xx_error_rate_notifications" {
-  description = "Notification recipients list for every alerting rules of 5xx_error_rate detector"
-  type        = list
-  default     = []
-}
-
-variable "app_5xx_error_rate_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of 5xx_error_rate detector"
-  type        = list
-  default     = []
-}
-
-variable "app_5xx_error_rate_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of 5xx_error_rate detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for 5xx_error_rate detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "app_5xx_error_rate_aggregation_function" {
@@ -263,21 +233,9 @@ variable "root_filesystem_usage_disabled_warning" {
 }
 
 variable "root_filesystem_usage_notifications" {
-  description = "Notification recipients list for every alerting rules of root_filesystem_usage detector"
-  type        = list
-  default     = []
-}
-
-variable "root_filesystem_usage_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of root_filesystem_usage detector"
-  type        = list
-  default     = []
-}
-
-variable "root_filesystem_usage_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of root_filesystem_usage detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for root_filesystem_usage detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "root_filesystem_usage_aggregation_function" {

--- a/cloud/aws/ecs/cluster/detectors-ecs-cluster.tf
+++ b/cloud/aws/ecs/cluster/detectors-ecs-cluster.tf
@@ -12,7 +12,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.heartbeat_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.heartbeat_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.heartbeat_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
 }
@@ -31,7 +31,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.cpu_utilization_disabled_critical, var.cpu_utilization_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.cpu_utilization_notifications_critical, var.cpu_utilization_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.cpu_utilization_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -40,7 +40,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.cpu_utilization_disabled_warning, var.cpu_utilization_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.cpu_utilization_notifications_warning, var.cpu_utilization_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.cpu_utilization_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -59,7 +59,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.memory_utilization_disabled_critical, var.memory_utilization_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.memory_utilization_notifications_critical, var.memory_utilization_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.memory_utilization_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -68,7 +68,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.memory_utilization_disabled_warning, var.memory_utilization_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.memory_utilization_notifications_warning, var.memory_utilization_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.memory_utilization_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/aws/ecs/cluster/variables.tf
+++ b/cloud/aws/ecs/cluster/variables.tf
@@ -8,8 +8,14 @@ variable "environment" {
 # SignalFx module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -45,9 +51,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_notifications" {
-  description = "Notification recipients list for every alerting rules of heartbeat detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for heartbeat detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "heartbeat_timeframe" {
@@ -77,21 +83,9 @@ variable "cpu_utilization_disabled_warning" {
 }
 
 variable "cpu_utilization_notifications" {
-  description = "Notification recipients list for every alerting rules of cpu_utilization detector"
-  type        = list
-  default     = []
-}
-
-variable "cpu_utilization_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of cpu_utilization detector"
-  type        = list
-  default     = []
-}
-
-variable "cpu_utilization_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of cpu_utilization detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for cpu_utilization detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "cpu_utilization_aggregation_function" {
@@ -139,21 +133,9 @@ variable "memory_utilization_disabled_warning" {
 }
 
 variable "memory_utilization_notifications" {
-  description = "Notification recipients list for every alerting rules of memory_utilization detector"
-  type        = list
-  default     = []
-}
-
-variable "memory_utilization_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of memory_utilization detector"
-  type        = list
-  default     = []
-}
-
-variable "memory_utilization_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of memory_utilization detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for memory_utilization detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "memory_utilization_aggregation_function" {

--- a/cloud/aws/ecs/service/detectors-ecs-service.tf
+++ b/cloud/aws/ecs/service/detectors-ecs-service.tf
@@ -12,7 +12,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.heartbeat_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.heartbeat_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.heartbeat_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
 }
@@ -32,7 +32,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.cpu_utilization_disabled_critical, var.cpu_utilization_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.cpu_utilization_notifications_critical, var.cpu_utilization_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.cpu_utilization_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -41,7 +41,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.cpu_utilization_disabled_warning, var.cpu_utilization_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.cpu_utilization_notifications_warning, var.cpu_utilization_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.cpu_utilization_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -60,7 +60,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.memory_utilization_disabled_critical, var.memory_utilization_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.memory_utilization_notifications_critical, var.memory_utilization_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.memory_utilization_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -69,7 +69,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.memory_utilization_disabled_warning, var.memory_utilization_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.memory_utilization_notifications_warning, var.memory_utilization_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.memory_utilization_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/aws/ecs/service/variables.tf
+++ b/cloud/aws/ecs/service/variables.tf
@@ -8,8 +8,14 @@ variable "environment" {
 # SignalFx module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -45,9 +51,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_notifications" {
-  description = "Notification recipients list for every alerting rules of heartbeat detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for heartbeat detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "heartbeat_timeframe" {
@@ -77,21 +83,9 @@ variable "cpu_utilization_disabled_warning" {
 }
 
 variable "cpu_utilization_notifications" {
-  description = "Notification recipients list for every alerting rules of cpu_utilization detector"
-  type        = list
-  default     = []
-}
-
-variable "cpu_utilization_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of cpu_utilization detector"
-  type        = list
-  default     = []
-}
-
-variable "cpu_utilization_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of cpu_utilization detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for cpu_utilization detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "cpu_utilization_aggregation_function" {
@@ -139,21 +133,9 @@ variable "memory_utilization_disabled_warning" {
 }
 
 variable "memory_utilization_notifications" {
-  description = "Notification recipients list for every alerting rules of memory_utilization detector"
-  type        = list
-  default     = []
-}
-
-variable "memory_utilization_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of memory_utilization detector"
-  type        = list
-  default     = []
-}
-
-variable "memory_utilization_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of memory_utilization detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for memory_utilization detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "memory_utilization_aggregation_function" {

--- a/cloud/aws/elasticache/common/detectors-elasticache.tf
+++ b/cloud/aws/elasticache/common/detectors-elasticache.tf
@@ -12,7 +12,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.heartbeat_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.heartbeat_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.heartbeat_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
 }
@@ -31,7 +31,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.evictions_disabled_critical, var.evictions_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.evictions_notifications_critical, var.evictions_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.evictions_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -40,7 +40,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.evictions_disabled_warning, var.evictions_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.evictions_notifications_warning, var.evictions_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.evictions_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -58,7 +58,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.max_connection_disabled_critical, var.max_connection_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.max_connection_notifications_critical, var.max_connection_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.max_connection_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -76,7 +76,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.no_connection_disabled_critical, var.no_connection_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.no_connection_notifications_critical, var.no_connection_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.no_connection_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -95,7 +95,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.swap_disabled_critical, var.swap_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.swap_notifications_critical, var.swap_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.swap_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -104,7 +104,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.swap_disabled_warning, var.swap_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.swap_notifications_warning, var.swap_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.swap_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -123,7 +123,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.free_memory_disabled_critical, var.free_memory_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.free_memory_notifications_critical, var.free_memory_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.free_memory_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -132,7 +132,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.free_memory_disabled_warning, var.free_memory_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.free_memory_notifications_warning, var.free_memory_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.free_memory_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -151,7 +151,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.evictions_growing_disabled_critical, var.evictions_growing_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.evictions_growing_notifications_critical, var.evictions_growing_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.evictions_growing_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -160,7 +160,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.evictions_growing_disabled_warning, var.evictions_growing_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.evictions_growing_notifications_warning, var.evictions_growing_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.evictions_growing_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/aws/elasticache/common/variables.tf
+++ b/cloud/aws/elasticache/common/variables.tf
@@ -8,8 +8,14 @@ variable "environment" {
 # SignalFx module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -45,9 +51,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_notifications" {
-  description = "Notification recipients list for every alerting rules of heartbeat detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for heartbeat detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "heartbeat_timeframe" {
@@ -77,21 +83,9 @@ variable "evictions_disabled_warning" {
 }
 
 variable "evictions_notifications" {
-  description = "Notification recipients list for every alerting rules of evictions detector"
-  type        = list
-  default     = []
-}
-
-variable "evictions_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of evictions detector"
-  type        = list
-  default     = []
-}
-
-variable "evictions_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of evictions detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for evictions detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "evictions_aggregation_function" {
@@ -133,15 +127,9 @@ variable "max_connection_disabled_critical" {
 }
 
 variable "max_connection_notifications" {
-  description = "Notification recipients list for every alerting rules of max_connection detector"
-  type        = list
-  default     = []
-}
-
-variable "max_connection_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of max_connection detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for max_connection detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "max_connection_aggregation_function" {
@@ -177,15 +165,9 @@ variable "no_connection_disabled_critical" {
 }
 
 variable "no_connection_notifications" {
-  description = "Notification recipients list for every alerting rules of no_connection detector"
-  type        = list
-  default     = []
-}
-
-variable "no_connection_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of no_connection detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for no_connection detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "no_connection_aggregation_function" {
@@ -227,21 +209,9 @@ variable "swap_disabled_warning" {
 }
 
 variable "swap_notifications" {
-  description = "Notification recipients list for every alerting rules of swap detector"
-  type        = list
-  default     = []
-}
-
-variable "swap_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of swap detector"
-  type        = list
-  default     = []
-}
-
-variable "swap_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of swap detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for swap detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "swap_aggregation_function" {
@@ -289,21 +259,9 @@ variable "free_memory_disabled_warning" {
 }
 
 variable "free_memory_notifications" {
-  description = "Notification recipients list for every alerting rules of free_memory detector"
-  type        = list
-  default     = []
-}
-
-variable "free_memory_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of free_memory detector"
-  type        = list
-  default     = []
-}
-
-variable "free_memory_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of free_memory detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for free_memory detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "free_memory_aggregation_function" {
@@ -351,21 +309,9 @@ variable "evictions_growing_disabled_warning" {
 }
 
 variable "evictions_growing_notifications" {
-  description = "Notification recipients list for every alerting rules of evictions_growing detector"
-  type        = list
-  default     = []
-}
-
-variable "evictions_growing_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of evictions_growing detector"
-  type        = list
-  default     = []
-}
-
-variable "evictions_growing_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of evictions_growing detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for evictions_growing detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "evictions_growing_aggregation_function" {

--- a/cloud/aws/elasticache/memcached/detectors-memcached.tf
+++ b/cloud/aws/elasticache/memcached/detectors-memcached.tf
@@ -14,7 +14,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.hit_ratio_disabled_critical, var.hit_ratio_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.hit_ratio_notifications_critical, var.hit_ratio_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.hit_ratio_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -23,7 +23,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.hit_ratio_disabled_warning, var.hit_ratio_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.hit_ratio_notifications_warning, var.hit_ratio_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.hit_ratio_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -42,7 +42,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.cpu_disabled_critical, var.cpu_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.cpu_notifications_critical, var.cpu_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.cpu_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -51,7 +51,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.cpu_disabled_warning, var.cpu_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.cpu_notifications_warning, var.cpu_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.cpu_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/aws/elasticache/memcached/variables.tf
+++ b/cloud/aws/elasticache/memcached/variables.tf
@@ -8,8 +8,14 @@ variable "environment" {
 # SignalFx module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -59,21 +65,9 @@ variable "hit_ratio_disabled_warning" {
 }
 
 variable "hit_ratio_notifications" {
-  description = "Notification recipients list for every alerting rules of hit_ratio detector"
-  type        = list
-  default     = []
-}
-
-variable "hit_ratio_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of hit_ratio detector"
-  type        = list
-  default     = []
-}
-
-variable "hit_ratio_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of hit_ratio detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for hit_ratio detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "hit_ratio_aggregation_function" {
@@ -133,21 +127,9 @@ variable "cpu_disabled_warning" {
 }
 
 variable "cpu_notifications" {
-  description = "Notification recipients list for every alerting rules of cpu detector"
-  type        = list
-  default     = []
-}
-
-variable "cpu_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of cpu detector"
-  type        = list
-  default     = []
-}
-
-variable "cpu_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of cpu detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for cpu detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "cpu_aggregation_function" {

--- a/cloud/aws/elasticache/redis/detectors-redis.tf
+++ b/cloud/aws/elasticache/redis/detectors-redis.tf
@@ -14,7 +14,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.cache_hits_disabled_critical, var.cache_hits_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.cache_hits_notifications_critical, var.cache_hits_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.cache_hits_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -23,7 +23,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.cache_hits_disabled_warning, var.cache_hits_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.cache_hits_notifications_warning, var.cache_hits_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.cache_hits_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -42,7 +42,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.cpu_high_disabled_critical, var.cpu_high_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.cpu_high_notifications_critical, var.cpu_high_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.cpu_high_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -51,7 +51,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.cpu_high_disabled_warning, var.cpu_high_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.cpu_high_notifications_warning, var.cpu_high_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.cpu_high_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -70,7 +70,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.replication_lag_disabled_critical, var.replication_lag_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.replication_lag_notifications_critical, var.replication_lag_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.replication_lag_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -79,7 +79,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.replication_lag_disabled_warning, var.replication_lag_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.replication_lag_notifications_warning, var.replication_lag_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.replication_lag_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -100,7 +100,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.commands_disabled_critical, var.commands_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.commands_notifications_critical, var.commands_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.commands_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -109,7 +109,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.commands_disabled_warning, var.commands_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.commands_notifications_warning, var.commands_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.commands_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/aws/elasticache/redis/variables.tf
+++ b/cloud/aws/elasticache/redis/variables.tf
@@ -8,8 +8,14 @@ variable "environment" {
 # SignalFx module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -59,21 +65,9 @@ variable "cache_hits_disabled_warning" {
 }
 
 variable "cache_hits_notifications" {
-  description = "Notification recipients list for every alerting rules of cache_hits detector"
-  type        = list
-  default     = []
-}
-
-variable "cache_hits_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of cache_hits detector"
-  type        = list
-  default     = []
-}
-
-variable "cache_hits_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of cache_hits detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for cache_hits detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "cache_hits_aggregation_function" {
@@ -133,21 +127,9 @@ variable "cpu_high_disabled_warning" {
 }
 
 variable "cpu_high_notifications" {
-  description = "Notification recipients list for every alerting rules of cpu_high detector"
-  type        = list
-  default     = []
-}
-
-variable "cpu_high_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of cpu_high detector"
-  type        = list
-  default     = []
-}
-
-variable "cpu_high_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of cpu_high detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for cpu_high detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "cpu_high_aggregation_function" {
@@ -195,21 +177,9 @@ variable "replication_lag_disabled_warning" {
 }
 
 variable "replication_lag_notifications" {
-  description = "Notification recipients list for every alerting rules of replication_lag detector"
-  type        = list
-  default     = []
-}
-
-variable "replication_lag_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of replication_lag detector"
-  type        = list
-  default     = []
-}
-
-variable "replication_lag_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of replication_lag detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for replication_lag detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "replication_lag_aggregation_function" {
@@ -257,21 +227,9 @@ variable "commands_disabled_warning" {
 }
 
 variable "commands_notifications" {
-  description = "Notification recipients list for every alerting rules of commands detector"
-  type        = list
-  default     = []
-}
-
-variable "commands_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of commands detector"
-  type        = list
-  default     = []
-}
-
-variable "commands_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of commands detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for commands detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "commands_aggregation_function" {

--- a/cloud/aws/elasticsearch/detectors-elasticsearch.tf
+++ b/cloud/aws/elasticsearch/detectors-elasticsearch.tf
@@ -12,7 +12,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.heartbeat_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.heartbeat_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.heartbeat_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
 }
@@ -32,7 +32,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.cluster_status_disabled_critical, var.cluster_status_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.cluster_status_notifications_critical, var.cluster_status_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.cluster_status_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
 
@@ -41,7 +41,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.cluster_status_disabled_warning, var.cluster_status_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.cluster_status_notifications_warning, var.cluster_status_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.cluster_status_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
 }
@@ -60,7 +60,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.free_space_disabled_critical, var.free_space_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.free_space_notifications_critical, var.free_space_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.free_space_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -69,7 +69,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.free_space_disabled_warning, var.free_space_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.free_space_notifications_warning, var.free_space_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.free_space_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -88,7 +88,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.cpu_90_15min_disabled_critical, var.cpu_90_15min_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.cpu_90_15min_notifications_critical, var.cpu_90_15min_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.cpu_90_15min_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -97,7 +97,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.cpu_90_15min_disabled_warning, var.cpu_90_15min_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.cpu_90_15min_notifications_warning, var.cpu_90_15min_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.cpu_90_15min_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/aws/elasticsearch/variables.tf
+++ b/cloud/aws/elasticsearch/variables.tf
@@ -8,8 +8,14 @@ variable "environment" {
 # SignalFx module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -45,9 +51,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_notifications" {
-  description = "Notification recipients list for every alerting rules of heartbeat detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for heartbeat detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "heartbeat_timeframe" {
@@ -77,21 +83,9 @@ variable "cluster_status_disabled_warning" {
 }
 
 variable "cluster_status_notifications" {
-  description = "Notification recipients list for every alerting rules of cluster_status detector"
-  type        = list
-  default     = []
-}
-
-variable "cluster_status_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of cluster_status detector"
-  type        = list
-  default     = []
-}
-
-variable "cluster_status_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of cluster_status detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for cluster_status detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "cluster_status_aggregation_function" {
@@ -127,21 +121,9 @@ variable "free_space_disabled_warning" {
 }
 
 variable "free_space_notifications" {
-  description = "Notification recipients list for every alerting rules of free_space detector"
-  type        = list
-  default     = []
-}
-
-variable "free_space_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of free_space detector"
-  type        = list
-  default     = []
-}
-
-variable "free_space_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of free_space detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for free_space detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "free_space_aggregation_function" {
@@ -189,21 +171,9 @@ variable "cpu_90_15min_disabled_warning" {
 }
 
 variable "cpu_90_15min_notifications" {
-  description = "Notification recipients list for every alerting rules of cpu_90_15min detector"
-  type        = list
-  default     = []
-}
-
-variable "cpu_90_15min_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of cpu_90_15min detector"
-  type        = list
-  default     = []
-}
-
-variable "cpu_90_15min_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of cpu_90_15min detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for cpu_90_15min detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "cpu_90_15min_aggregation_function" {

--- a/cloud/aws/elb/detectors-elb.tf
+++ b/cloud/aws/elb/detectors-elb.tf
@@ -12,7 +12,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.heartbeat_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.heartbeat_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.heartbeat_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
 }
@@ -33,7 +33,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.no_healthy_instances_disabled_critical, var.no_healthy_instances_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.no_healthy_instances_notifications_critical, var.no_healthy_instances_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.no_healthy_instances_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -42,7 +42,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.no_healthy_instances_disabled_warning, var.no_healthy_instances_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.no_healthy_instances_notifications_warning, var.no_healthy_instances_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.no_healthy_instances_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -63,7 +63,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.elb_4xx_disabled_critical, var.elb_4xx_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.elb_4xx_notifications_critical, var.elb_4xx_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.elb_4xx_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -72,7 +72,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.elb_4xx_disabled_warning, var.elb_4xx_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.elb_4xx_notifications_warning, var.elb_4xx_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.elb_4xx_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -93,7 +93,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.elb_5xx_disabled_critical, var.elb_5xx_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.elb_5xx_notifications_critical, var.elb_5xx_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.elb_5xx_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -102,7 +102,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.elb_5xx_disabled_warning, var.elb_5xx_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.elb_5xx_notifications_warning, var.elb_5xx_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.elb_5xx_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -123,7 +123,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.backend_4xx_disabled_critical, var.backend_4xx_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.backend_4xx_notifications_critical, var.backend_4xx_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.backend_4xx_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -132,7 +132,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.backend_4xx_disabled_warning, var.backend_4xx_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.backend_4xx_notifications_warning, var.backend_4xx_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.backend_4xx_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -153,7 +153,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.backend_5xx_disabled_critical, var.backend_5xx_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.backend_5xx_notifications_critical, var.backend_5xx_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.backend_5xx_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -162,7 +162,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.backend_5xx_disabled_warning, var.backend_5xx_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.backend_5xx_notifications_warning, var.backend_5xx_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.backend_5xx_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -181,7 +181,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.backend_latency_disabled_critical, var.backend_latency_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.backend_latency_notifications_critical, var.backend_latency_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.backend_latency_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -190,7 +190,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.backend_latency_disabled_warning, var.backend_latency_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.backend_latency_notifications_warning, var.backend_latency_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.backend_latency_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/aws/elb/variables.tf
+++ b/cloud/aws/elb/variables.tf
@@ -8,8 +8,14 @@ variable "environment" {
 # SignalFx module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -51,9 +57,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_notifications" {
-  description = "Notification recipients list for every alerting rules of heartbeat detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for heartbeat detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "heartbeat_timeframe" {
@@ -83,21 +89,9 @@ variable "no_healthy_instances_disabled_warning" {
 }
 
 variable "no_healthy_instances_notifications" {
-  description = "Notification recipients list for every alerting rules of no_healthy_instances detector"
-  type        = list
-  default     = []
-}
-
-variable "no_healthy_instances_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of no_healthy_instances detector"
-  type        = list
-  default     = []
-}
-
-variable "no_healthy_instances_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of no_healthy_instances detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for no_healthy_instances detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "no_healthy_instances_aggregation_function" {
@@ -145,21 +139,9 @@ variable "elb_4xx_disabled_warning" {
 }
 
 variable "elb_4xx_notifications" {
-  description = "Notification recipients list for every alerting rules of 4xx detector"
-  type        = list
-  default     = []
-}
-
-variable "elb_4xx_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of 4xx detector"
-  type        = list
-  default     = []
-}
-
-variable "elb_4xx_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of 4xx detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for 4xx detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "elb_4xx_aggregation_function" {
@@ -219,21 +201,9 @@ variable "elb_5xx_disabled_warning" {
 }
 
 variable "elb_5xx_notifications" {
-  description = "Notification recipients list for every alerting rules of 5xx detector"
-  type        = list
-  default     = []
-}
-
-variable "elb_5xx_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of 5xx detector"
-  type        = list
-  default     = []
-}
-
-variable "elb_5xx_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of 5xx detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for 5xx detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "elb_5xx_aggregation_function" {
@@ -293,21 +263,9 @@ variable "backend_4xx_disabled_warning" {
 }
 
 variable "backend_4xx_notifications" {
-  description = "Notification recipients list for every alerting rules of backend_4xx detector"
-  type        = list
-  default     = []
-}
-
-variable "backend_4xx_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of backend_4xx detector"
-  type        = list
-  default     = []
-}
-
-variable "backend_4xx_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of backend_4xx detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for backend_4xx detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "backend_4xx_aggregation_function" {
@@ -367,21 +325,9 @@ variable "backend_5xx_disabled_warning" {
 }
 
 variable "backend_5xx_notifications" {
-  description = "Notification recipients list for every alerting rules of backend_5xx detector"
-  type        = list
-  default     = []
-}
-
-variable "backend_5xx_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of backend_5xx detector"
-  type        = list
-  default     = []
-}
-
-variable "backend_5xx_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of backend_5xx detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for backend_5xx detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "backend_5xx_aggregation_function" {
@@ -441,21 +387,9 @@ variable "backend_latency_disabled_warning" {
 }
 
 variable "backend_latency_notifications" {
-  description = "Notification recipients list for every alerting rules of backend_latency detector"
-  type        = list
-  default     = []
-}
-
-variable "backend_latency_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of backend_latency detector"
-  type        = list
-  default     = []
-}
-
-variable "backend_latency_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of backend_latency detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for backend_latency detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "backend_latency_aggregation_function" {

--- a/cloud/aws/kinesis-firehose/detectors-kinesis-firehose.tf
+++ b/cloud/aws/kinesis-firehose/detectors-kinesis-firehose.tf
@@ -12,7 +12,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.heartbeat_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.heartbeat_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.heartbeat_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
 }
@@ -31,7 +31,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.incoming_records_disabled_critical, var.incoming_records_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.incoming_records_notifications_critical, var.incoming_records_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.incoming_records_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -40,7 +40,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.incoming_records_disabled_warning, var.incoming_records_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.incoming_records_notifications_warning, var.incoming_records_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.incoming_records_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/aws/kinesis-firehose/variables.tf
+++ b/cloud/aws/kinesis-firehose/variables.tf
@@ -8,8 +8,14 @@ variable "environment" {
 # SignalFx module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -45,9 +51,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_notifications" {
-  description = "Notification recipients list for every alerting rules of heartbeat detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for heartbeat detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "heartbeat_timeframe" {
@@ -77,21 +83,9 @@ variable "incoming_records_disabled_warning" {
 }
 
 variable "incoming_records_notifications" {
-  description = "Notification recipients list for every alerting rules of incoming_records detector"
-  type        = list
-  default     = []
-}
-
-variable "incoming_records_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of incoming_records detector"
-  type        = list
-  default     = []
-}
-
-variable "incoming_records_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of incoming_records detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for incoming_records detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "incoming_records_aggregation_function" {

--- a/cloud/aws/lambda/detectors-lambda.tf
+++ b/cloud/aws/lambda/detectors-lambda.tf
@@ -14,7 +14,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.pct_errors_disabled_critical, var.pct_errors_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.pct_errors_notifications_critical, var.pct_errors_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.pct_errors_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -23,7 +23,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.pct_errors_disabled_warning, var.pct_errors_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.pct_errors_notifications_warning, var.pct_errors_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.pct_errors_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -42,7 +42,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.throttles_disabled_critical, var.throttles_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.throttles_notifications_critical, var.throttles_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.throttles_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -51,7 +51,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.throttles_disabled_warning, var.throttles_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.throttles_notifications_warning, var.throttles_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.throttles_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -69,7 +69,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.invocations_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.invocations_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.invocations_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/aws/lambda/variables.tf
+++ b/cloud/aws/lambda/variables.tf
@@ -8,8 +8,14 @@ variable "environment" {
 # SignalFx module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -59,21 +65,9 @@ variable "pct_errors_disabled_warning" {
 }
 
 variable "pct_errors_notifications" {
-  description = "Notification recipients list for every alerting rules of pct_errors detector"
-  type        = list
-  default     = []
-}
-
-variable "pct_errors_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of pct_errors detector"
-  type        = list
-  default     = []
-}
-
-variable "pct_errors_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of pct_errors detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for pct_errors detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "pct_errors_aggregation_function" {
@@ -127,21 +121,9 @@ variable "throttles_disabled_warning" {
 }
 
 variable "throttles_notifications" {
-  description = "Notification recipients list for every alerting rules of throttles detector"
-  type        = list
-  default     = []
-}
-
-variable "throttles_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of throttles detector"
-  type        = list
-  default     = []
-}
-
-variable "throttles_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of throttles detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for throttles detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "throttles_aggregation_function" {
@@ -177,9 +159,9 @@ variable "invocations_disabled" {
 }
 
 variable "invocations_notifications" {
-  description = "Notification recipients list for every alerting rules of invocations detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for invocations detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "invocations_aggregation_function" {

--- a/cloud/aws/nlb/detectors-nlb.tf
+++ b/cloud/aws/nlb/detectors-nlb.tf
@@ -12,7 +12,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.heartbeat_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.heartbeat_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.heartbeat_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
 }
@@ -33,7 +33,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.no_healthy_instances_disabled_critical, var.no_healthy_instances_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.no_healthy_instances_notifications_critical, var.no_healthy_instances_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.no_healthy_instances_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -42,7 +42,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.no_healthy_instances_disabled_warning, var.no_healthy_instances_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.no_healthy_instances_notifications_warning, var.no_healthy_instances_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.no_healthy_instances_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/aws/nlb/variables.tf
+++ b/cloud/aws/nlb/variables.tf
@@ -8,8 +8,14 @@ variable "environment" {
 # SignalFx module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -45,9 +51,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_notifications" {
-  description = "Notification recipients list for every alerting rules of heartbeat detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for heartbeat detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "heartbeat_timeframe" {
@@ -77,21 +83,9 @@ variable "no_healthy_instances_disabled_warning" {
 }
 
 variable "no_healthy_instances_notifications" {
-  description = "Notification recipients list for every alerting rules of no_healthy_instances detector"
-  type        = list
-  default     = []
-}
-
-variable "no_healthy_instances_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of no_healthy_instances detector"
-  type        = list
-  default     = []
-}
-
-variable "no_healthy_instances_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of no_healthy_instances detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for no_healthy_instances detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "no_healthy_instances_aggregation_function" {

--- a/cloud/aws/rds/aurora/mysql/detectors-rds-aurora-mysql.tf
+++ b/cloud/aws/rds/aurora/mysql/detectors-rds-aurora-mysql.tf
@@ -12,7 +12,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.aurora_mysql_replica_lag_disabled_critical, var.aurora_mysql_replica_lag_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.aurora_mysql_replica_lag_notifications_critical, var.aurora_mysql_replica_lag_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.aurora_mysql_replica_lag_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -21,7 +21,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.aurora_mysql_replica_lag_disabled_warning, var.aurora_mysql_replica_lag_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.aurora_mysql_replica_lag_notifications_warning, var.aurora_mysql_replica_lag_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.aurora_mysql_replica_lag_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/aws/rds/aurora/mysql/variables.tf
+++ b/cloud/aws/rds/aurora/mysql/variables.tf
@@ -8,8 +8,14 @@ variable "environment" {
 # SignalFx module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -57,21 +63,9 @@ variable "aurora_mysql_replica_lag_disabled_warning" {
 }
 
 variable "aurora_mysql_replica_lag_notifications" {
-  description = "Notification recipients list for every alerting rules of aurora_mysql_replica_lag detector"
-  type        = list
-  default     = []
-}
-
-variable "aurora_mysql_replica_lag_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of aurora_mysql_replica_lag detector"
-  type        = list
-  default     = []
-}
-
-variable "aurora_mysql_replica_lag_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of aurora_mysql_replica_lag detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for aurora_mysql_replica_lag detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "aurora_mysql_replica_lag_aggregation_function" {

--- a/cloud/aws/rds/aurora/postgresql/detectors-rds-aurora-postgresql.tf
+++ b/cloud/aws/rds/aurora/postgresql/detectors-rds-aurora-postgresql.tf
@@ -12,7 +12,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.aurora_postgresql_replica_lag_disabled_critical, var.aurora_postgresql_replica_lag_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.aurora_postgresql_replica_lag_notifications_critical, var.aurora_postgresql_replica_lag_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.aurora_postgresql_replica_lag_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -21,7 +21,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.aurora_postgresql_replica_lag_disabled_warning, var.aurora_postgresql_replica_lag_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.aurora_postgresql_replica_lag_notifications_warning, var.aurora_postgresql_replica_lag_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.aurora_postgresql_replica_lag_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/aws/rds/aurora/postgresql/variables.tf
+++ b/cloud/aws/rds/aurora/postgresql/variables.tf
@@ -8,8 +8,14 @@ variable "environment" {
 # SignalFx module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -59,21 +65,9 @@ variable "aurora_postgresql_replica_lag_disabled_warning" {
 }
 
 variable "aurora_postgresql_replica_lag_notifications" {
-  description = "Notification recipients list for every alerting rules of aurora_postgresql_replica_lag detector"
-  type        = list
-  default     = []
-}
-
-variable "aurora_postgresql_replica_lag_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of aurora_postgresql_replica_lag detector"
-  type        = list
-  default     = []
-}
-
-variable "aurora_postgresql_replica_lag_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of aurora_postgresql_replica_lag detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for aurora_postgresql_replica_lag detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "aurora_postgresql_replica_lag_aggregation_function" {

--- a/cloud/aws/rds/common/detectors-rds-common.tf
+++ b/cloud/aws/rds/common/detectors-rds-common.tf
@@ -12,7 +12,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.heartbeat_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.heartbeat_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.heartbeat_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
 }
@@ -31,7 +31,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.cpu_90_15min_disabled_critical, var.cpu_90_15min_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.cpu_90_15min_notifications_critical, var.cpu_90_15min_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.cpu_90_15min_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -40,7 +40,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.cpu_90_15min_disabled_warning, var.cpu_90_15min_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.cpu_90_15min_notifications_warning, var.cpu_90_15min_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.cpu_90_15min_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -59,7 +59,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.free_space_low_disabled_critical, var.free_space_low_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.free_space_low_notifications_critical, var.free_space_low_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.free_space_low_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -68,7 +68,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.free_space_low_disabled_warning, var.free_space_low_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.free_space_low_notifications_warning, var.free_space_low_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.free_space_low_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -87,7 +87,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.replica_lag_disabled_critical, var.replica_lag_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.replica_lag_notifications_critical, var.replica_lag_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.replica_lag_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -96,7 +96,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.replica_lag_disabled_warning, var.replica_lag_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.replica_lag_notifications_warning, var.replica_lag_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.replica_lag_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/aws/rds/common/variables.tf
+++ b/cloud/aws/rds/common/variables.tf
@@ -8,8 +8,14 @@ variable "environment" {
 # SignalFx module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -45,9 +51,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_notifications" {
-  description = "Notification recipients list for every alerting rules of heartbeat detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for heartbeat detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "heartbeat_timeframe" {
@@ -77,21 +83,9 @@ variable "cpu_90_15min_disabled_warning" {
 }
 
 variable "cpu_90_15min_notifications" {
-  description = "Notification recipients list for every alerting rules of cpu_90_15min detector"
-  type        = list
-  default     = []
-}
-
-variable "cpu_90_15min_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of cpu_90_15min detector"
-  type        = list
-  default     = []
-}
-
-variable "cpu_90_15min_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of cpu_90_15min detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for cpu_90_15min detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "cpu_90_15min_aggregation_function" {
@@ -139,21 +133,9 @@ variable "free_space_low_disabled_warning" {
 }
 
 variable "free_space_low_notifications" {
-  description = "Notification recipients list for every alerting rules of free_space_low detector"
-  type        = list
-  default     = []
-}
-
-variable "free_space_low_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of free_space_low detector"
-  type        = list
-  default     = []
-}
-
-variable "free_space_low_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of free_space_low detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for free_space_low detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "free_space_low_aggregation_function" {
@@ -201,21 +183,9 @@ variable "replica_lag_disabled_warning" {
 }
 
 variable "replica_lag_notifications" {
-  description = "Notification recipients list for every alerting rules of replica_lag detector"
-  type        = list
-  default     = []
-}
-
-variable "replica_lag_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of replica_lag detector"
-  type        = list
-  default     = []
-}
-
-variable "replica_lag_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of replica_lag detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for replica_lag detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "replica_lag_aggregation_function" {

--- a/cloud/aws/sqs/detectors-sqs.tf
+++ b/cloud/aws/sqs/detectors-sqs.tf
@@ -12,7 +12,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.heartbeat_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.heartbeat_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.heartbeat_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
 }
@@ -31,7 +31,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.visible_messages_disabled_critical, var.visible_messages_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.visible_messages_notifications_critical, var.visible_messages_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.visible_messages_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -40,7 +40,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.visible_messages_disabled_warning, var.visible_messages_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.visible_messages_notifications_warning, var.visible_messages_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.visible_messages_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -59,7 +59,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.age_of_oldest_message_disabled_critical, var.age_of_oldest_message_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.age_of_oldest_message_notifications_critical, var.age_of_oldest_message_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.age_of_oldest_message_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -68,7 +68,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.age_of_oldest_message_disabled_warning, var.age_of_oldest_message_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.age_of_oldest_message_notifications_warning, var.age_of_oldest_message_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.age_of_oldest_message_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/aws/sqs/variables.tf
+++ b/cloud/aws/sqs/variables.tf
@@ -8,8 +8,14 @@ variable "environment" {
 # SignalFx module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -45,9 +51,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_notifications" {
-  description = "Notification recipients list for every alerting rules of heartbeat detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for heartbeat detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "heartbeat_timeframe" {
@@ -77,21 +83,9 @@ variable "visible_messages_disabled_warning" {
 }
 
 variable "visible_messages_notifications" {
-  description = "Notification recipients list for every alerting rules of visible_messages detector"
-  type        = list
-  default     = []
-}
-
-variable "visible_messages_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of visible_messages detector"
-  type        = list
-  default     = []
-}
-
-variable "visible_messages_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of visible_messages detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for visible_messages detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "visible_messages_aggregation_function" {
@@ -139,21 +133,9 @@ variable "age_of_oldest_message_disabled_warning" {
 }
 
 variable "age_of_oldest_message_notifications" {
-  description = "Notification recipients list for every alerting rules of age_of_oldest_message detector"
-  type        = list
-  default     = []
-}
-
-variable "age_of_oldest_message_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of age_of_oldest_message detector"
-  type        = list
-  default     = []
-}
-
-variable "age_of_oldest_message_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of age_of_oldest_message detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for age_of_oldest_message detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "age_of_oldest_message_aggregation_function" {

--- a/cloud/aws/vpn/detectors-vpn.tf
+++ b/cloud/aws/vpn/detectors-vpn.tf
@@ -12,7 +12,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.heartbeat_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.heartbeat_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.heartbeat_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
 }
@@ -30,7 +30,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.vpn_status_disabled_critical, var.vpn_status_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.vpn_status_notifications_critical, var.vpn_status_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.vpn_status_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/aws/vpn/variables.tf
+++ b/cloud/aws/vpn/variables.tf
@@ -8,8 +8,14 @@ variable "environment" {
 # SignalFx module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -45,9 +51,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_notifications" {
-  description = "Notification recipients list for every alerting rules of heartbeat detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for heartbeat detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "heartbeat_timeframe" {
@@ -71,15 +77,9 @@ variable "vpn_status_disabled_critical" {
 }
 
 variable "vpn_status_notifications" {
-  description = "Notification recipients list for every alerting rules of vpn_status detector"
-  type        = list
-  default     = []
-}
-
-variable "vpn_status_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of vpn_status detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for vpn_status detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "vpn_status_aggregation_function" {

--- a/cloud/azure/app-service-plan/detectors-azure-app-service-plan.tf
+++ b/cloud/azure/app-service-plan/detectors-azure-app-service-plan.tf
@@ -13,7 +13,7 @@ resource "signalfx_detector" "heartbeat" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.heartbeat_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.heartbeat_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.heartbeat_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
 }
@@ -33,7 +33,7 @@ resource "signalfx_detector" "cpu_percentage" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.cpu_percentage_disabled_critical, var.cpu_percentage_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.cpu_percentage_notifications_critical, var.cpu_percentage_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.cpu_percentage_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -42,7 +42,7 @@ resource "signalfx_detector" "cpu_percentage" {
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.cpu_percentage_disabled_warning, var.cpu_percentage_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.cpu_percentage_notifications_warning, var.cpu_percentage_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.cpu_percentage_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -62,7 +62,7 @@ resource "signalfx_detector" "memory_percentage" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.memory_percentage_disabled_critical, var.memory_percentage_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.memory_percentage_notifications_critical, var.memory_percentage_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.memory_percentage_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -71,7 +71,7 @@ resource "signalfx_detector" "memory_percentage" {
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.memory_percentage_disabled_warning, var.memory_percentage_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.memory_percentage_notifications_warning, var.memory_percentage_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.memory_percentage_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/azure/app-service-plan/variables.tf
+++ b/cloud/azure/app-service-plan/variables.tf
@@ -8,8 +8,14 @@ variable "environment" {
 # SignalFx module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list(string)
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -45,9 +51,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_notifications" {
-  description = "Notification recipients list for every alerting rules of heartbeat detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for heartbeat detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "heartbeat_timeframe" {
@@ -77,21 +83,9 @@ variable "cpu_percentage_disabled_warning" {
 }
 
 variable "cpu_percentage_notifications" {
-  description = "Notification recipients list for every alerting rules of cpu_percentage detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "cpu_percentage_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of cpu_percentage detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "cpu_percentage_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of cpu_percentage detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for cpu_percentage detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "cpu_percentage_aggregation_function" {
@@ -139,21 +133,9 @@ variable "memory_percentage_disabled_warning" {
 }
 
 variable "memory_percentage_notifications" {
-  description = "Notification recipients list for every alerting rules of memory_percentage detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "memory_percentage_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of memory_percentage detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "memory_percentage_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of memory_percentage detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for memory_percentage detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "memory_percentage_aggregation_function" {

--- a/cloud/azure/app-service/detectors-app_services.tf
+++ b/cloud/azure/app-service/detectors-app_services.tf
@@ -13,7 +13,7 @@ resource "signalfx_detector" "heartbeat" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.heartbeat_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.heartbeat_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.heartbeat_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
 }
@@ -33,7 +33,7 @@ resource "signalfx_detector" "response_time" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.response_time_disabled_critical, var.response_time_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.response_time_notifications_critical, var.response_time_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.response_time_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -42,7 +42,7 @@ resource "signalfx_detector" "response_time" {
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.response_time_disabled_warning, var.response_time_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.response_time_notifications_warning, var.response_time_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.response_time_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -63,7 +63,7 @@ resource "signalfx_detector" "memory_usage_count" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.memory_usage_count_disabled_critical, var.memory_usage_count_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.memory_usage_count_notifications_critical, var.memory_usage_count_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.memory_usage_count_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -72,7 +72,7 @@ resource "signalfx_detector" "memory_usage_count" {
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.memory_usage_count_disabled_warning, var.memory_usage_count_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.memory_usage_count_notifications_warning, var.memory_usage_count_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.memory_usage_count_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -95,7 +95,7 @@ resource "signalfx_detector" "http_5xx_errors_count" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.http_5xx_errors_count_disabled_critical, var.http_5xx_errors_count_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.http_5xx_errors_count_notifications_critical, var.http_5xx_errors_count_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.http_5xx_errors_count_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -104,7 +104,7 @@ resource "signalfx_detector" "http_5xx_errors_count" {
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.http_5xx_errors_count_disabled_warning, var.http_5xx_errors_count_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.http_5xx_errors_count_notifications_warning, var.http_5xx_errors_count_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.http_5xx_errors_count_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -127,7 +127,7 @@ resource "signalfx_detector" "http_4xx_errors_count" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.http_4xx_errors_count_disabled_critical, var.http_4xx_errors_count_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.http_4xx_errors_count_notifications_critical, var.http_4xx_errors_count_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.http_4xx_errors_count_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -136,7 +136,7 @@ resource "signalfx_detector" "http_4xx_errors_count" {
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.http_4xx_errors_count_disabled_warning, var.http_4xx_errors_count_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.http_4xx_errors_count_notifications_warning, var.http_4xx_errors_count_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.http_4xx_errors_count_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -159,7 +159,7 @@ resource "signalfx_detector" "http_success_status_rate" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.http_success_status_rate_disabled_critical, var.http_success_status_rate_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.http_success_status_rate_notifications_critical, var.http_success_status_rate_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.http_success_status_rate_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -168,7 +168,7 @@ resource "signalfx_detector" "http_success_status_rate" {
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.http_success_status_rate_disabled_warning, var.http_success_status_rate_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.http_success_status_rate_notifications_warning, var.http_success_status_rate_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.http_success_status_rate_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/azure/app-service/variables.tf
+++ b/cloud/azure/app-service/variables.tf
@@ -8,8 +8,14 @@ variable "environment" {
 # SignalFx module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list(string)
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -45,9 +51,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_notifications" {
-  description = "Notification recipients list for every alerting rules of heartbeat detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for heartbeat detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "heartbeat_timeframe" {
@@ -77,21 +83,9 @@ variable "response_time_disabled_warning" {
 }
 
 variable "response_time_notifications" {
-  description = "Notification recipients list for every alerting rules of response_time detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "response_time_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of response_time detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "response_time_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of response_time detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for response_time detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "response_time_aggregation_function" {
@@ -139,21 +133,9 @@ variable "memory_usage_count_disabled_warning" {
 }
 
 variable "memory_usage_count_notifications" {
-  description = "Notification recipients list for every alerting rules of memory_usage_count detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "memory_usage_count_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of memory_usage_count detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "memory_usage_count_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of memory_usage_count detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for memory_usage_count detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "memory_usage_count_aggregation_function" {
@@ -201,21 +183,9 @@ variable "http_5xx_errors_count_disabled_warning" {
 }
 
 variable "http_5xx_errors_count_notifications" {
-  description = "Notification recipients list for every alerting rules of http_5xx_errors_count detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "http_5xx_errors_count_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of http_5xx_errors_count detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "http_5xx_errors_count_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of http_5xx_errors_count detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for http_5xx_errors_count detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "http_5xx_errors_count_aggregation_function" {
@@ -263,21 +233,9 @@ variable "http_4xx_errors_count_disabled_warning" {
 }
 
 variable "http_4xx_errors_count_notifications" {
-  description = "Notification recipients list for every alerting rules of http_4xx_errors_count detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "http_4xx_errors_count_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of http_4xx_errors_count detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "http_4xx_errors_count_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of http_4xx_errors_count detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for http_4xx_errors_count detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "http_4xx_errors_count_aggregation_function" {
@@ -325,21 +283,9 @@ variable "http_success_status_rate_disabled_warning" {
 }
 
 variable "http_success_status_rate_notifications" {
-  description = "Notification recipients list for every alerting rules of http_success_status_rate detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "http_success_status_rate_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of http_success_status_rate detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "http_success_status_rate_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of http_success_status_rate detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for http_success_status_rate detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "http_success_status_rate_aggregation_function" {

--- a/cloud/azure/application-gateway/detectors-app-gateway.tf
+++ b/cloud/azure/application-gateway/detectors-app-gateway.tf
@@ -13,7 +13,7 @@ resource "signalfx_detector" "heartbeat" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.heartbeat_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.heartbeat_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.heartbeat_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
 }
@@ -32,7 +32,7 @@ resource "signalfx_detector" "total_requests" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.total_requests_disabled_critical, var.total_requests_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.total_requests_notifications_critical, var.total_requests_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.total_requests_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -53,7 +53,7 @@ resource "signalfx_detector" "backend_connect_time" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.backend_connect_time_disabled_critical, var.backend_connect_time_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.backend_connect_time_notifications_critical, var.backend_connect_time_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.backend_connect_time_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -62,7 +62,7 @@ resource "signalfx_detector" "backend_connect_time" {
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.backend_connect_time_disabled_warning, var.backend_connect_time_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.backend_connect_time_notifications_warning, var.backend_connect_time_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.backend_connect_time_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -85,7 +85,7 @@ resource "signalfx_detector" "failed_requests" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.failed_requests_disabled_critical, var.failed_requests_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.failed_requests_notifications_critical, var.failed_requests_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.failed_requests_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -94,7 +94,7 @@ resource "signalfx_detector" "failed_requests" {
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.failed_requests_disabled_warning, var.failed_requests_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.failed_requests_notifications_warning, var.failed_requests_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.failed_requests_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -116,7 +116,7 @@ resource "signalfx_detector" "unhealthy_host_ratio" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.unhealthy_host_ratio_disabled_critical, var.unhealthy_host_ratio_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.unhealthy_host_ratio_notifications_critical, var.unhealthy_host_ratio_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.unhealthy_host_ratio_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -125,7 +125,7 @@ resource "signalfx_detector" "unhealthy_host_ratio" {
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.unhealthy_host_ratio_disabled_warning, var.unhealthy_host_ratio_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.unhealthy_host_ratio_notifications_warning, var.unhealthy_host_ratio_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.unhealthy_host_ratio_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -147,7 +147,7 @@ resource "signalfx_detector" "http_4xx_errors" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.http_4xx_errors_disabled_critical, var.http_4xx_errors_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.http_4xx_errors_notifications_critical, var.http_4xx_errors_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.http_4xx_errors_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -156,7 +156,7 @@ resource "signalfx_detector" "http_4xx_errors" {
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.http_4xx_errors_disabled_warning, var.http_4xx_errors_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.http_4xx_errors_notifications_warning, var.http_4xx_errors_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.http_4xx_errors_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -178,7 +178,7 @@ resource "signalfx_detector" "http_5xx_errors" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.http_5xx_errors_disabled_critical, var.http_5xx_errors_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.http_5xx_errors_notifications_critical, var.http_5xx_errors_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.http_5xx_errors_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -187,7 +187,7 @@ resource "signalfx_detector" "http_5xx_errors" {
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.http_5xx_errors_disabled_warning, var.http_5xx_errors_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.http_5xx_errors_notifications_warning, var.http_5xx_errors_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.http_5xx_errors_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -209,7 +209,7 @@ resource "signalfx_detector" "backend_http_4xx_errors" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.backend_http_4xx_errors_disabled_critical, var.backend_http_4xx_errors_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.backend_http_4xx_errors_notifications_critical, var.backend_http_4xx_errors_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.backend_http_4xx_errors_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -218,7 +218,7 @@ resource "signalfx_detector" "backend_http_4xx_errors" {
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.backend_http_4xx_errors_disabled_warning, var.backend_http_4xx_errors_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.backend_http_4xx_errors_notifications_warning, var.backend_http_4xx_errors_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.backend_http_4xx_errors_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -240,7 +240,7 @@ resource "signalfx_detector" "backend_http_5xx_errors" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.backend_http_5xx_errors_disabled_critical, var.backend_http_5xx_errors_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.backend_http_5xx_errors_notifications_critical, var.backend_http_5xx_errors_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.backend_http_5xx_errors_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -249,7 +249,7 @@ resource "signalfx_detector" "backend_http_5xx_errors" {
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.backend_http_5xx_errors_disabled_warning, var.backend_http_5xx_errors_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.backend_http_5xx_errors_notifications_warning, var.backend_http_5xx_errors_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.backend_http_5xx_errors_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/azure/application-gateway/variables.tf
+++ b/cloud/azure/application-gateway/variables.tf
@@ -8,8 +8,14 @@ variable "environment" {
 # SignalFx module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list(string)
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -45,9 +51,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_notifications" {
-  description = "Notification recipients list for every alerting rules of heartbeat detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for heartbeat detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "heartbeat_timeframe" {
@@ -71,15 +77,9 @@ variable "total_requests_disabled_critical" {
 }
 
 variable "total_requests_notifications" {
-  description = "Notification recipients list for every alerting rules of total_requests detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "total_requests_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of total_requests detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for total_requests detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "total_requests_aggregation_function" {
@@ -115,21 +115,9 @@ variable "backend_connect_time_disabled_warning" {
 }
 
 variable "backend_connect_time_notifications" {
-  description = "Notification recipients list for every alerting rules of backend_connect_time detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "backend_connect_time_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of backend_connect_time detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "backend_connect_time_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of backend_connect_time detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for backend_connect_time detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "backend_connect_time_aggregation_function" {
@@ -177,21 +165,9 @@ variable "failed_requests_disabled_warning" {
 }
 
 variable "failed_requests_notifications" {
-  description = "Notification recipients list for every alerting rules of failed_requests detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "failed_requests_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of failed_requests detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "failed_requests_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of failed_requests detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for failed_requests detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "failed_requests_aggregation_function" {
@@ -239,21 +215,9 @@ variable "unhealthy_host_ratio_disabled_warning" {
 }
 
 variable "unhealthy_host_ratio_notifications" {
-  description = "Notification recipients list for every alerting rules of unhealthy_host_ratio detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "unhealthy_host_ratio_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of unhealthy_host_ratio detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "unhealthy_host_ratio_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of unhealthy_host_ratio detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for unhealthy_host_ratio detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "unhealthy_host_ratio_aggregation_function" {
@@ -301,21 +265,9 @@ variable "http_4xx_errors_disabled_warning" {
 }
 
 variable "http_4xx_errors_notifications" {
-  description = "Notification recipients list for every alerting rules of http_4xx_errors detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "http_4xx_errors_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of http_4xx_errors detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "http_4xx_errors_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of http_4xx_errors detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for http_4xx_errors detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "http_4xx_errors_aggregation_function" {
@@ -363,21 +315,9 @@ variable "http_5xx_errors_disabled_warning" {
 }
 
 variable "http_5xx_errors_notifications" {
-  description = "Notification recipients list for every alerting rules of http_5xx_errors detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "http_5xx_errors_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of http_5xx_errors detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "http_5xx_errors_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of http_5xx_errors detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for http_5xx_errors detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "http_5xx_errors_aggregation_function" {
@@ -425,21 +365,9 @@ variable "backend_http_4xx_errors_disabled_warning" {
 }
 
 variable "backend_http_4xx_errors_notifications" {
-  description = "Notification recipients list for every alerting rules of backend_http_4xx_errors detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "backend_http_4xx_errors_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of backend_http_4xx_errors detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "backend_http_4xx_errors_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of backend_http_4xx_errors detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for backend_http_4xx_errors detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "backend_http_4xx_errors_aggregation_function" {
@@ -487,21 +415,9 @@ variable "backend_http_5xx_errors_disabled_warning" {
 }
 
 variable "backend_http_5xx_errors_notifications" {
-  description = "Notification recipients list for every alerting rules of backend_http_5xx_errors detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "backend_http_5xx_errors_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of backend_http_5xx_errors detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "backend_http_5xx_errors_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of backend_http_5xx_errors detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for backend_http_5xx_errors detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "backend_http_5xx_errors_aggregation_function" {

--- a/cloud/azure/azure-search/detectors-azure-search.tf
+++ b/cloud/azure/azure-search/detectors-azure-search.tf
@@ -13,7 +13,7 @@ resource "signalfx_detector" "search_latency" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.search_latency_disabled_critical, var.search_latency_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.search_latency_notifications_critical, var.search_latency_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.search_latency_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -22,7 +22,7 @@ resource "signalfx_detector" "search_latency" {
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.search_latency_disabled_warning, var.search_latency_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.search_latency_notifications_warning, var.search_latency_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.search_latency_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -42,7 +42,7 @@ resource "signalfx_detector" "search_throttled_queries_rate" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.search_throttled_queries_rate_disabled_critical, var.search_throttled_queries_rate_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.search_throttled_queries_rate_notifications_critical, var.search_throttled_queries_rate_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.search_throttled_queries_rate_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -51,7 +51,7 @@ resource "signalfx_detector" "search_throttled_queries_rate" {
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.search_throttled_queries_rate_disabled_warning, var.search_throttled_queries_rate_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.search_throttled_queries_rate_notifications_warning, var.search_throttled_queries_rate_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.search_throttled_queries_rate_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 

--- a/cloud/azure/azure-search/variables.tf
+++ b/cloud/azure/azure-search/variables.tf
@@ -8,8 +8,14 @@ variable "environment" {
 # SignalFx module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list(string)
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -59,21 +65,9 @@ variable "search_latency_disabled_warning" {
 }
 
 variable "search_latency_notifications" {
-  description = "Notification recipients list for every alerting rules of search_latency detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "search_latency_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of search_latency detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "search_latency_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of search_latency detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for search_latency detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "search_latency_aggregation_function" {
@@ -121,21 +115,9 @@ variable "search_throttled_queries_rate_disabled_warning" {
 }
 
 variable "search_throttled_queries_rate_notifications" {
-  description = "Notification recipients list for every alerting rules of search_throttled_queries_rate detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "search_throttled_queries_rate_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of search_throttled_queries_rate detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "search_throttled_queries_rate_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of search_throttled_queries_rate detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for search_throttled_queries_rate detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "search_throttled_queries_rate_aggregation_function" {

--- a/cloud/azure/cosmos-db/detectors-cosmosdb.tf
+++ b/cloud/azure/cosmos-db/detectors-cosmosdb.tf
@@ -13,7 +13,7 @@ resource "signalfx_detector" "heartbeat" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.heartbeat_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.heartbeat_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.heartbeat_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
 }
@@ -36,7 +36,7 @@ resource "signalfx_detector" "db_4xx_requests" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.db_4xx_requests_disabled_critical, var.db_4xx_requests_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.db_4xx_requests_notifications_critical, var.db_4xx_requests_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.db_4xx_requests_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -45,7 +45,7 @@ resource "signalfx_detector" "db_4xx_requests" {
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.db_4xx_requests_disabled_warning, var.db_4xx_requests_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.db_4xx_requests_notifications_warning, var.db_4xx_requests_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.db_4xx_requests_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -68,7 +68,7 @@ resource "signalfx_detector" "db_5xx_requests" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.db_5xx_requests_disabled_critical, var.db_5xx_requests_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.db_5xx_requests_notifications_critical, var.db_5xx_requests_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.db_5xx_requests_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -77,7 +77,7 @@ resource "signalfx_detector" "db_5xx_requests" {
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.db_5xx_requests_disabled_warning, var.db_5xx_requests_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.db_5xx_requests_notifications_warning, var.db_5xx_requests_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.db_5xx_requests_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -100,7 +100,7 @@ resource "signalfx_detector" "scaling" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.scaling_disabled_critical, var.scaling_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.scaling_notifications_critical, var.scaling_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.scaling_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -109,7 +109,7 @@ resource "signalfx_detector" "scaling" {
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.scaling_disabled_warning, var.scaling_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.scaling_notifications_warning, var.scaling_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.scaling_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/azure/cosmos-db/variables.tf
+++ b/cloud/azure/cosmos-db/variables.tf
@@ -8,8 +8,14 @@ variable "environment" {
 # SignalFx module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list(string)
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -45,9 +51,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_notifications" {
-  description = "Notification recipients list for every alerting rules of heartbeat detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for heartbeat detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "heartbeat_timeframe" {
@@ -77,21 +83,9 @@ variable "db_4xx_requests_disabled_warning" {
 }
 
 variable "db_4xx_requests_notifications" {
-  description = "Notification recipients list for every alerting rules of db_4xx_requests detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "db_4xx_requests_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of db_4xx_requests detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "db_4xx_requests_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of db_4xx_requests detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for db_4xx_requests detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "db_4xx_requests_aggregation_function" {
@@ -139,21 +133,9 @@ variable "db_5xx_requests_disabled_warning" {
 }
 
 variable "db_5xx_requests_notifications" {
-  description = "Notification recipients list for every alerting rules of db_5xx_requests detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "db_5xx_requests_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of db_5xx_requests detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "db_5xx_requests_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of db_5xx_requests detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for db_5xx_requests detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "db_5xx_requests_aggregation_function" {
@@ -201,21 +183,9 @@ variable "scaling_disabled_warning" {
 }
 
 variable "scaling_notifications" {
-  description = "Notification recipients list for every alerting rules of scaling detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "scaling_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of scaling detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "scaling_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of scaling detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for scaling detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "scaling_aggregation_function" {

--- a/cloud/azure/functions/detectors-functions.tf
+++ b/cloud/azure/functions/detectors-functions.tf
@@ -13,7 +13,7 @@ resource "signalfx_detector" "heartbeat" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.heartbeat_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.heartbeat_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.heartbeat_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
 }
@@ -35,7 +35,7 @@ resource "signalfx_detector" "http_5xx_errors_rate" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.http_5xx_errors_rate_disabled_critical, var.http_5xx_errors_rate_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.http_5xx_errors_rate_notifications_critical, var.http_5xx_errors_rate_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.http_5xx_errors_rate_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -44,7 +44,7 @@ resource "signalfx_detector" "http_5xx_errors_rate" {
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.http_5xx_errors_rate_disabled_warning, var.http_5xx_errors_rate_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.http_5xx_errors_rate_notifications_warning, var.http_5xx_errors_rate_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.http_5xx_errors_rate_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -64,7 +64,7 @@ resource "signalfx_detector" "high_connections_count" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.high_connections_count_disabled_critical, var.high_connections_count_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.high_connections_count_notifications_critical, var.high_connections_count_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.high_connections_count_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -73,7 +73,7 @@ resource "signalfx_detector" "high_connections_count" {
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.high_connections_count_disabled_warning, var.high_connections_count_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.high_connections_count_notifications_warning, var.high_connections_count_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.high_connections_count_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -93,7 +93,7 @@ resource "signalfx_detector" "high_threads_count" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.high_threads_count_disabled_critical, var.high_threads_count_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.high_threads_count_notifications_critical, var.high_threads_count_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.high_threads_count_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -102,7 +102,7 @@ resource "signalfx_detector" "high_threads_count" {
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.high_threads_count_disabled_warning, var.high_threads_count_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.high_threads_count_notifications_warning, var.high_threads_count_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.high_threads_count_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/azure/functions/variables.tf
+++ b/cloud/azure/functions/variables.tf
@@ -8,8 +8,14 @@ variable "environment" {
 # SignalFx module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list(string)
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -45,9 +51,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_notifications" {
-  description = "Notification recipients list for every alerting rules of heartbeat detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for heartbeat detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "heartbeat_timeframe" {
@@ -77,21 +83,9 @@ variable "http_5xx_errors_rate_disabled_warning" {
 }
 
 variable "http_5xx_errors_rate_notifications" {
-  description = "Notification recipients list for every alerting rules of http_5xx_errors_rate detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "http_5xx_errors_rate_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of http_5xx_errors_rate detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "http_5xx_errors_rate_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of http_5xx_errors_rate detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for http_5xx_errors_rate detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "http_5xx_errors_rate_aggregation_function" {
@@ -139,21 +133,9 @@ variable "high_connections_count_disabled_warning" {
 }
 
 variable "high_connections_count_notifications" {
-  description = "Notification recipients list for every alerting rules of high_connections_count detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "high_connections_count_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of high_connections_count detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "high_connections_count_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of high_connections_count detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for high_connections_count detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "high_connections_count_aggregation_function" {
@@ -201,21 +183,9 @@ variable "high_threads_count_disabled_warning" {
 }
 
 variable "high_threads_count_notifications" {
-  description = "Notification recipients list for every alerting rules of high_threads_count detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "high_threads_count_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of high_threads_count detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "high_threads_count_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of high_threads_count detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for high_threads_count detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "high_threads_count_aggregation_function" {

--- a/cloud/azure/key-vault/detectors-keyvault.tf
+++ b/cloud/azure/key-vault/detectors-keyvault.tf
@@ -15,7 +15,7 @@ resource "signalfx_detector" "api_result" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.api_result_disabled_critical, var.api_result_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.api_result_notifications_critical, var.api_result_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.api_result_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -24,7 +24,7 @@ resource "signalfx_detector" "api_result" {
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.api_result_disabled_warning, var.api_result_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.api_result_notifications_warning, var.api_result_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.api_result_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -44,7 +44,7 @@ resource "signalfx_detector" "api_latency" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.api_latency_disabled_critical, var.api_latency_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.api_latency_notifications_critical, var.api_latency_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.api_latency_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -53,7 +53,7 @@ resource "signalfx_detector" "api_latency" {
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.api_latency_disabled_warning, var.api_latency_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.api_latency_notifications_warning, var.api_latency_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.api_latency_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/azure/key-vault/variables.tf
+++ b/cloud/azure/key-vault/variables.tf
@@ -8,8 +8,14 @@ variable "environment" {
 # SignalFx module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list(string)
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -57,21 +63,9 @@ variable "api_result_disabled_warning" {
 }
 
 variable "api_result_notifications" {
-  description = "Notification recipients list for every alerting rules of api_result detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "api_result_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of api_result detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "api_result_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of api_result detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for api_result detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "api_result_aggregation_function" {
@@ -119,21 +113,9 @@ variable "api_latency_disabled_warning" {
 }
 
 variable "api_latency_notifications" {
-  description = "Notification recipients list for every alerting rules of api_latency detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "api_latency_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of api_latency detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "api_latency_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of api_latency detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for api_latency detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "api_latency_aggregation_function" {

--- a/cloud/azure/load-balancer/detectors-load-balancer.tf
+++ b/cloud/azure/load-balancer/detectors-load-balancer.tf
@@ -13,7 +13,7 @@ resource "signalfx_detector" "heartbeat" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.heartbeat_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.heartbeat_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.heartbeat_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
 }

--- a/cloud/azure/load-balancer/variables.tf
+++ b/cloud/azure/load-balancer/variables.tf
@@ -8,8 +8,14 @@ variable "environment" {
 # SignalFx module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list(string)
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -45,9 +51,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_notifications" {
-  description = "Notification recipients list for every alerting rules of heartbeat detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for heartbeat detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "heartbeat_timeframe" {

--- a/cloud/azure/mysql/detectors-mysql.tf
+++ b/cloud/azure/mysql/detectors-mysql.tf
@@ -13,7 +13,7 @@ resource "signalfx_detector" "heartbeat" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.heartbeat_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.heartbeat_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.heartbeat_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
 }
@@ -33,7 +33,7 @@ resource "signalfx_detector" "cpu_usage" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.cpu_usage_disabled_critical, var.cpu_usage_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.cpu_usage_notifications_critical, var.cpu_usage_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.cpu_usage_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -42,7 +42,7 @@ resource "signalfx_detector" "cpu_usage" {
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.cpu_usage_disabled_warning, var.cpu_usage_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.cpu_usage_notifications_warning, var.cpu_usage_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.cpu_usage_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -63,7 +63,7 @@ resource "signalfx_detector" "free_storage" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.free_storage_disabled_critical, var.free_storage_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.free_storage_notifications_critical, var.free_storage_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.free_storage_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -72,7 +72,7 @@ resource "signalfx_detector" "free_storage" {
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.free_storage_disabled_warning, var.free_storage_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.free_storage_notifications_warning, var.free_storage_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.free_storage_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -92,7 +92,7 @@ resource "signalfx_detector" "io_consumption" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.io_consumption_disabled_critical, var.io_consumption_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.io_consumption_notifications_critical, var.io_consumption_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.io_consumption_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -101,7 +101,7 @@ resource "signalfx_detector" "io_consumption" {
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.io_consumption_disabled_warning, var.io_consumption_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.io_consumption_notifications_warning, var.io_consumption_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.io_consumption_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -121,7 +121,7 @@ resource "signalfx_detector" "memory_usage" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.memory_usage_disabled_critical, var.memory_usage_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.memory_usage_notifications_critical, var.memory_usage_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.memory_usage_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -130,7 +130,7 @@ resource "signalfx_detector" "memory_usage" {
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.memory_usage_disabled_warning, var.memory_usage_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.memory_usage_notifications_warning, var.memory_usage_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.memory_usage_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -150,7 +150,7 @@ resource "signalfx_detector" "replication_lag" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.replication_lag_disabled_critical, var.replication_lag_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.replication_lag_notifications_critical, var.replication_lag_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.replication_lag_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -159,7 +159,7 @@ resource "signalfx_detector" "replication_lag" {
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.replication_lag_disabled_warning, var.replication_lag_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.replication_lag_notifications_warning, var.replication_lag_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.replication_lag_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/azure/mysql/variables.tf
+++ b/cloud/azure/mysql/variables.tf
@@ -8,8 +8,14 @@ variable "environment" {
 # SignalFx module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list(string)
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -45,9 +51,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_notifications" {
-  description = "Notification recipients list for every alerting rules of heartbeat detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for heartbeat detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "heartbeat_timeframe" {
@@ -77,21 +83,9 @@ variable "cpu_usage_disabled_warning" {
 }
 
 variable "cpu_usage_notifications" {
-  description = "Notification recipients list for every alerting rules of cpu_usage detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "cpu_usage_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of cpu_usage detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "cpu_usage_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of cpu_usage detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for cpu_usage detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "cpu_usage_aggregation_function" {
@@ -139,21 +133,9 @@ variable "free_storage_disabled_warning" {
 }
 
 variable "free_storage_notifications" {
-  description = "Notification recipients list for every alerting rules of free_storage detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "free_storage_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of free_storage detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "free_storage_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of free_storage detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for free_storage detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "free_storage_aggregation_function" {
@@ -201,21 +183,9 @@ variable "io_consumption_disabled_warning" {
 }
 
 variable "io_consumption_notifications" {
-  description = "Notification recipients list for every alerting rules of io_consumption detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "io_consumption_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of io_consumption detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "io_consumption_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of io_consumption detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for io_consumption detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "io_consumption_aggregation_function" {
@@ -263,21 +233,9 @@ variable "memory_usage_disabled_warning" {
 }
 
 variable "memory_usage_notifications" {
-  description = "Notification recipients list for every alerting rules of memory_usage detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "memory_usage_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of memory_usage detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "memory_usage_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of memory_usage detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for memory_usage detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "memory_usage_aggregation_function" {
@@ -325,21 +283,9 @@ variable "replication_lag_disabled_warning" {
 }
 
 variable "replication_lag_notifications" {
-  description = "Notification recipients list for every alerting rules of replication_lag detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "replication_lag_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of replication_lag detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "replication_lag_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of replication_lag detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for replication_lag detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "replication_lag_aggregation_function" {

--- a/cloud/azure/postgresql/detectors-postgresql.tf
+++ b/cloud/azure/postgresql/detectors-postgresql.tf
@@ -13,7 +13,7 @@ resource "signalfx_detector" "heartbeat" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.heartbeat_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.heartbeat_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.heartbeat_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
 }
@@ -33,7 +33,7 @@ resource "signalfx_detector" "cpu_usage" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.cpu_usage_disabled_critical, var.cpu_usage_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.cpu_usage_notifications_critical, var.cpu_usage_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.cpu_usage_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -42,7 +42,7 @@ resource "signalfx_detector" "cpu_usage" {
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.cpu_usage_disabled_warning, var.cpu_usage_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.cpu_usage_notifications_warning, var.cpu_usage_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.cpu_usage_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -60,7 +60,7 @@ resource "signalfx_detector" "no_connection" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.no_connection_disabled_critical, var.no_connection_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.no_connection_notifications_critical, var.no_connection_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.no_connection_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -81,7 +81,7 @@ resource "signalfx_detector" "free_storage" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.free_storage_disabled_critical, var.free_storage_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.free_storage_notifications_critical, var.free_storage_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.free_storage_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -90,7 +90,7 @@ resource "signalfx_detector" "free_storage" {
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.free_storage_disabled_warning, var.free_storage_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.free_storage_notifications_warning, var.free_storage_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.free_storage_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -110,7 +110,7 @@ resource "signalfx_detector" "io_consumption" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.io_consumption_disabled_critical, var.io_consumption_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.io_consumption_notifications_critical, var.io_consumption_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.io_consumption_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -119,7 +119,7 @@ resource "signalfx_detector" "io_consumption" {
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.io_consumption_disabled_warning, var.io_consumption_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.io_consumption_notifications_warning, var.io_consumption_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.io_consumption_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -139,7 +139,7 @@ resource "signalfx_detector" "memory_usage" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.memory_usage_disabled_critical, var.memory_usage_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.memory_usage_notifications_critical, var.memory_usage_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.memory_usage_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -148,7 +148,7 @@ resource "signalfx_detector" "memory_usage" {
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.memory_usage_disabled_warning, var.memory_usage_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.memory_usage_notifications_warning, var.memory_usage_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.memory_usage_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/azure/postgresql/variables.tf
+++ b/cloud/azure/postgresql/variables.tf
@@ -8,8 +8,14 @@ variable "environment" {
 # SignalFx module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list(string)
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -45,9 +51,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_notifications" {
-  description = "Notification recipients list for every alerting rules of heartbeat detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for heartbeat detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "heartbeat_timeframe" {
@@ -77,21 +83,9 @@ variable "cpu_usage_disabled_warning" {
 }
 
 variable "cpu_usage_notifications" {
-  description = "Notification recipients list for every alerting rules of cpu_usage detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "cpu_usage_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of cpu_usage detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "cpu_usage_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of cpu_usage detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for cpu_usage detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "cpu_usage_aggregation_function" {
@@ -133,15 +127,9 @@ variable "no_connection_disabled_critical" {
 }
 
 variable "no_connection_notifications" {
-  description = "Notification recipients list for every alerting rules of no_connection detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "no_connection_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of no_connection detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for no_connection detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "no_connection_aggregation_function" {
@@ -177,21 +165,9 @@ variable "free_storage_disabled_warning" {
 }
 
 variable "free_storage_notifications" {
-  description = "Notification recipients list for every alerting rules of free_storage detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "free_storage_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of free_storage detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "free_storage_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of free_storage detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for free_storage detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "free_storage_aggregation_function" {
@@ -239,21 +215,9 @@ variable "io_consumption_disabled_warning" {
 }
 
 variable "io_consumption_notifications" {
-  description = "Notification recipients list for every alerting rules of io_consumption detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "io_consumption_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of io_consumption detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "io_consumption_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of io_consumption detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for io_consumption detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "io_consumption_aggregation_function" {
@@ -301,21 +265,9 @@ variable "memory_usage_disabled_warning" {
 }
 
 variable "memory_usage_notifications" {
-  description = "Notification recipients list for every alerting rules of memory_usage detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "memory_usage_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of memory_usage detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "memory_usage_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of memory_usage detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for memory_usage detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "memory_usage_aggregation_function" {

--- a/cloud/azure/redis/detectors-azure-redis.tf
+++ b/cloud/azure/redis/detectors-azure-redis.tf
@@ -13,7 +13,7 @@ resource "signalfx_detector" "heartbeat" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.heartbeat_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.heartbeat_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.heartbeat_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
 }
@@ -33,7 +33,7 @@ resource "signalfx_detector" "evictedkeys" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.evictedkeys_disabled_critical, var.evictedkeys_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.evictedkeys_notifications_critical, var.evictedkeys_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.evictedkeys_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -42,7 +42,7 @@ resource "signalfx_detector" "evictedkeys" {
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.evictedkeys_disabled_warning, var.evictedkeys_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.evictedkeys_notifications_warning, var.evictedkeys_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.evictedkeys_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -62,7 +62,7 @@ resource "signalfx_detector" "percent_processor_time" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.percent_processor_time_disabled_critical, var.percent_processor_time_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.percent_processor_time_notifications_critical, var.percent_processor_time_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.percent_processor_time_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -71,7 +71,7 @@ resource "signalfx_detector" "percent_processor_time" {
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.percent_processor_time_disabled_warning, var.percent_processor_time_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.percent_processor_time_notifications_warning, var.percent_processor_time_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.percent_processor_time_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -91,7 +91,7 @@ resource "signalfx_detector" "load" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.load_disabled_critical, var.load_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.load_notifications_critical, var.load_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.load_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -100,7 +100,7 @@ resource "signalfx_detector" "load" {
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.load_disabled_warning, var.load_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.load_notifications_warning, var.load_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.load_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/azure/redis/variables.tf
+++ b/cloud/azure/redis/variables.tf
@@ -8,8 +8,14 @@ variable "environment" {
 # SignalFx module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list(string)
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -45,9 +51,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_notifications" {
-  description = "Notification recipients list for every alerting rules of heartbeat detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for heartbeat detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "heartbeat_timeframe" {
@@ -77,21 +83,9 @@ variable "evictedkeys_disabled_warning" {
 }
 
 variable "evictedkeys_notifications" {
-  description = "Notification recipients list for every alerting rules of evictedkeys detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "evictedkeys_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of evictedkeys detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "evictedkeys_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of evictedkeys detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for evictedkeys detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "evictedkeys_aggregation_function" {
@@ -139,21 +133,9 @@ variable "percent_processor_time_disabled_warning" {
 }
 
 variable "percent_processor_time_notifications" {
-  description = "Notification recipients list for every alerting rules of percent_processor_time detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "percent_processor_time_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of percent_processor_time detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "percent_processor_time_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of percent_processor_time detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for percent_processor_time detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "percent_processor_time_aggregation_function" {
@@ -201,21 +183,9 @@ variable "load_disabled_warning" {
 }
 
 variable "load_notifications" {
-  description = "Notification recipients list for every alerting rules of load detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "load_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of load detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "load_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of load detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for load detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "load_aggregation_function" {

--- a/cloud/azure/service-bus/detectors-service-bus.tf
+++ b/cloud/azure/service-bus/detectors-service-bus.tf
@@ -13,7 +13,7 @@ resource "signalfx_detector" "heartbeat" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.heartbeat_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.heartbeat_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.heartbeat_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
 }
@@ -32,7 +32,7 @@ resource "signalfx_detector" "active_connections" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.active_connections_disabled_critical, var.active_connections_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.active_connections_notifications_critical, var.active_connections_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.active_connections_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -55,7 +55,7 @@ resource "signalfx_detector" "user_errors" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.user_errors_disabled_critical, var.user_errors_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.user_errors_notifications_critical, var.user_errors_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.user_errors_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -64,7 +64,7 @@ resource "signalfx_detector" "user_errors" {
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.user_errors_disabled_warning, var.user_errors_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.user_errors_notifications_warning, var.user_errors_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.user_errors_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -86,7 +86,7 @@ resource "signalfx_detector" "server_errors" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.server_errors_disabled_critical, var.server_errors_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.server_errors_notifications_critical, var.server_errors_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.server_errors_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -95,7 +95,7 @@ resource "signalfx_detector" "server_errors" {
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.server_errors_disabled_warning, var.server_errors_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.server_errors_notifications_warning, var.server_errors_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.server_errors_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/azure/service-bus/variables.tf
+++ b/cloud/azure/service-bus/variables.tf
@@ -8,8 +8,14 @@ variable "environment" {
 # SignalFx module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list(string)
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -45,9 +51,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_notifications" {
-  description = "Notification recipients list for every alerting rules of heartbeat detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for heartbeat detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "heartbeat_timeframe" {
@@ -71,15 +77,9 @@ variable "active_connections_disabled_critical" {
 }
 
 variable "active_connections_notifications" {
-  description = "Notification recipients list for every alerting rules of active_connections detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "active_connections_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of active_connections detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for active_connections detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "active_connections_aggregation_function" {
@@ -121,21 +121,9 @@ variable "user_errors_disabled_warning" {
 }
 
 variable "user_errors_notifications" {
-  description = "Notification recipients list for every alerting rules of user_errors detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "user_errors_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of user_errors detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "user_errors_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of user_errors detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for user_errors detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "user_errors_aggregation_function" {
@@ -183,21 +171,9 @@ variable "server_errors_disabled_warning" {
 }
 
 variable "server_errors_notifications" {
-  description = "Notification recipients list for every alerting rules of server_errors detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "server_errors_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of server_errors detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "server_errors_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of server_errors detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for server_errors detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "server_errors_aggregation_function" {

--- a/cloud/azure/sql-database/detectors-sql-database.tf
+++ b/cloud/azure/sql-database/detectors-sql-database.tf
@@ -13,7 +13,7 @@ resource "signalfx_detector" "heartbeat" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.heartbeat_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.heartbeat_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.heartbeat_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
 }
@@ -33,7 +33,7 @@ resource "signalfx_detector" "cpu" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.cpu_disabled_critical, var.cpu_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.cpu_notifications_critical, var.cpu_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.cpu_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -42,7 +42,7 @@ resource "signalfx_detector" "cpu" {
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.cpu_disabled_warning, var.cpu_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.cpu_notifications_warning, var.cpu_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.cpu_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -62,7 +62,7 @@ resource "signalfx_detector" "free_space" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.free_space_disabled_critical, var.free_space_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.free_space_notifications_critical, var.free_space_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.free_space_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -71,7 +71,7 @@ resource "signalfx_detector" "free_space" {
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.free_space_disabled_warning, var.free_space_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.free_space_notifications_warning, var.free_space_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.free_space_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -91,7 +91,7 @@ resource "signalfx_detector" "dtu_consumption" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.dtu_consumption_disabled_critical, var.dtu_consumption_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.dtu_consumption_notifications_critical, var.dtu_consumption_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.dtu_consumption_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -100,7 +100,7 @@ resource "signalfx_detector" "dtu_consumption" {
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.dtu_consumption_disabled_warning, var.dtu_consumption_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.dtu_consumption_notifications_warning, var.dtu_consumption_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.dtu_consumption_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -119,7 +119,7 @@ resource "signalfx_detector" "deadlocks_count" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.deadlocks_count_disabled_critical, var.deadlocks_count_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.deadlocks_count_notifications_critical, var.deadlocks_count_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.deadlocks_count_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/azure/sql-database/variables.tf
+++ b/cloud/azure/sql-database/variables.tf
@@ -8,8 +8,14 @@ variable "environment" {
 # SignalFx module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list(string)
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -45,9 +51,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_notifications" {
-  description = "Notification recipients list for every alerting rules of heartbeat detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for heartbeat detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "heartbeat_timeframe" {
@@ -77,21 +83,9 @@ variable "cpu_disabled_warning" {
 }
 
 variable "cpu_notifications" {
-  description = "Notification recipients list for every alerting rules of cpu detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "cpu_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of cpu detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "cpu_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of cpu detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for cpu detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "cpu_aggregation_function" {
@@ -139,21 +133,9 @@ variable "free_space_disabled_warning" {
 }
 
 variable "free_space_notifications" {
-  description = "Notification recipients list for every alerting rules of free_space detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "free_space_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of free_space detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "free_space_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of free_space detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for free_space detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "free_space_aggregation_function" {
@@ -201,21 +183,9 @@ variable "dtu_consumption_disabled_warning" {
 }
 
 variable "dtu_consumption_notifications" {
-  description = "Notification recipients list for every alerting rules of dtu_consumption detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "dtu_consumption_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of dtu_consumption detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "dtu_consumption_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of dtu_consumption detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for dtu_consumption detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "dtu_consumption_aggregation_function" {
@@ -257,15 +227,9 @@ variable "deadlocks_count_disabled_critical" {
 }
 
 variable "deadlocks_count_notifications" {
-  description = "Notification recipients list for every alerting rules of deadlocks_count detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "deadlocks_count_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of deadlocks_count detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for deadlocks_count detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "deadlocks_count_aggregation_function" {

--- a/cloud/azure/sql-elastic-pool/detectors-sql-elasticpool.tf
+++ b/cloud/azure/sql-elastic-pool/detectors-sql-elasticpool.tf
@@ -13,7 +13,7 @@ resource "signalfx_detector" "heartbeat" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.heartbeat_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.heartbeat_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.heartbeat_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
 }
@@ -33,7 +33,7 @@ resource "signalfx_detector" "cpu" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.cpu_disabled_critical, var.cpu_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.cpu_notifications_critical, var.cpu_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.cpu_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -42,7 +42,7 @@ resource "signalfx_detector" "cpu" {
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.cpu_disabled_warning, var.cpu_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.cpu_notifications_warning, var.cpu_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.cpu_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -62,7 +62,7 @@ resource "signalfx_detector" "free_space" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.free_space_disabled_critical, var.free_space_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.free_space_notifications_critical, var.free_space_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.free_space_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -71,7 +71,7 @@ resource "signalfx_detector" "free_space" {
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.free_space_disabled_warning, var.free_space_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.free_space_notifications_warning, var.free_space_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.free_space_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -91,7 +91,7 @@ resource "signalfx_detector" "dtu_consumption" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.dtu_consumption_disabled_critical, var.dtu_consumption_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.dtu_consumption_notifications_critical, var.dtu_consumption_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.dtu_consumption_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -100,7 +100,7 @@ resource "signalfx_detector" "dtu_consumption" {
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.dtu_consumption_disabled_warning, var.dtu_consumption_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.dtu_consumption_notifications_warning, var.dtu_consumption_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.dtu_consumption_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/azure/sql-elastic-pool/variables.tf
+++ b/cloud/azure/sql-elastic-pool/variables.tf
@@ -8,8 +8,14 @@ variable "environment" {
 # SignalFx module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list(string)
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -45,9 +51,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_notifications" {
-  description = "Notification recipients list for every alerting rules of heartbeat detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for heartbeat detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "heartbeat_timeframe" {
@@ -77,21 +83,9 @@ variable "cpu_disabled_warning" {
 }
 
 variable "cpu_notifications" {
-  description = "Notification recipients list for every alerting rules of cpu detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "cpu_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of cpu detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "cpu_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of cpu detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for cpu detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "cpu_aggregation_function" {
@@ -139,21 +133,9 @@ variable "free_space_disabled_warning" {
 }
 
 variable "free_space_notifications" {
-  description = "Notification recipients list for every alerting rules of free_space detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "free_space_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of free_space detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "free_space_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of free_space detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for free_space detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "free_space_aggregation_function" {
@@ -201,21 +183,9 @@ variable "dtu_consumption_disabled_warning" {
 }
 
 variable "dtu_consumption_notifications" {
-  description = "Notification recipients list for every alerting rules of dtu_consumption detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "dtu_consumption_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of dtu_consumption detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "dtu_consumption_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of dtu_consumption detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for dtu_consumption detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "dtu_consumption_aggregation_function" {

--- a/cloud/azure/stream-analytics/detectors-stream-analytics.tf
+++ b/cloud/azure/stream-analytics/detectors-stream-analytics.tf
@@ -13,7 +13,7 @@ resource "signalfx_detector" "heartbeat" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.heartbeat_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.heartbeat_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.heartbeat_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
 }
@@ -33,7 +33,7 @@ resource "signalfx_detector" "su_utilization" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.su_utilization_disabled_critical, var.su_utilization_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.su_utilization_notifications_critical, var.su_utilization_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.su_utilization_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -42,7 +42,7 @@ resource "signalfx_detector" "su_utilization" {
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.su_utilization_disabled_warning, var.su_utilization_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.su_utilization_notifications_warning, var.su_utilization_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.su_utilization_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -64,7 +64,7 @@ resource "signalfx_detector" "failed_function_requests" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.failed_function_requests_disabled_critical, var.failed_function_requests_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.failed_function_requests_notifications_critical, var.failed_function_requests_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.failed_function_requests_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -73,7 +73,7 @@ resource "signalfx_detector" "failed_function_requests" {
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.failed_function_requests_disabled_warning, var.failed_function_requests_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.failed_function_requests_notifications_warning, var.failed_function_requests_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.failed_function_requests_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -93,7 +93,7 @@ resource "signalfx_detector" "conversion_errors" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.conversion_errors_disabled_critical, var.conversion_errors_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.conversion_errors_notifications_critical, var.conversion_errors_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.conversion_errors_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -102,7 +102,7 @@ resource "signalfx_detector" "conversion_errors" {
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.conversion_errors_disabled_warning, var.conversion_errors_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.conversion_errors_notifications_warning, var.conversion_errors_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.conversion_errors_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -122,7 +122,7 @@ resource "signalfx_detector" "runtime_errors" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.runtime_errors_disabled_critical, var.runtime_errors_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.runtime_errors_notifications_critical, var.runtime_errors_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.runtime_errors_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -131,7 +131,7 @@ resource "signalfx_detector" "runtime_errors" {
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.runtime_errors_disabled_warning, var.runtime_errors_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.runtime_errors_notifications_warning, var.runtime_errors_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.runtime_errors_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/azure/stream-analytics/variables.tf
+++ b/cloud/azure/stream-analytics/variables.tf
@@ -8,8 +8,14 @@ variable "environment" {
 # SignalFx module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list(string)
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -45,9 +51,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_notifications" {
-  description = "Notification recipients list for every alerting rules of heartbeat detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for heartbeat detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "heartbeat_timeframe" {
@@ -77,21 +83,9 @@ variable "su_utilization_disabled_warning" {
 }
 
 variable "su_utilization_notifications" {
-  description = "Notification recipients list for every alerting rules of su_utilization detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "su_utilization_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of su_utilization detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "su_utilization_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of su_utilization detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for su_utilization detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "su_utilization_aggregation_function" {
@@ -139,21 +133,9 @@ variable "failed_function_requests_disabled_warning" {
 }
 
 variable "failed_function_requests_notifications" {
-  description = "Notification recipients list for every alerting rules of failed_function_requests detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "failed_function_requests_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of failed_function_requests detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "failed_function_requests_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of failed_function_requests detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for failed_function_requests detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "failed_function_requests_aggregation_function" {
@@ -201,21 +183,9 @@ variable "conversion_errors_disabled_warning" {
 }
 
 variable "conversion_errors_notifications" {
-  description = "Notification recipients list for every alerting rules of conversion_errors detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "conversion_errors_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of conversion_errors detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "conversion_errors_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of conversion_errors detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for conversion_errors detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "conversion_errors_aggregation_function" {
@@ -263,21 +233,9 @@ variable "runtime_errors_disabled_warning" {
 }
 
 variable "runtime_errors_notifications" {
-  description = "Notification recipients list for every alerting rules of runtime_errors detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "runtime_errors_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of runtime_errors detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "runtime_errors_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of runtime_errors detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for runtime_errors detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "runtime_errors_aggregation_function" {

--- a/cloud/azure/virtual-machine/detectors-virtual-machine.tf
+++ b/cloud/azure/virtual-machine/detectors-virtual-machine.tf
@@ -13,7 +13,7 @@ resource "signalfx_detector" "heartbeat" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.heartbeat_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.heartbeat_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.heartbeat_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
 }
@@ -33,7 +33,7 @@ resource "signalfx_detector" "cpu_usage" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.cpu_usage_disabled_critical, var.cpu_usage_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.cpu_usage_notifications_critical, var.cpu_usage_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.cpu_usage_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -42,7 +42,7 @@ resource "signalfx_detector" "cpu_usage" {
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.cpu_usage_disabled_warning, var.cpu_usage_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.cpu_usage_notifications_warning, var.cpu_usage_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.cpu_usage_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -64,7 +64,7 @@ resource "signalfx_detector" "credit_cpu" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.credit_cpu_disabled_critical, var.credit_cpu_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.credit_cpu_notifications_critical, var.credit_cpu_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.credit_cpu_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -73,7 +73,7 @@ resource "signalfx_detector" "credit_cpu" {
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.credit_cpu_disabled_warning, var.credit_cpu_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.credit_cpu_notifications_warning, var.credit_cpu_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.credit_cpu_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/azure/virtual-machine/variables.tf
+++ b/cloud/azure/virtual-machine/variables.tf
@@ -8,8 +8,14 @@ variable "environment" {
 # SignalFx module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list(string)
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -45,9 +51,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_notifications" {
-  description = "Notification recipients list for every alerting rules of heartbeat detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for heartbeat detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "heartbeat_timeframe" {
@@ -77,21 +83,9 @@ variable "cpu_usage_disabled_warning" {
 }
 
 variable "cpu_usage_notifications" {
-  description = "Notification recipients list for every alerting rules of cpu_usage detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "cpu_usage_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of cpu_usage detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "cpu_usage_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of cpu_usage detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for cpu_usage detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "cpu_usage_aggregation_function" {
@@ -139,21 +133,9 @@ variable "credit_cpu_disabled_warning" {
 }
 
 variable "credit_cpu_notifications" {
-  description = "Notification recipients list for every alerting rules of credit_cpu detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "credit_cpu_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of credit_cpu detector"
-  type        = list(string)
-  default     = []
-}
-
-variable "credit_cpu_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of credit_cpu detector"
-  type        = list(string)
-  default     = []
+  description = "Notification recipients list per severity overridden for credit_cpu detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "credit_cpu_aggregation_function" {

--- a/cloud/gcp/big-query/detectors-big-query.tf
+++ b/cloud/gcp/big-query/detectors-big-query.tf
@@ -15,7 +15,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.concurrent_queries_disabled_critical, var.concurrent_queries_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.concurrent_queries_notifications_critical, var.concurrent_queries_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.concurrent_queries_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -24,7 +24,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.concurrent_queries_disabled_warning, var.concurrent_queries_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.concurrent_queries_notifications_warning, var.concurrent_queries_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.concurrent_queries_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -47,7 +47,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.execution_time_disabled_critical, var.execution_time_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.execution_time_notifications_critical, var.execution_time_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.execution_time_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -56,7 +56,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.execution_time_disabled_warning, var.execution_time_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.execution_time_notifications_warning, var.execution_time_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.execution_time_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -79,7 +79,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.scanned_bytes_disabled_critical, var.scanned_bytes_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.scanned_bytes_notifications_critical, var.scanned_bytes_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.scanned_bytes_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -88,7 +88,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.scanned_bytes_disabled_warning, var.scanned_bytes_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.scanned_bytes_notifications_warning, var.scanned_bytes_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.scanned_bytes_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -111,7 +111,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.scanned_bytes_billed_disabled_critical, var.scanned_bytes_billed_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.scanned_bytes_billed_notifications_critical, var.scanned_bytes_billed_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.scanned_bytes_billed_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -120,7 +120,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.scanned_bytes_billed_disabled_warning, var.scanned_bytes_billed_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.scanned_bytes_billed_notifications_warning, var.scanned_bytes_billed_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.scanned_bytes_billed_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -143,7 +143,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.available_slots_disabled_critical, var.available_slots_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.available_slots_notifications_critical, var.available_slots_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.available_slots_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -152,7 +152,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.available_slots_disabled_warning, var.available_slots_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.available_slots_notifications_warning, var.available_slots_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.available_slots_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -175,7 +175,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.stored_bytes_disabled_critical, var.stored_bytes_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.stored_bytes_notifications_critical, var.stored_bytes_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.stored_bytes_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -184,7 +184,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.stored_bytes_disabled_warning, var.stored_bytes_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.stored_bytes_notifications_warning, var.stored_bytes_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.stored_bytes_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -207,7 +207,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.table_count_disabled_critical, var.table_count_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.table_count_notifications_critical, var.table_count_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.table_count_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -216,7 +216,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.table_count_disabled_warning, var.table_count_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.table_count_notifications_warning, var.table_count_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.table_count_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -239,7 +239,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.uploaded_bytes_disabled_critical, var.uploaded_bytes_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.uploaded_bytes_notifications_critical, var.uploaded_bytes_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.uploaded_bytes_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -248,7 +248,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.uploaded_bytes_disabled_warning, var.uploaded_bytes_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.uploaded_bytes_notifications_warning, var.uploaded_bytes_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.uploaded_bytes_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -271,7 +271,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.uploaded_bytes_billed_disabled_critical, var.uploaded_bytes_billed_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.uploaded_bytes_billed_notifications_critical, var.uploaded_bytes_billed_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.uploaded_bytes_billed_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -280,7 +280,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.uploaded_bytes_billed_disabled_warning, var.uploaded_bytes_billed_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.uploaded_bytes_billed_notifications_warning, var.uploaded_bytes_billed_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.uploaded_bytes_billed_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 

--- a/cloud/gcp/big-query/variables.tf
+++ b/cloud/gcp/big-query/variables.tf
@@ -13,8 +13,14 @@ variable "gcp_project_id" {
 # SignalFx module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -64,21 +70,9 @@ variable "concurrent_queries_disabled_warning" {
 }
 
 variable "concurrent_queries_notifications" {
-  description = "Notification recipients list for every alerting rules of concurrent_queries detector"
-  type        = list
-  default     = []
-}
-
-variable "concurrent_queries_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of concurrent_queries detector"
-  type        = list
-  default     = []
-}
-
-variable "concurrent_queries_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of concurrent_queries detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for concurrent_queries detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "concurrent_queries_aggregation_function" {
@@ -144,21 +138,9 @@ variable "execution_time_disabled_warning" {
 }
 
 variable "execution_time_notifications" {
-  description = "Notification recipients list for every alerting rules of execution_time detector"
-  type        = list
-  default     = []
-}
-
-variable "execution_time_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of execution_time detector"
-  type        = list
-  default     = []
-}
-
-variable "execution_time_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of execution_time detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for execution_time detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "execution_time_aggregation_function" {
@@ -224,21 +206,9 @@ variable "scanned_bytes_disabled_warning" {
 }
 
 variable "scanned_bytes_notifications" {
-  description = "Notification recipients list for every alerting rules of scanned_bytes detector"
-  type        = list
-  default     = []
-}
-
-variable "scanned_bytes_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of scanned_bytes detector"
-  type        = list
-  default     = []
-}
-
-variable "scanned_bytes_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of scanned_bytes detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for scanned_bytes detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "scanned_bytes_aggregation_function" {
@@ -304,21 +274,9 @@ variable "scanned_bytes_billed_disabled_warning" {
 }
 
 variable "scanned_bytes_billed_notifications" {
-  description = "Notification recipients list for every alerting rules of scanned_bytes_billed detector"
-  type        = list
-  default     = []
-}
-
-variable "scanned_bytes_billed_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of scanned_bytes_billed detector"
-  type        = list
-  default     = []
-}
-
-variable "scanned_bytes_billed_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of scanned_bytes_billed detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for scanned_bytes_billed detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "scanned_bytes_billed_aggregation_function" {
@@ -384,21 +342,9 @@ variable "available_slots_disabled_warning" {
 }
 
 variable "available_slots_notifications" {
-  description = "Notification recipients list for every alerting rules of available_slots detector"
-  type        = list
-  default     = []
-}
-
-variable "available_slots_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of available_slots detector"
-  type        = list
-  default     = []
-}
-
-variable "available_slots_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of available_slots detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for available_slots detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "available_slots_aggregation_function" {
@@ -464,21 +410,9 @@ variable "stored_bytes_disabled_warning" {
 }
 
 variable "stored_bytes_notifications" {
-  description = "Notification recipients list for every alerting rules of stored_bytes detector"
-  type        = list
-  default     = []
-}
-
-variable "stored_bytes_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of stored_bytes detector"
-  type        = list
-  default     = []
-}
-
-variable "stored_bytes_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of stored_bytes detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for stored_bytes detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "stored_bytes_aggregation_function" {
@@ -544,21 +478,9 @@ variable "table_count_disabled_warning" {
 }
 
 variable "table_count_notifications" {
-  description = "Notification recipients list for every alerting rules of table_count detector"
-  type        = list
-  default     = []
-}
-
-variable "table_count_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of table_count detector"
-  type        = list
-  default     = []
-}
-
-variable "table_count_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of table_count detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for table_count detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "table_count_aggregation_function" {
@@ -624,21 +546,9 @@ variable "uploaded_bytes_disabled_warning" {
 }
 
 variable "uploaded_bytes_notifications" {
-  description = "Notification recipients list for every alerting rules of uploaded_bytes detector"
-  type        = list
-  default     = []
-}
-
-variable "uploaded_bytes_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of uploaded_bytes detector"
-  type        = list
-  default     = []
-}
-
-variable "uploaded_bytes_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of uploaded_bytes detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for uploaded_bytes detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "uploaded_bytes_aggregation_function" {
@@ -704,21 +614,9 @@ variable "uploaded_bytes_billed_disabled_warning" {
 }
 
 variable "uploaded_bytes_billed_notifications" {
-  description = "Notification recipients list for every alerting rules of uploaded_bytes_billed detector"
-  type        = list
-  default     = []
-}
-
-variable "uploaded_bytes_billed_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of uploaded_bytes_billed detector"
-  type        = list
-  default     = []
-}
-
-variable "uploaded_bytes_billed_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of uploaded_bytes_billed detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for uploaded_bytes_billed detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "uploaded_bytes_billed_aggregation_function" {

--- a/cloud/gcp/cloud-sql/common/detectors-cloud-sql-common.tf
+++ b/cloud/gcp/cloud-sql/common/detectors-cloud-sql-common.tf
@@ -12,7 +12,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.heartbeat_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.heartbeat_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.heartbeat_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
 }
@@ -31,7 +31,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.cpu_utilization_disabled_critical, var.cpu_utilization_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.cpu_utilization_notifications_critical, var.cpu_utilization_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.cpu_utilization_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -40,7 +40,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.cpu_utilization_disabled_warning, var.cpu_utilization_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.cpu_utilization_notifications_warning, var.cpu_utilization_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.cpu_utilization_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -59,7 +59,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.disk_utilization_disabled_critical, var.disk_utilization_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.disk_utilization_notifications_critical, var.disk_utilization_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.disk_utilization_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -68,7 +68,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.disk_utilization_disabled_warning, var.disk_utilization_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.disk_utilization_notifications_warning, var.disk_utilization_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.disk_utilization_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -87,7 +87,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.disk_utilization_forecast_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.disk_utilization_forecast_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.disk_utilization_forecast_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
 }
@@ -106,7 +106,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.memory_utilization_disabled_critical, var.memory_utilization_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.memory_utilization_notifications_critical, var.memory_utilization_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.memory_utilization_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -115,7 +115,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.memory_utilization_disabled_warning, var.memory_utilization_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.memory_utilization_notifications_warning, var.memory_utilization_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.memory_utilization_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -134,7 +134,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.memory_utilization_forecast_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.memory_utilization_forecast_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.memory_utilization_forecast_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
 }

--- a/cloud/gcp/cloud-sql/common/failover/detectors-cloud-sql-failover.tf
+++ b/cloud/gcp/cloud-sql/common/failover/detectors-cloud-sql-failover.tf
@@ -11,7 +11,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.failover_unavailable_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.failover_unavailable_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.failover_unavailable_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/gcp/cloud-sql/common/failover/variables.tf
+++ b/cloud/gcp/cloud-sql/common/failover/variables.tf
@@ -13,8 +13,14 @@ variable "gcp_project_id" {
 # SignalFx module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -50,9 +56,9 @@ variable "failover_unavailable_disabled" {
 }
 
 variable "failover_unavailable_notifications" {
-  description = "Notification recipients list for every alerting rules of failover_unavailable detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for failover_unavailable detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "failover_unavailable_aggregation_function" {

--- a/cloud/gcp/cloud-sql/common/variables.tf
+++ b/cloud/gcp/cloud-sql/common/variables.tf
@@ -13,8 +13,14 @@ variable "gcp_project_id" {
 # SignalFx module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -50,9 +56,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_notifications" {
-  description = "Notification recipients list for every alerting rules of heartbeat detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for heartbeat detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "heartbeat_timeframe" {
@@ -82,21 +88,9 @@ variable "cpu_utilization_disabled_warning" {
 }
 
 variable "cpu_utilization_notifications" {
-  description = "Notification recipients list for every alerting rules of cpu_utilization detector"
-  type        = list
-  default     = []
-}
-
-variable "cpu_utilization_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of cpu_utilization detector"
-  type        = list
-  default     = []
-}
-
-variable "cpu_utilization_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of cpu_utilization detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for cpu_utilization detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "cpu_utilization_aggregation_function" {
@@ -144,21 +138,9 @@ variable "disk_utilization_disabled_warning" {
 }
 
 variable "disk_utilization_notifications" {
-  description = "Notification recipients list for every alerting rules of disk_utilization detector"
-  type        = list
-  default     = []
-}
-
-variable "disk_utilization_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of disk_utilization detector"
-  type        = list
-  default     = []
-}
-
-variable "disk_utilization_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of disk_utilization detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for disk_utilization detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "disk_utilization_aggregation_function" {
@@ -242,9 +224,9 @@ variable "disk_utilization_forecast_use_ewma" {
 }
 
 variable "disk_utilization_forecast_notifications" {
-  description = "Notification recipients list for every alerting rules of disk_utilization_forecast detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for disk_utilization_forecast detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 # Memory_utilization detectors
@@ -268,21 +250,9 @@ variable "memory_utilization_disabled_warning" {
 }
 
 variable "memory_utilization_notifications" {
-  description = "Notification recipients list for every alerting rules of memory_utilization detector"
-  type        = list
-  default     = []
-}
-
-variable "memory_utilization_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of memory_utilization detector"
-  type        = list
-  default     = []
-}
-
-variable "memory_utilization_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of memory_utilization detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for memory_utilization detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "memory_utilization_aggregation_function" {
@@ -366,8 +336,8 @@ variable "memory_utilization_forecast_use_ewma" {
 }
 
 variable "memory_utilization_forecast_notifications" {
-  description = "Notification recipients list for every alerting rules of memory_utilization_forecast detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for memory_utilization_forecast detector"
+  type        = map(list(string))
+  default     = {}
 }
 

--- a/cloud/gcp/cloud-sql/mysql/detectors-cloudsql-mysql.tf
+++ b/cloud/gcp/cloud-sql/mysql/detectors-cloudsql-mysql.tf
@@ -12,7 +12,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.replication_lag_disabled_critical, var.replication_lag_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.replication_lag_notifications_critical, var.replication_lag_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.replication_lag_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -21,7 +21,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.replication_lag_disabled_warning, var.replication_lag_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.replication_lag_notifications_warning, var.replication_lag_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.replication_lag_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/gcp/cloud-sql/mysql/variables.tf
+++ b/cloud/gcp/cloud-sql/mysql/variables.tf
@@ -13,8 +13,14 @@ variable "gcp_project_id" {
 # SignalFx module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -64,21 +70,9 @@ variable "replication_lag_disabled_warning" {
 }
 
 variable "replication_lag_notifications" {
-  description = "Notification recipients list for every alerting rules of replication_lag detector"
-  type        = list
-  default     = []
-}
-
-variable "replication_lag_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of replication_lag detector"
-  type        = list
-  default     = []
-}
-
-variable "replication_lag_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of replication_lag detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for replication_lag detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "replication_lag_aggregation_function" {

--- a/cloud/gcp/gce/instance/detectors-gce-instance.tf
+++ b/cloud/gcp/gce/instance/detectors-gce-instance.tf
@@ -12,7 +12,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.heartbeat_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.heartbeat_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.heartbeat_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
 }
@@ -31,7 +31,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.cpu_utilization_disabled_critical, var.cpu_utilization_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.cpu_utilization_notifications_critical, var.cpu_utilization_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.cpu_utilization_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -40,7 +40,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.cpu_utilization_disabled_warning, var.cpu_utilization_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.cpu_utilization_notifications_warning, var.cpu_utilization_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.cpu_utilization_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -63,7 +63,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.disk_throttled_bps_disabled_critical, var.disk_throttled_bps_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.disk_throttled_bps_notifications_critical, var.disk_throttled_bps_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.disk_throttled_bps_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -72,7 +72,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.disk_throttled_bps_disabled_warning, var.disk_throttled_bps_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.disk_throttled_bps_notifications_warning, var.disk_throttled_bps_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.disk_throttled_bps_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -95,7 +95,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.disk_throttled_ops_disabled_critical, var.disk_throttled_ops_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.disk_throttled_ops_notifications_critical, var.disk_throttled_ops_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.disk_throttled_ops_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -104,7 +104,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.disk_throttled_ops_disabled_warning, var.disk_throttled_ops_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.disk_throttled_ops_notifications_warning, var.disk_throttled_ops_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.disk_throttled_ops_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/gcp/gce/instance/variables.tf
+++ b/cloud/gcp/gce/instance/variables.tf
@@ -8,8 +8,14 @@ variable "environment" {
 # SignalFx module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -45,9 +51,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_notifications" {
-  description = "Notification recipients list for every alerting rules of heartbeat detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for heartbeat detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "heartbeat_timeframe" {
@@ -77,21 +83,9 @@ variable "cpu_utilization_disabled_warning" {
 }
 
 variable "cpu_utilization_notifications" {
-  description = "Notification recipients list for every alerting rules of cpu_utilization detector"
-  type        = list
-  default     = []
-}
-
-variable "cpu_utilization_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of cpu_utilization detector"
-  type        = list
-  default     = []
-}
-
-variable "cpu_utilization_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of cpu_utilization detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for cpu_utilization detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "cpu_utilization_aggregation_function" {
@@ -139,21 +133,9 @@ variable "disk_throttled_bps_disabled_warning" {
 }
 
 variable "disk_throttled_bps_notifications" {
-  description = "Notification recipients list for every alerting rules of disk_throttled_bps detector"
-  type        = list
-  default     = []
-}
-
-variable "disk_throttled_bps_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of disk_throttled_bps detector"
-  type        = list
-  default     = []
-}
-
-variable "disk_throttled_bps_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of disk_throttled_bps detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for disk_throttled_bps detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "disk_throttled_bps_aggregation_function" {
@@ -201,21 +183,9 @@ variable "disk_throttled_ops_disabled_warning" {
 }
 
 variable "disk_throttled_ops_notifications" {
-  description = "Notification recipients list for every alerting rules of disk_throttled_ops detector"
-  type        = list
-  default     = []
-}
-
-variable "disk_throttled_ops_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of disk_throttled_ops detector"
-  type        = list
-  default     = []
-}
-
-variable "disk_throttled_ops_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of disk_throttled_ops detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for disk_throttled_ops detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "disk_throttled_ops_aggregation_function" {

--- a/cloud/gcp/lb/detectors-lb.tf
+++ b/cloud/gcp/lb/detectors-lb.tf
@@ -14,7 +14,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.error_rate_4xx_disabled_critical, var.error_rate_4xx_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.error_rate_4xx_notifications_critical, var.error_rate_4xx_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.error_rate_4xx_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -23,7 +23,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.error_rate_4xx_disabled_warning, var.error_rate_4xx_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.error_rate_4xx_notifications_warning, var.error_rate_4xx_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.error_rate_4xx_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -44,7 +44,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.error_rate_5xx_disabled_critical, var.error_rate_5xx_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.error_rate_5xx_notifications_critical, var.error_rate_5xx_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.error_rate_5xx_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -53,7 +53,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.error_rate_5xx_disabled_warning, var.error_rate_5xx_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.error_rate_5xx_notifications_warning, var.error_rate_5xx_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.error_rate_5xx_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -72,7 +72,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.backend_latency_service_disabled_critical, var.backend_latency_service_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.backend_latency_service_notifications_critical, var.backend_latency_service_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.backend_latency_service_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -81,7 +81,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.backend_latency_service_disabled_warning, var.backend_latency_service_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.backend_latency_service_notifications_warning, var.backend_latency_service_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.backend_latency_service_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -100,7 +100,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.backend_latency_bucket_disabled_critical, var.backend_latency_bucket_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.backend_latency_bucket_notifications_critical, var.backend_latency_bucket_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.backend_latency_bucket_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -109,7 +109,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.backend_latency_bucket_disabled_warning, var.backend_latency_bucket_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.backend_latency_bucket_notifications_warning, var.backend_latency_bucket_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.backend_latency_bucket_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -127,7 +127,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.request_count_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.request_count_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.request_count_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/gcp/lb/variables.tf
+++ b/cloud/gcp/lb/variables.tf
@@ -13,8 +13,14 @@ variable "gcp_project_id" {
 # SignalFx module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -70,21 +76,9 @@ variable "error_rate_4xx_disabled_warning" {
 }
 
 variable "error_rate_4xx_notifications" {
-  description = "Notification recipients list for every alerting rules of error_rate_4xx detector"
-  type        = list
-  default     = []
-}
-
-variable "error_rate_4xx_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of error_rate_4xx detector"
-  type        = list
-  default     = []
-}
-
-variable "error_rate_4xx_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of error_rate_4xx detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for error_rate_4xx detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "error_rate_4xx_aggregation_function" {
@@ -144,21 +138,9 @@ variable "error_rate_5xx_disabled_warning" {
 }
 
 variable "error_rate_5xx_notifications" {
-  description = "Notification recipients list for every alerting rules of error_rate_5xx detector"
-  type        = list
-  default     = []
-}
-
-variable "error_rate_5xx_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of error_rate_5xx detector"
-  type        = list
-  default     = []
-}
-
-variable "error_rate_5xx_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of error_rate_5xx detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for error_rate_5xx detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "error_rate_5xx_aggregation_function" {
@@ -218,21 +200,9 @@ variable "backend_latency_service_disabled_warning" {
 }
 
 variable "backend_latency_service_notifications" {
-  description = "Notification recipients list for every alerting rules of backend_latency_service detector"
-  type        = list
-  default     = []
-}
-
-variable "backend_latency_service_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of backend_latency_service detector"
-  type        = list
-  default     = []
-}
-
-variable "backend_latency_service_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of backend_latency_service detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for backend_latency_service detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "backend_latency_service_aggregation_function" {
@@ -292,21 +262,9 @@ variable "backend_latency_bucket_disabled_warning" {
 }
 
 variable "backend_latency_bucket_notifications" {
-  description = "Notification recipients list for every alerting rules of backend_latency_bucket detector"
-  type        = list
-  default     = []
-}
-
-variable "backend_latency_bucket_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of backend_latency_bucket detector"
-  type        = list
-  default     = []
-}
-
-variable "backend_latency_bucket_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of backend_latency_bucket detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for backend_latency_bucket detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "backend_latency_bucket_aggregation_function" {
@@ -354,9 +312,9 @@ variable "request_count_disabled" {
 }
 
 variable "request_count_notifications" {
-  description = "Notification recipients list for every alerting rules of request_count detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for request_count detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "request_count_aggregation_function" {

--- a/cloud/gcp/pubsub/subscription/detectors-subscription.tf
+++ b/cloud/gcp/pubsub/subscription/detectors-subscription.tf
@@ -12,7 +12,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.heartbeat_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.heartbeat_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.heartbeat_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
 }
@@ -31,7 +31,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.oldest_unacked_message_disabled_critical, var.oldest_unacked_message_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.oldest_unacked_message_notifications_critical, var.oldest_unacked_message_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.oldest_unacked_message_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -40,7 +40,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.oldest_unacked_message_disabled_warning, var.oldest_unacked_message_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.oldest_unacked_message_notifications_warning, var.oldest_unacked_message_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.oldest_unacked_message_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -59,7 +59,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.push_latency_disabled_critical, var.push_latency_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.push_latency_notifications_critical, var.push_latency_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.push_latency_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -68,7 +68,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.push_latency_disabled_warning, var.push_latency_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.push_latency_notifications_warning, var.push_latency_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.push_latency_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/gcp/pubsub/subscription/variables.tf
+++ b/cloud/gcp/pubsub/subscription/variables.tf
@@ -13,8 +13,14 @@ variable "gcp_project_id" {
 # SignalFx module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -50,9 +56,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_notifications" {
-  description = "Notification recipients list for every alerting rules of heartbeat detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for heartbeat detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "heartbeat_timeframe" {
@@ -82,21 +88,9 @@ variable "oldest_unacked_message_disabled_warning" {
 }
 
 variable "oldest_unacked_message_notifications" {
-  description = "Notification recipients list for every alerting rules of oldest_unacked_message detector"
-  type        = list
-  default     = []
-}
-
-variable "oldest_unacked_message_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of oldest_unacked_message detector"
-  type        = list
-  default     = []
-}
-
-variable "oldest_unacked_message_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of oldest_unacked_message detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for oldest_unacked_message detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "oldest_unacked_message_aggregation_function" {
@@ -144,21 +138,9 @@ variable "push_latency_disabled_warning" {
 }
 
 variable "push_latency_notifications" {
-  description = "Notification recipients list for every alerting rules of push_latency detector"
-  type        = list
-  default     = []
-}
-
-variable "push_latency_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of push_latency detector"
-  type        = list
-  default     = []
-}
-
-variable "push_latency_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of push_latency detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for push_latency detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "push_latency_aggregation_function" {

--- a/cloud/gcp/pubsub/topic/detectors-topics.tf
+++ b/cloud/gcp/pubsub/topic/detectors-topics.tf
@@ -12,7 +12,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.sending_operations_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.sending_operations_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.sending_operations_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -32,7 +32,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.unavailable_sending_operations_disabled_critical, var.unavailable_sending_operations_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.unavailable_sending_operations_notifications_critical, var.unavailable_sending_operations_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.unavailable_sending_operations_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -41,7 +41,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.unavailable_sending_operations_disabled_warning, var.unavailable_sending_operations_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.unavailable_sending_operations_notifications_warning, var.unavailable_sending_operations_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.unavailable_sending_operations_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -63,7 +63,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.unavailable_sending_operations_ratio_disabled_critical, var.unavailable_sending_operations_ratio_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.unavailable_sending_operations_ratio_notifications_critical, var.unavailable_sending_operations_ratio_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.unavailable_sending_operations_ratio_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -72,7 +72,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.unavailable_sending_operations_ratio_disabled_warning, var.unavailable_sending_operations_ratio_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.unavailable_sending_operations_ratio_notifications_warning, var.unavailable_sending_operations_ratio_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.unavailable_sending_operations_ratio_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/gcp/pubsub/topic/variables.tf
+++ b/cloud/gcp/pubsub/topic/variables.tf
@@ -13,8 +13,14 @@ variable "gcp_project_id" {
 # SignalFx module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -52,9 +58,9 @@ variable "sending_operations_disabled" {
 }
 
 variable "sending_operations_notifications" {
-  description = "Notification recipients list for every alerting rules of sending_operations detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for sending_operations detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "sending_operations_aggregation_function" {
@@ -96,21 +102,9 @@ variable "unavailable_sending_operations_disabled_warning" {
 }
 
 variable "unavailable_sending_operations_notifications" {
-  description = "Notification recipients list for every alerting rules of unavailable_sending_operations detector"
-  type        = list
-  default     = []
-}
-
-variable "unavailable_sending_operations_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of unavailable_sending_operations detector"
-  type        = list
-  default     = []
-}
-
-variable "unavailable_sending_operations_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of unavailable_sending_operations detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for unavailable_sending_operations detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "unavailable_sending_operations_aggregation_function" {
@@ -158,21 +152,9 @@ variable "unavailable_sending_operations_ratio_disabled_warning" {
 }
 
 variable "unavailable_sending_operations_ratio_notifications" {
-  description = "Notification recipients list for every alerting rules of unavailable_sending_operations_ratio detector"
-  type        = list
-  default     = []
-}
-
-variable "unavailable_sending_operations_ratio_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of unavailable_sending_operations_ratio detector"
-  type        = list
-  default     = []
-}
-
-variable "unavailable_sending_operations_ratio_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of unavailable_sending_operations_ratio detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for unavailable_sending_operations_ratio detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "unavailable_sending_operations_ratio_aggregation_function" {

--- a/container/docker/detectors-docker.tf
+++ b/container/docker/detectors-docker.tf
@@ -13,7 +13,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.heartbeat_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.heartbeat_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.heartbeat_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
 }
@@ -32,7 +32,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.cpu_disabled_warning, var.cpu_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.cpu_notifications_warning, var.cpu_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.cpu_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -41,7 +41,7 @@ EOF
     severity              = "Major"
     detect_label          = "MAJOR"
     disabled              = coalesce(var.cpu_disabled_major, var.cpu_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.cpu_notifications_major, var.cpu_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.cpu_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -62,7 +62,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.throttling_disabled_warning, var.throttling_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.throttling_notifications_warning, var.throttling_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.throttling_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -71,7 +71,7 @@ EOF
     severity              = "Major"
     detect_label          = "MAJOR"
     disabled              = coalesce(var.throttling_disabled_major, var.throttling_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.throttling_notifications_major, var.throttling_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.throttling_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -92,7 +92,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.memory_disabled_warning, var.memory_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.memory_notifications_warning, var.memory_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.memory_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -101,7 +101,7 @@ EOF
     severity              = "Major"
     detect_label          = "MAJOR"
     disabled              = coalesce(var.memory_disabled_major, var.memory_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.memory_notifications_major, var.memory_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.memory_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/container/docker/variables.tf
+++ b/container/docker/variables.tf
@@ -8,8 +8,14 @@ variable "environment" {
 # SignalFx module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -45,9 +51,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_notifications" {
-  description = "Notification recipients list for every alerting rules of heartbeat detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for heartbeat detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "heartbeat_timeframe" {
@@ -77,21 +83,9 @@ variable "cpu_disabled_warning" {
 }
 
 variable "cpu_notifications" {
-  description = "Notification recipients list for every alerting rules of cpu detector"
-  type        = list
-  default     = []
-}
-
-variable "cpu_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of cpu detector"
-  type        = list
-  default     = []
-}
-
-variable "cpu_notifications_major" {
-  description = "Notification recipients list for major alerting rule of cpu detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for cpu detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "cpu_aggregation_function" {
@@ -139,21 +133,9 @@ variable "throttling_disabled_warning" {
 }
 
 variable "throttling_notifications" {
-  description = "Notification recipients list for every alerting rules of throttling detector"
-  type        = list
-  default     = []
-}
-
-variable "throttling_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of throttling detector"
-  type        = list
-  default     = []
-}
-
-variable "throttling_notifications_major" {
-  description = "Notification recipients list for major alerting rule of throttling detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for throttling detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "throttling_aggregation_function" {
@@ -201,21 +183,9 @@ variable "memory_disabled_warning" {
 }
 
 variable "memory_notifications" {
-  description = "Notification recipients list for every alerting rules of memory detector"
-  type        = list
-  default     = []
-}
-
-variable "memory_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of memory detector"
-  type        = list
-  default     = []
-}
-
-variable "memory_notifications_major" {
-  description = "Notification recipients list for major alerting rule of memory detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for memory detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "memory_aggregation_function" {

--- a/container/kubernetes/apiserver/detectors-k8s-cluster.tf
+++ b/container/kubernetes/apiserver/detectors-k8s-cluster.tf
@@ -12,7 +12,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.heartbeat_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.heartbeat_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.heartbeat_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{ruleName}}} on {{{dimensions}}}"
   }
 }

--- a/container/kubernetes/apiserver/variables.tf
+++ b/container/kubernetes/apiserver/variables.tf
@@ -8,8 +8,14 @@ variable "environment" {
 # SignalFx module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -45,9 +51,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_notifications" {
-  description = "Notification recipients list for every alerting rules of heartbeat detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for heartbeat detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "heartbeat_timeframe" {

--- a/container/kubernetes/common/detectors-kubernetes-common.tf
+++ b/container/kubernetes/common/detectors-kubernetes-common.tf
@@ -12,7 +12,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.heartbeat_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.heartbeat_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.heartbeat_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{ruleName}}} on {{{dimensions}}}"
   }
 }
@@ -31,7 +31,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.node_ready_disabled_warning, var.node_ready_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.node_ready_notifications_warning, var.node_ready_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.node_ready_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -40,7 +40,7 @@ EOF
     severity              = "Major"
     detect_label          = "MAJOR"
     disabled              = coalesce(var.node_ready_disabled_major, var.node_ready_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.node_ready_notifications_major, var.node_ready_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.node_ready_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -58,7 +58,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.pod_phase_status_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.pod_phase_status_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.pod_phase_status_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -76,7 +76,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.terminated_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.terminated_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.terminated_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -94,7 +94,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.oom_killed_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.oom_killed_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.oom_killed_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -112,7 +112,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.deployment_crashloopbackoff_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.deployment_crashloopbackoff_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.deployment_crashloopbackoff_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -130,7 +130,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.daemonset_crashloopbackoff_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.daemonset_crashloopbackoff_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.daemonset_crashloopbackoff_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -151,7 +151,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.job_failed_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.job_failed_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.job_failed_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -171,7 +171,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.daemonset_scheduled_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.daemonset_scheduled_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.daemonset_scheduled_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -191,7 +191,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.daemonset_ready_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.daemonset_ready_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.daemonset_ready_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -209,7 +209,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.daemonset_misscheduled_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.daemonset_misscheduled_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.daemonset_misscheduled_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -229,7 +229,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.deployment_available_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.deployment_available_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.deployment_available_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -249,7 +249,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.replicaset_available_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.replicaset_available_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.replicaset_available_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -269,7 +269,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.replication_controller_available_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.replication_controller_available_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.replication_controller_available_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -289,7 +289,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.satefulset_ready_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.satefulset_ready_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.satefulset_ready_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/container/kubernetes/common/variables.tf
+++ b/container/kubernetes/common/variables.tf
@@ -8,8 +8,14 @@ variable "environment" {
 # SignalFx module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -45,9 +51,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_notifications" {
-  description = "Notification recipients list for every alerting rules of heartbeat detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for heartbeat detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "heartbeat_timeframe" {
@@ -77,27 +83,15 @@ variable "node_ready_disabled_warning" {
 }
 
 variable "node_ready_notifications" {
-  description = "Notification recipients list for every alerting rules of node_ready detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for node_ready detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "node_ready_lasting_duration_seconds" {
   description = "Minimum duration that conditions must be true before raising alert (in seconds)"
   type        = number
   default     = 3600
-}
-
-variable "node_ready_notifications_major" {
-  description = "Notification recipients list for major alerting rule of node_ready detector"
-  type        = list
-  default     = []
-}
-
-variable "node_ready_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of node_ready detector"
-  type        = list
-  default     = []
 }
 
 variable "node_ready_aggregation_function" {
@@ -121,9 +115,9 @@ variable "pod_phase_status_disabled" {
 }
 
 variable "pod_phase_status_notifications" {
-  description = "Notification recipients list for every alerting rules of pod_phase_status detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for pod_phase_status detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "pod_phase_status_aggregation_function" {
@@ -153,9 +147,9 @@ variable "terminated_disabled" {
 }
 
 variable "terminated_notifications" {
-  description = "Notification recipients list for every alerting rules of terminated detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for terminated detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "terminated_aggregation_function" {
@@ -191,9 +185,9 @@ variable "oom_killed_disabled" {
 }
 
 variable "oom_killed_notifications" {
-  description = "Notification recipients list for every alerting rules of oom_killed detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for oom_killed detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "oom_killed_aggregation_function" {
@@ -223,9 +217,9 @@ variable "deployment_crashloopbackoff_disabled" {
 }
 
 variable "deployment_crashloopbackoff_notifications" {
-  description = "Notification recipients list for every alerting rules of deployment_crashloopbackoff detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for deployment_crashloopbackoff detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "deployment_crashloopbackoff_aggregation_function" {
@@ -255,9 +249,9 @@ variable "daemonset_crashloopbackoff_disabled" {
 }
 
 variable "daemonset_crashloopbackoff_notifications" {
-  description = "Notification recipients list for every alerting rules of daemonset_crashloopbackoff detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for daemonset_crashloopbackoff detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "daemonset_crashloopbackoff_aggregation_function" {
@@ -287,9 +281,9 @@ variable "job_failed_disabled" {
 }
 
 variable "job_failed_notifications" {
-  description = "Notification recipients list for every alerting rules of job_failed detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for job_failed detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "job_failed_aggregation_function" {
@@ -325,9 +319,9 @@ variable "daemonset_scheduled_disabled" {
 }
 
 variable "daemonset_scheduled_notifications" {
-  description = "Notification recipients list for every alerting rules of daemonset_scheduled detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for daemonset_scheduled detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "daemonset_scheduled_aggregation_function" {
@@ -357,9 +351,9 @@ variable "daemonset_ready_disabled" {
 }
 
 variable "daemonset_ready_notifications" {
-  description = "Notification recipients list for every alerting rules of daemonset_ready detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for daemonset_ready detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "daemonset_ready_aggregation_function" {
@@ -395,9 +389,9 @@ variable "daemonset_misscheduled_disabled" {
 }
 
 variable "daemonset_misscheduled_notifications" {
-  description = "Notification recipients list for every alerting rules of daemonset_misscheduled detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for daemonset_misscheduled detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "daemonset_misscheduled_aggregation_function" {
@@ -433,9 +427,9 @@ variable "deployment_available_disabled" {
 }
 
 variable "deployment_available_notifications" {
-  description = "Notification recipients list for every alerting rules of deployment_available detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for deployment_available detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "deployment_available_aggregation_function" {
@@ -465,9 +459,9 @@ variable "replicaset_available_disabled" {
 }
 
 variable "replicaset_available_notifications" {
-  description = "Notification recipients list for every alerting rules of replicaset_available detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for replicaset_available detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "replicaset_available_aggregation_function" {
@@ -497,9 +491,9 @@ variable "replication_controller_available_disabled" {
 }
 
 variable "replication_controller_available_notifications" {
-  description = "Notification recipients list for every alerting rules of replication_controller_available detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for replication_controller_available detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "replication_controller_available_aggregation_function" {
@@ -529,9 +523,9 @@ variable "satefulset_ready_disabled" {
 }
 
 variable "satefulset_ready_notifications" {
-  description = "Notification recipients list for every alerting rules of satefulset_ready detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for satefulset_ready detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "satefulset_ready_aggregation_function" {

--- a/container/kubernetes/ingress/nginx/detectors-ingress-nginx.tf
+++ b/container/kubernetes/ingress/nginx/detectors-ingress-nginx.tf
@@ -14,7 +14,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.ingress_5xx_disabled_critical, var.ingress_5xx_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.ingress_5xx_notifications_critical, var.ingress_5xx_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.ingress_5xx_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -23,7 +23,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.ingress_5xx_disabled_warning, var.ingress_5xx_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.ingress_5xx_notifications_warning, var.ingress_5xx_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.ingress_5xx_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -44,7 +44,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.ingress_4xx_disabled_critical, var.ingress_4xx_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.ingress_4xx_notifications_critical, var.ingress_4xx_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.ingress_4xx_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -53,7 +53,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.ingress_4xx_disabled_warning, var.ingress_4xx_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.ingress_4xx_notifications_warning, var.ingress_4xx_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.ingress_4xx_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -72,7 +72,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.ingress_latency_disabled_critical, var.ingress_latency_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.ingress_latency_notifications_critical, var.ingress_latency_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.ingress_latency_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -81,7 +81,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.ingress_latency_disabled_warning, var.ingress_latency_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.ingress_latency_notifications_warning, var.ingress_latency_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.ingress_latency_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/container/kubernetes/ingress/nginx/variables.tf
+++ b/container/kubernetes/ingress/nginx/variables.tf
@@ -8,8 +8,14 @@ variable "environment" {
 # SignalFx module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -65,21 +71,9 @@ variable "ingress_5xx_disabled_warning" {
 }
 
 variable "ingress_5xx_notifications" {
-  description = "Notification recipients list for every alerting rules of ingress_5xx detector"
-  type        = list
-  default     = []
-}
-
-variable "ingress_5xx_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of ingress_5xx detector"
-  type        = list
-  default     = []
-}
-
-variable "ingress_5xx_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of ingress_5xx detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for ingress_5xx detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "ingress_5xx_aggregation_function" {
@@ -141,21 +135,9 @@ variable "ingress_4xx_disabled_warning" {
 }
 
 variable "ingress_4xx_notifications" {
-  description = "Notification recipients list for every alerting rules of ingress_4xx detector"
-  type        = list
-  default     = []
-}
-
-variable "ingress_4xx_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of ingress_4xx detector"
-  type        = list
-  default     = []
-}
-
-variable "ingress_4xx_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of ingress_4xx detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for ingress_4xx detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "ingress_4xx_aggregation_function" {
@@ -217,21 +199,9 @@ variable "ingress_latency_disabled_warning" {
 }
 
 variable "ingress_latency_notifications" {
-  description = "Notification recipients list for every alerting rules of ingress_latency detector"
-  type        = list
-  default     = []
-}
-
-variable "ingress_latency_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of ingress_latency detector"
-  type        = list
-  default     = []
-}
-
-variable "ingress_latency_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of ingress_latency detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for ingress_latency detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "ingress_latency_aggregation_function" {

--- a/container/kubernetes/velero/detectors-velero.tf
+++ b/container/kubernetes/velero/detectors-velero.tf
@@ -11,7 +11,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.velero_scheduled_backup_missing_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.velero_scheduled_backup_missing_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.velero_scheduled_backup_missing_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -29,7 +29,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.velero_backup_failure_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.velero_backup_failure_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.velero_backup_failure_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -47,7 +47,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.velero_backup_partial_failure_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.velero_backup_partial_failure_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.velero_backup_partial_failure_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -65,7 +65,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.velero_backup_deletion_failure_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.velero_backup_deletion_failure_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.velero_backup_deletion_failure_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -83,7 +83,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.velero_volume_snapshot_failure_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.velero_volume_snapshot_failure_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.velero_volume_snapshot_failure_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/container/kubernetes/velero/variables.tf
+++ b/container/kubernetes/velero/variables.tf
@@ -8,8 +8,14 @@ variable "environment" {
 # SignalFx module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -47,9 +53,9 @@ variable "velero_scheduled_backup_missing_disabled" {
 }
 
 variable "velero_scheduled_backup_missing_notifications" {
-  description = "Notification recipients list for every alerting rules of velero_scheduled_backup_missing detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for velero_scheduled_backup_missing detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "velero_scheduled_backup_missing_aggregation_function" {
@@ -73,9 +79,9 @@ variable "velero_backup_failure_disabled" {
 }
 
 variable "velero_backup_failure_notifications" {
-  description = "Notification recipients list for every alerting rules of velero_backup_failure detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for velero_backup_failure detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "velero_backup_failure_aggregation_function" {
@@ -99,9 +105,9 @@ variable "velero_backup_partial_failure_disabled" {
 }
 
 variable "velero_backup_partial_failure_notifications" {
-  description = "Notification recipients list for every alerting rules of velero_backup_partial_failure detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for velero_backup_partial_failure detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "velero_backup_partial_failure_aggregation_function" {
@@ -125,9 +131,9 @@ variable "velero_backup_deletion_failure_disabled" {
 }
 
 variable "velero_backup_deletion_failure_notifications" {
-  description = "Notification recipients list for every alerting rules of velero_backup_deletion_failure detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for velero_backup_deletion_failure detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "velero_backup_deletion_failure_aggregation_function" {
@@ -151,9 +157,9 @@ variable "velero_volume_snapshot_failure_disabled" {
 }
 
 variable "velero_volume_snapshot_failure_notifications" {
-  description = "Notification recipients list for every alerting rules of velero_volume_snapshot_failure detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for velero_volume_snapshot_failure detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "velero_volume_snapshot_failure_aggregation_function" {

--- a/container/kubernetes/volumes/detectors-kubernetes-volumes.tf
+++ b/container/kubernetes/volumes/detectors-kubernetes-volumes.tf
@@ -14,7 +14,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.volume_space_disabled_critical, var.volume_space_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.volume_space_notifications_critical, var.volume_space_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.volume_space_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -23,7 +23,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.volume_space_disabled_warning, var.volume_space_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.volume_space_notifications_warning, var.volume_space_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.volume_space_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -44,7 +44,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.volume_inodes_disabled_critical, var.volume_inodes_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.volume_inodes_notifications_critical, var.volume_inodes_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.volume_inodes_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -53,7 +53,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.volume_inodes_disabled_warning, var.volume_inodes_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.volume_inodes_notifications_warning, var.volume_inodes_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.volume_inodes_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/container/kubernetes/volumes/variables.tf
+++ b/container/kubernetes/volumes/variables.tf
@@ -8,8 +8,14 @@ variable "environment" {
 # SignalFx module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -59,21 +65,9 @@ variable "volume_space_disabled_warning" {
 }
 
 variable "volume_space_notifications" {
-  description = "Notification recipients list for every alerting rules of volume_space detector"
-  type        = list
-  default     = []
-}
-
-variable "volume_space_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of volume_space detector"
-  type        = list
-  default     = []
-}
-
-variable "volume_space_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of volume_space detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for volume_space detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "volume_space_aggregation_function" {
@@ -121,21 +115,9 @@ variable "volume_inodes_disabled_warning" {
 }
 
 variable "volume_inodes_notifications" {
-  description = "Notification recipients list for every alerting rules of volume_inodes detector"
-  type        = list
-  default     = []
-}
-
-variable "volume_inodes_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of volume_inodes detector"
-  type        = list
-  default     = []
-}
-
-variable "volume_inodes_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of volume_inodes detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for volume_inodes detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "volume_inodes_aggregation_function" {

--- a/database/elasticsearch/detectors-elasticsearch.tf
+++ b/database/elasticsearch/detectors-elasticsearch.tf
@@ -13,7 +13,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.heartbeat_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.heartbeat_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.heartbeat_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
 }
@@ -32,7 +32,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.cluster_status_disabled_critical, var.cluster_status_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.cluster_status_notifications_critical, var.cluster_status_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.cluster_status_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -41,7 +41,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.cluster_status_disabled_warning, var.cluster_status_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.cluster_status_notifications_warning, var.cluster_status_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.cluster_status_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -60,7 +60,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.cluster_initializing_shards_disabled_critical, var.cluster_initializing_shards_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.cluster_initializing_shards_notifications_critical, var.cluster_initializing_shards_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.cluster_initializing_shards_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -69,7 +69,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.cluster_initializing_shards_disabled_warning, var.cluster_initializing_shards_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.cluster_initializing_shards_notifications_warning, var.cluster_initializing_shards_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.cluster_initializing_shards_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -88,7 +88,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.cluster_relocating_shards_disabled_critical, var.cluster_relocating_shards_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.cluster_relocating_shards_notifications_critical, var.cluster_relocating_shards_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.cluster_relocating_shards_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -97,7 +97,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.cluster_relocating_shards_disabled_warning, var.cluster_relocating_shards_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.cluster_relocating_shards_notifications_warning, var.cluster_relocating_shards_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.cluster_relocating_shards_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -116,7 +116,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.cluster_unassigned_shards_disabled_critical, var.cluster_unassigned_shards_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.cluster_unassigned_shards_notifications_critical, var.cluster_unassigned_shards_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.cluster_unassigned_shards_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -125,7 +125,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.cluster_unassigned_shards_disabled_warning, var.cluster_unassigned_shards_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.cluster_unassigned_shards_notifications_warning, var.cluster_unassigned_shards_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.cluster_unassigned_shards_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -144,7 +144,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.pending_tasks_disabled_critical, var.pending_tasks_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.pending_tasks_notifications_critical, var.pending_tasks_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.pending_tasks_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -153,7 +153,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.pending_tasks_disabled_warning, var.pending_tasks_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.pending_tasks_notifications_warning, var.pending_tasks_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.pending_tasks_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -172,7 +172,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.cpu_usage_disabled_critical, var.cpu_usage_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.cpu_usage_notifications_critical, var.cpu_usage_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.cpu_usage_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -181,7 +181,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.cpu_usage_disabled_warning, var.cpu_usage_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.cpu_usage_notifications_warning, var.cpu_usage_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.cpu_usage_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -202,7 +202,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.file_descriptors_disabled_critical, var.file_descriptors_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.file_descriptors_notifications_critical, var.file_descriptors_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.file_descriptors_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -211,7 +211,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.file_descriptors_disabled_warning, var.file_descriptors_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.file_descriptors_notifications_warning, var.file_descriptors_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.file_descriptors_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -230,7 +230,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.jvm_heap_memory_usage_disabled_critical, var.jvm_heap_memory_usage_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.jvm_heap_memory_usage_notifications_critical, var.jvm_heap_memory_usage_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.jvm_heap_memory_usage_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -239,7 +239,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.jvm_heap_memory_usage_disabled_warning, var.jvm_heap_memory_usage_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.jvm_heap_memory_usage_notifications_warning, var.jvm_heap_memory_usage_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.jvm_heap_memory_usage_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -260,7 +260,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.jvm_memory_young_usage_disabled_warning, var.jvm_memory_young_usage_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.jvm_memory_young_usage_notifications_warning, var.jvm_memory_young_usage_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.jvm_memory_young_usage_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -269,7 +269,7 @@ EOF
     severity              = "Major"
     detect_label          = "MAJOR"
     disabled              = coalesce(var.jvm_memory_young_usage_disabled_major, var.jvm_memory_young_usage_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.jvm_memory_young_usage_notifications_major, var.jvm_memory_young_usage_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.jvm_memory_young_usage_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -290,7 +290,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.jvm_memory_old_usage_disabled_warning, var.jvm_memory_old_usage_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.jvm_memory_old_usage_notifications_warning, var.jvm_memory_old_usage_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.jvm_memory_old_usage_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -299,7 +299,7 @@ EOF
     severity              = "Major"
     detect_label          = "MAJOR"
     disabled              = coalesce(var.jvm_memory_old_usage_disabled_major, var.jvm_memory_old_usage_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.jvm_memory_old_usage_notifications_major, var.jvm_memory_old_usage_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.jvm_memory_old_usage_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -320,7 +320,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.jvm_gc_old_collection_latency_disabled_warning, var.jvm_gc_old_collection_latency_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.jvm_gc_old_collection_latency_notifications_warning, var.jvm_gc_old_collection_latency_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.jvm_gc_old_collection_latency_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -329,7 +329,7 @@ EOF
     severity              = "Major"
     detect_label          = "MAJOR"
     disabled              = coalesce(var.jvm_gc_old_collection_latency_disabled_major, var.jvm_gc_old_collection_latency_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.jvm_gc_old_collection_latency_notifications_major, var.jvm_gc_old_collection_latency_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.jvm_gc_old_collection_latency_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -350,7 +350,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.jvm_gc_young_collection_latency_disabled_warning, var.jvm_gc_young_collection_latency_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.jvm_gc_young_collection_latency_notifications_warning, var.jvm_gc_young_collection_latency_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.jvm_gc_young_collection_latency_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -359,7 +359,7 @@ EOF
     severity              = "Major"
     detect_label          = "MAJOR"
     disabled              = coalesce(var.jvm_gc_young_collection_latency_disabled_major, var.jvm_gc_young_collection_latency_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.jvm_gc_young_collection_latency_notifications_major, var.jvm_gc_young_collection_latency_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.jvm_gc_young_collection_latency_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -380,7 +380,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.indexing_latency_disabled_warning, var.indexing_latency_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.indexing_latency_notifications_warning, var.indexing_latency_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.indexing_latency_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -389,7 +389,7 @@ EOF
     severity              = "Major"
     detect_label          = "MAJOR"
     disabled              = coalesce(var.indexing_latency_disabled_major, var.indexing_latency_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.indexing_latency_notifications_major, var.indexing_latency_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.indexing_latency_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -410,7 +410,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.flush_latency_disabled_warning, var.flush_latency_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.flush_latency_notifications_warning, var.flush_latency_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.flush_latency_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -419,7 +419,7 @@ EOF
     severity              = "Major"
     detect_label          = "MAJOR"
     disabled              = coalesce(var.flush_latency_disabled_major, var.flush_latency_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.flush_latency_notifications_major, var.flush_latency_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.flush_latency_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -440,7 +440,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.search_latency_disabled_warning, var.search_latency_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.search_latency_notifications_warning, var.search_latency_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.search_latency_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -449,7 +449,7 @@ EOF
     severity              = "Major"
     detect_label          = "MAJOR"
     disabled              = coalesce(var.search_latency_disabled_major, var.search_latency_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.search_latency_notifications_major, var.search_latency_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.search_latency_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -470,7 +470,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.fetch_latency_disabled_warning, var.fetch_latency_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.fetch_latency_notifications_warning, var.fetch_latency_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.fetch_latency_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -479,7 +479,7 @@ EOF
     severity              = "Major"
     detect_label          = "MAJOR"
     disabled              = coalesce(var.fetch_latency_disabled_major, var.fetch_latency_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.fetch_latency_notifications_major, var.fetch_latency_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.fetch_latency_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -498,7 +498,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.field_data_evictions_change_disabled_warning, var.field_data_evictions_change_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.field_data_evictions_change_notifications_warning, var.field_data_evictions_change_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.field_data_evictions_change_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -507,7 +507,7 @@ EOF
     severity              = "Major"
     detect_label          = "MAJOR"
     disabled              = coalesce(var.field_data_evictions_change_disabled_major, var.field_data_evictions_change_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.field_data_evictions_change_notifications_major, var.field_data_evictions_change_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.field_data_evictions_change_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -526,7 +526,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.query_cache_evictions_change_disabled_warning, var.query_cache_evictions_change_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.query_cache_evictions_change_notifications_warning, var.query_cache_evictions_change_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.query_cache_evictions_change_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -535,7 +535,7 @@ EOF
     severity              = "Major"
     detect_label          = "MAJOR"
     disabled              = coalesce(var.query_cache_evictions_change_disabled_major, var.query_cache_evictions_change_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.query_cache_evictions_change_notifications_major, var.query_cache_evictions_change_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.query_cache_evictions_change_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -554,7 +554,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.request_cache_evictions_change_disabled_warning, var.request_cache_evictions_change_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.request_cache_evictions_change_notifications_warning, var.request_cache_evictions_change_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.request_cache_evictions_change_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -563,7 +563,7 @@ EOF
     severity              = "Major"
     detect_label          = "MAJOR"
     disabled              = coalesce(var.request_cache_evictions_change_disabled_major, var.request_cache_evictions_change_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.request_cache_evictions_change_notifications_major, var.request_cache_evictions_change_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.request_cache_evictions_change_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -582,7 +582,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.task_time_in_queue_change_disabled_warning, var.task_time_in_queue_change_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.task_time_in_queue_change_notifications_warning, var.task_time_in_queue_change_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.task_time_in_queue_change_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -591,7 +591,7 @@ EOF
     severity              = "Major"
     detect_label          = "MAJOR"
     disabled              = coalesce(var.task_time_in_queue_change_disabled_major, var.task_time_in_queue_change_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.task_time_in_queue_change_notifications_major, var.task_time_in_queue_change_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.task_time_in_queue_change_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/database/elasticsearch/variables.tf
+++ b/database/elasticsearch/variables.tf
@@ -8,8 +8,14 @@ variable "environment" {
 # SignalFx module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -45,9 +51,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_notifications" {
-  description = "Notification recipients list for every alerting rules of heartbeat detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for heartbeat detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "heartbeat_timeframe" {
@@ -77,21 +83,9 @@ variable "cluster_status_disabled_warning" {
 }
 
 variable "cluster_status_notifications" {
-  description = "Notification recipients list for every alerting rules of cluster_status_not_green detector"
-  type        = list
-  default     = []
-}
-
-variable "cluster_status_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of cluster_status_not_green detector"
-  type        = list
-  default     = []
-}
-
-variable "cluster_status_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of cluster_status_not_green detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for cluster_status_not_green detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "cluster_status_aggregation_function" {
@@ -127,21 +121,9 @@ variable "cluster_initializing_shards_disabled_warning" {
 }
 
 variable "cluster_initializing_shards_notifications" {
-  description = "Notification recipients list for every alerting rules of cluster_initializing_shards detector"
-  type        = list
-  default     = []
-}
-
-variable "cluster_initializing_shards_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of cluster_initializing_shards detector"
-  type        = list
-  default     = []
-}
-
-variable "cluster_initializing_shards_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of cluster_initializing_shards detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for cluster_initializing_shards detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "cluster_initializing_shards_aggregation_function" {
@@ -189,21 +171,9 @@ variable "cluster_relocating_shards_disabled_warning" {
 }
 
 variable "cluster_relocating_shards_notifications" {
-  description = "Notification recipients list for every alerting rules of cluster_relocating_shards detector"
-  type        = list
-  default     = []
-}
-
-variable "cluster_relocating_shards_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of cluster_relocating_shards detector"
-  type        = list
-  default     = []
-}
-
-variable "cluster_relocating_shards_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of cluster_relocating_shards detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for cluster_relocating_shards detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "cluster_relocating_shards_aggregation_function" {
@@ -251,21 +221,9 @@ variable "cluster_unassigned_shards_disabled_warning" {
 }
 
 variable "cluster_unassigned_shards_notifications" {
-  description = "Notification recipients list for every alerting rules of cluster_unassigned_shards detector"
-  type        = list
-  default     = []
-}
-
-variable "cluster_unassigned_shards_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of cluster_unassigned_shards detector"
-  type        = list
-  default     = []
-}
-
-variable "cluster_unassigned_shards_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of cluster_unassigned_shards detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for cluster_unassigned_shards detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "cluster_unassigned_shards_aggregation_function" {
@@ -313,21 +271,9 @@ variable "pending_tasks_disabled_warning" {
 }
 
 variable "pending_tasks_notifications" {
-  description = "Notification recipients list for every alerting rules of pending_tasks detector"
-  type        = list
-  default     = []
-}
-
-variable "pending_tasks_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of pending_tasks detector"
-  type        = list
-  default     = []
-}
-
-variable "pending_tasks_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of pending_tasks detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for pending_tasks detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "pending_tasks_aggregation_function" {
@@ -375,21 +321,9 @@ variable "jvm_heap_memory_usage_disabled_warning" {
 }
 
 variable "jvm_heap_memory_usage_notifications" {
-  description = "Notification recipients list for every alerting rules of jvm_heap_memory_usage detector"
-  type        = list
-  default     = []
-}
-
-variable "jvm_heap_memory_usage_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of jvm_heap_memory_usage detector"
-  type        = list
-  default     = []
-}
-
-variable "jvm_heap_memory_usage_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of jvm_heap_memory_usage detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for jvm_heap_memory_usage detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "jvm_heap_memory_usage_aggregation_function" {
@@ -437,21 +371,9 @@ variable "cpu_usage_disabled_warning" {
 }
 
 variable "cpu_usage_notifications" {
-  description = "Notification recipients list for every alerting rules of cpu_usage detector"
-  type        = list
-  default     = []
-}
-
-variable "cpu_usage_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of cpu_usage detector"
-  type        = list
-  default     = []
-}
-
-variable "cpu_usage_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of cpu_usage detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for cpu_usage detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "cpu_usage_aggregation_function" {
@@ -499,21 +421,9 @@ variable "file_descriptors_disabled_warning" {
 }
 
 variable "file_descriptors_notifications" {
-  description = "Notification recipients list for every alerting rules of file_descriptors detector"
-  type        = list
-  default     = []
-}
-
-variable "file_descriptors_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of file_descriptors detector"
-  type        = list
-  default     = []
-}
-
-variable "file_descriptors_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of file_descriptors detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for file_descriptors detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "file_descriptors_aggregation_function" {
@@ -561,21 +471,9 @@ variable "jvm_memory_young_usage_disabled_major" {
 }
 
 variable "jvm_memory_young_usage_notifications" {
-  description = "Notification recipients list for every alerting rules of jvm_memory_young_usage detector"
-  type        = list
-  default     = []
-}
-
-variable "jvm_memory_young_usage_notifications_major" {
-  description = "Notification recipients list for major alerting rule of jvm_memory_young_usage detector"
-  type        = list
-  default     = []
-}
-
-variable "jvm_memory_young_usage_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of jvm_memory_young_usage detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for jvm_memory_young_usage detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "jvm_memory_young_usage_aggregation_function" {
@@ -623,21 +521,9 @@ variable "jvm_memory_old_usage_disabled_major" {
 }
 
 variable "jvm_memory_old_usage_notifications" {
-  description = "Notification recipients list for every alerting rules of jvm_memory_old_usage detector"
-  type        = list
-  default     = []
-}
-
-variable "jvm_memory_old_usage_notifications_major" {
-  description = "Notification recipients list for major alerting rule of jvm_memory_old_usage detector"
-  type        = list
-  default     = []
-}
-
-variable "jvm_memory_old_usage_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of jvm_memory_old_usage detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for jvm_memory_old_usage detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "jvm_memory_old_usage_aggregation_function" {
@@ -685,21 +571,9 @@ variable "jvm_gc_old_collection_latency_disabled_major" {
 }
 
 variable "jvm_gc_old_collection_latency_notifications" {
-  description = "Notification recipients list for every alerting rules of jvm_gc_old_collection_latency detector"
-  type        = list
-  default     = []
-}
-
-variable "jvm_gc_old_collection_latency_notifications_major" {
-  description = "Notification recipients list for major alerting rule of jvm_gc_old_collection_latency detector"
-  type        = list
-  default     = []
-}
-
-variable "jvm_gc_old_collection_latency_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of jvm_gc_old_collection_latency detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for jvm_gc_old_collection_latency detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "jvm_gc_old_collection_latency_aggregation_function" {
@@ -747,21 +621,9 @@ variable "jvm_gc_young_collection_latency_disabled_major" {
 }
 
 variable "jvm_gc_young_collection_latency_notifications" {
-  description = "Notification recipients list for every alerting rules of jvm_gc_young_collection_latency detector"
-  type        = list
-  default     = []
-}
-
-variable "jvm_gc_young_collection_latency_notifications_major" {
-  description = "Notification recipients list for major alerting rule of jvm_gc_young_collection_latency detector"
-  type        = list
-  default     = []
-}
-
-variable "jvm_gc_young_collection_latency_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of jvm_gc_young_collection_latency detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for jvm_gc_young_collection_latency detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "jvm_gc_young_collection_latency_aggregation_function" {
@@ -809,21 +671,9 @@ variable "indexing_latency_disabled_major" {
 }
 
 variable "indexing_latency_notifications" {
-  description = "Notification recipients list for every alerting rules of indexing_latency detector"
-  type        = list
-  default     = []
-}
-
-variable "indexing_latency_notifications_major" {
-  description = "Notification recipients list for major alerting rule of indexing_latency detector"
-  type        = list
-  default     = []
-}
-
-variable "indexing_latency_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of indexing_latency detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for indexing_latency detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "indexing_latency_aggregation_function" {
@@ -871,21 +721,9 @@ variable "flush_latency_disabled_major" {
 }
 
 variable "flush_latency_notifications" {
-  description = "Notification recipients list for every alerting rules of flush_latency detector"
-  type        = list
-  default     = []
-}
-
-variable "flush_latency_notifications_major" {
-  description = "Notification recipients list for major alerting rule of flush_latency detector"
-  type        = list
-  default     = []
-}
-
-variable "flush_latency_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of flush_latency detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for flush_latency detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "flush_latency_aggregation_function" {
@@ -933,21 +771,9 @@ variable "search_latency_disabled_major" {
 }
 
 variable "search_latency_notifications" {
-  description = "Notification recipients list for every alerting rules of search_latency detector"
-  type        = list
-  default     = []
-}
-
-variable "search_latency_notifications_major" {
-  description = "Notification recipients list for major alerting rule of search_latency detector"
-  type        = list
-  default     = []
-}
-
-variable "search_latency_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of search_latency detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for search_latency detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "search_latency_aggregation_function" {
@@ -995,21 +821,9 @@ variable "fetch_latency_disabled_major" {
 }
 
 variable "fetch_latency_notifications" {
-  description = "Notification recipients list for every alerting rules of fetch_latency detector"
-  type        = list
-  default     = []
-}
-
-variable "fetch_latency_notifications_major" {
-  description = "Notification recipients list for major alerting rule of fetch_latency detector"
-  type        = list
-  default     = []
-}
-
-variable "fetch_latency_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of fetch_latency detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for fetch_latency detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "fetch_latency_aggregation_function" {
@@ -1057,21 +871,9 @@ variable "field_data_evictions_change_disabled_major" {
 }
 
 variable "field_data_evictions_change_notifications" {
-  description = "Notification recipients list for every alerting rules of field_data_evictions_change detector"
-  type        = list
-  default     = []
-}
-
-variable "field_data_evictions_change_notifications_major" {
-  description = "Notification recipients list for major alerting rule of field_data_evictions_change detector"
-  type        = list
-  default     = []
-}
-
-variable "field_data_evictions_change_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of field_data_evictions_change detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for field_data_evictions_change detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "field_data_evictions_change_aggregation_function" {
@@ -1119,21 +921,9 @@ variable "query_cache_evictions_change_disabled_major" {
 }
 
 variable "query_cache_evictions_change_notifications" {
-  description = "Notification recipients list for every alerting rules of query_cache_evictions_change detector"
-  type        = list
-  default     = []
-}
-
-variable "query_cache_evictions_change_notifications_major" {
-  description = "Notification recipients list for major alerting rule of query_cache_evictions_change detector"
-  type        = list
-  default     = []
-}
-
-variable "query_cache_evictions_change_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of query_cache_evictions_change detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for query_cache_evictions_change detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "query_cache_evictions_change_aggregation_function" {
@@ -1181,21 +971,9 @@ variable "request_cache_evictions_change_disabled_major" {
 }
 
 variable "request_cache_evictions_change_notifications" {
-  description = "Notification recipients list for every alerting rules of request_cache_evictions_change detector"
-  type        = list
-  default     = []
-}
-
-variable "request_cache_evictions_change_notifications_major" {
-  description = "Notification recipients list for major alerting rule of request_cache_evictions_change detector"
-  type        = list
-  default     = []
-}
-
-variable "request_cache_evictions_change_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of request_cache_evictions_change detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for request_cache_evictions_change detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "request_cache_evictions_change_aggregation_function" {
@@ -1243,21 +1021,9 @@ variable "task_time_in_queue_change_disabled_major" {
 }
 
 variable "task_time_in_queue_change_notifications" {
-  description = "Notification recipients list for every alerting rules of task_time_in_queue_change detector"
-  type        = list
-  default     = []
-}
-
-variable "task_time_in_queue_change_notifications_major" {
-  description = "Notification recipients list for major alerting rule of task_time_in_queue_change detector"
-  type        = list
-  default     = []
-}
-
-variable "task_time_in_queue_change_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of task_time_in_queue_change detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for task_time_in_queue_change detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "task_time_in_queue_change_aggregation_function" {

--- a/database/mysql/detectors-mysql.tf
+++ b/database/mysql/detectors-mysql.tf
@@ -13,7 +13,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.heartbeat_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.heartbeat_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.heartbeat_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
 }
@@ -34,7 +34,7 @@ resource "signalfx_detector" "mysql_connections" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.mysql_connections_disabled_critical, var.mysql_connections_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.mysql_connections_notifications_critical, var.mysql_connections_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.mysql_connections_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -43,7 +43,7 @@ resource "signalfx_detector" "mysql_connections" {
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.mysql_connections_disabled_warning, var.mysql_connections_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.mysql_connections_notifications_warning, var.mysql_connections_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.mysql_connections_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -64,7 +64,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.mysql_slow_disabled_critical, var.mysql_slow_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.mysql_slow_notifications_critical, var.mysql_slow_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.mysql_slow_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -73,7 +73,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.mysql_slow_disabled_warning, var.mysql_slow_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.mysql_slow_notifications_warning, var.mysql_slow_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.mysql_slow_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -94,7 +94,7 @@ EOF
     severity              = "Major"
     detect_label          = "MAJOR"
     disabled              = coalesce(var.mysql_pool_efficiency_disabled_major, var.mysql_pool_efficiency_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.mysql_pool_efficiency_notifications_major, var.mysql_pool_efficiency_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.mysql_pool_efficiency_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -103,7 +103,7 @@ EOF
     severity              = "Minor"
     detect_label          = "MINOR"
     disabled              = coalesce(var.mysql_pool_efficiency_disabled_minor, var.mysql_pool_efficiency_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.mysql_pool_efficiency_notifications_minor, var.mysql_pool_efficiency_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.mysql_pool_efficiency_notifications, "minor", []), var.notifications.minor)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -124,7 +124,7 @@ EOF
     severity              = "Major"
     detect_label          = "MAJOR"
     disabled              = coalesce(var.mysql_pool_utilization_disabled_major, var.mysql_pool_utilization_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.mysql_pool_utilization_notifications_major, var.mysql_pool_utilization_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.mysql_pool_utilization_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -133,7 +133,7 @@ EOF
     severity              = "Minor"
     detect_label          = "MINOR"
     disabled              = coalesce(var.mysql_pool_utilization_disabled_minor, var.mysql_pool_utilization_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.mysql_pool_utilization_notifications_minor, var.mysql_pool_utilization_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.mysql_pool_utilization_notifications, "minor", []), var.notifications.minor)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -152,7 +152,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.mysql_threads_anomaly_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.mysql_threads_anomaly_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.mysql_threads_anomaly_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -171,7 +171,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.mysql_questions_anomaly_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.mysql_questions_anomaly_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.mysql_questions_anomaly_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -190,7 +190,7 @@ resource "signalfx_detector" "mysql_replication_lag" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.mysql_replication_lag_disabled_critical, var.mysql_replication_lag_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.mysql_replication_lag_notifications_critical, var.mysql_replication_lag_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.mysql_replication_lag_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -199,7 +199,7 @@ resource "signalfx_detector" "mysql_replication_lag" {
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.mysql_replication_lag_disabled_warning, var.mysql_replication_lag_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.mysql_replication_lag_notifications_warning, var.mysql_replication_lag_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.mysql_replication_lag_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -217,7 +217,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.mysql_replication_status_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.mysql_replication_status_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.mysql_replication_status_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/database/mysql/variables.tf
+++ b/database/mysql/variables.tf
@@ -8,8 +8,14 @@ variable "environment" {
 # SignalFx module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -45,9 +51,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_notifications" {
-  description = "Notification recipients list for every alerting rules of heartbeat detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for heartbeat detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "heartbeat_timeframe" {
@@ -77,21 +83,9 @@ variable "mysql_connections_disabled_warning" {
 }
 
 variable "mysql_connections_notifications" {
-  description = "Notification recipients list for every alerting rules of mysql_connection detector"
-  type        = list
-  default     = []
-}
-
-variable "mysql_connections_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of mysql_connection detector"
-  type        = list
-  default     = []
-}
-
-variable "mysql_connections_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of mysql_connection detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for mysql_connection detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "mysql_connections_aggregation_function" {
@@ -139,21 +133,9 @@ variable "mysql_pool_efficiency_disabled_minor" {
 }
 
 variable "mysql_pool_efficiency_notifications" {
-  description = "Notification recipients list for every alerting rules of mysql_pool_efficiency detector"
-  type        = list
-  default     = []
-}
-
-variable "mysql_pool_efficiency_notifications_minor" {
-  description = "Notification recipients list for minor alerting rule of mysql_pool_efficiency detector"
-  type        = list
-  default     = []
-}
-
-variable "mysql_pool_efficiency_notifications_major" {
-  description = "Notification recipients list for major alerting rule of mysql_pool_efficiency detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for mysql_pool_efficiency detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "mysql_pool_efficiency_aggregation_function" {
@@ -201,21 +183,9 @@ variable "mysql_pool_utilization_disabled_minor" {
 }
 
 variable "mysql_pool_utilization_notifications" {
-  description = "Notification recipients list for every alerting rules of mysql_pool_utilization detector"
-  type        = list
-  default     = []
-}
-
-variable "mysql_pool_utilization_notifications_minor" {
-  description = "Notification recipients list for minor alerting rule of mysql_pool_utilization detector"
-  type        = list
-  default     = []
-}
-
-variable "mysql_pool_utilization_notifications_major" {
-  description = "Notification recipients list for major alerting rule of mysql_pool_utilization detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for mysql_pool_utilization detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "mysql_pool_utilization_aggregation_function" {
@@ -263,21 +233,9 @@ variable "mysql_slow_disabled_warning" {
 }
 
 variable "mysql_slow_notifications" {
-  description = "Notification recipients list for every alerting rules of mysql_slow detector"
-  type        = list
-  default     = []
-}
-
-variable "mysql_slow_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of mysql_slow detector"
-  type        = list
-  default     = []
-}
-
-variable "mysql_slow_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of mysql_slow detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for mysql_slow detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "mysql_slow_aggregation_function" {
@@ -313,9 +271,9 @@ variable "mysql_threads_anomaly_disabled" {
 }
 
 variable "mysql_threads_anomaly_notifications" {
-  description = "Notification recipients list for every alerting rules of mysql_threads_anomaly detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for mysql_threads_anomaly detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "mysql_threads_anomaly_aggregation_function" {
@@ -375,9 +333,9 @@ variable "mysql_questions_anomaly_disabled" {
 }
 
 variable "mysql_questions_anomaly_notifications" {
-  description = "Notification recipients list for every alerting rules of mysql_questions_anomaly detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for mysql_questions_anomaly detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "mysql_questions_anomaly_aggregation_function" {
@@ -449,21 +407,9 @@ variable "mysql_replication_lag_disabled_warning" {
 }
 
 variable "mysql_replication_lag_notifications" {
-  description = "Notification recipients list for every alerting rules of mysql_replication_lag detector"
-  type        = list
-  default     = []
-}
-
-variable "mysql_replication_lag_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of mysql_replication_lag detector"
-  type        = list
-  default     = []
-}
-
-variable "mysql_replication_lag_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of mysql_replication_lag detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for mysql_replication_lag detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "mysql_replication_lag_aggregation_function" {
@@ -499,9 +445,9 @@ variable "mysql_replication_status_disabled" {
 }
 
 variable "mysql_replication_status_notifications" {
-  description = "Notification recipients list for every alerting rules of mysql_replication_status detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for mysql_replication_status detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "mysql_replication_status_aggregation_function" {

--- a/database/postgresql/detectors-postgresql.tf
+++ b/database/postgresql/detectors-postgresql.tf
@@ -13,7 +13,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.heartbeat_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.heartbeat_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.heartbeat_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
 }
@@ -32,7 +32,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.deadlocks_disabled_warning, var.deadlocks_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.deadlocks_notifications_warning, var.deadlocks_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.deadlocks_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -41,7 +41,7 @@ EOF
     severity              = "Major"
     detect_label          = "MAJOR"
     disabled              = coalesce(var.deadlocks_disabled_major, var.deadlocks_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.deadlocks_notifications_major, var.deadlocks_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.deadlocks_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -60,7 +60,7 @@ EOF
     severity              = "Major"
     detect_label          = "MAJOR"
     disabled              = coalesce(var.hit_ratio_disabled_major, var.hit_ratio_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.hit_ratio_notifications_major, var.hit_ratio_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.hit_ratio_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -69,7 +69,7 @@ EOF
     severity              = "Minor"
     detect_label          = "MINOR"
     disabled              = coalesce(var.hit_ratio_disabled_minor, var.hit_ratio_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.hit_ratio_notifications_minor, var.hit_ratio_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.hit_ratio_notifications, "minor", []), var.notifications.minor)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -90,7 +90,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.rollbacks_disabled_warning, var.rollbacks_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.rollbacks_notifications_warning, var.rollbacks_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.rollbacks_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -99,7 +99,7 @@ EOF
     severity              = "Major"
     detect_label          = "MAJOR"
     disabled              = coalesce(var.rollbacks_disabled_major, var.rollbacks_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.rollbacks_notifications_major, var.rollbacks_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.rollbacks_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -118,7 +118,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.conflicts_disabled_warning, var.conflicts_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.conflicts_notifications_warning, var.conflicts_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.conflicts_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -127,7 +127,7 @@ EOF
     severity              = "Major"
     detect_label          = "MAJOR"
     disabled              = coalesce(var.conflicts_disabled_major, var.conflicts_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.conflicts_notifications_major, var.conflicts_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.conflicts_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -146,7 +146,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.max_connections_disabled_critical, var.max_connections_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.max_connections_notifications_critical, var.max_connections_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.max_connections_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -155,7 +155,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.max_connections_disabled_warning, var.max_connections_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.max_connections_notifications_warning, var.max_connections_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.max_connections_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -174,7 +174,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.replication_lag_disabled_critical, var.replication_lag_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.replication_lag_notifications_critical, var.replication_lag_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.replication_lag_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -183,7 +183,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.replication_lag_disabled_warning, var.replication_lag_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.replication_lag_notifications_warning, var.replication_lag_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.replication_lag_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -201,7 +201,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.replication_state_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.replication_state_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.replication_state_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/database/postgresql/variables.tf
+++ b/database/postgresql/variables.tf
@@ -8,8 +8,14 @@ variable "environment" {
 # SignalFx module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -45,9 +51,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_notifications" {
-  description = "Notification recipients list for every alerting rules of heartbeat detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for heartbeat detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "heartbeat_timeframe" {
@@ -77,21 +83,9 @@ variable "deadlocks_disabled_warning" {
 }
 
 variable "deadlocks_notifications" {
-  description = "Notification recipients list for every alerting rules of deadlocks detector"
-  type        = list
-  default     = []
-}
-
-variable "deadlocks_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of deadlocks detector"
-  type        = list
-  default     = []
-}
-
-variable "deadlocks_notifications_major" {
-  description = "Notification recipients list for major alerting rule of deadlocks detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for deadlocks detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "deadlocks_aggregation_function" {
@@ -139,21 +133,9 @@ variable "hit_ratio_disabled_major" {
 }
 
 variable "hit_ratio_notifications" {
-  description = "Notification recipients list for every alerting rules of hit_ratio detector"
-  type        = list
-  default     = []
-}
-
-variable "hit_ratio_notifications_minor" {
-  description = "Notification recipients list for minor alerting rule of hit_ratio detector"
-  type        = list
-  default     = []
-}
-
-variable "hit_ratio_notifications_major" {
-  description = "Notification recipients list for major alerting rule of hit_ratio detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for hit_ratio detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "hit_ratio_aggregation_function" {
@@ -201,21 +183,9 @@ variable "rollbacks_disabled_major" {
 }
 
 variable "rollbacks_notifications" {
-  description = "Notification recipients list for every alerting rules of rollbacks detector"
-  type        = list
-  default     = []
-}
-
-variable "rollbacks_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of rollbacks detector"
-  type        = list
-  default     = []
-}
-
-variable "rollbacks_notifications_major" {
-  description = "Notification recipients list for major alerting rule of rollbacks detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for rollbacks detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "rollbacks_aggregation_function" {
@@ -263,21 +233,9 @@ variable "conflicts_disabled_warning" {
 }
 
 variable "conflicts_notifications" {
-  description = "Notification recipients list for every alerting rules of conflicts detector"
-  type        = list
-  default     = []
-}
-
-variable "conflicts_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of conflicts detector"
-  type        = list
-  default     = []
-}
-
-variable "conflicts_notifications_major" {
-  description = "Notification recipients list for major alerting rule of conflicts detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for conflicts detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "conflicts_aggregation_function" {
@@ -325,21 +283,9 @@ variable "max_connections_disabled_warning" {
 }
 
 variable "max_connections_notifications" {
-  description = "Notification recipients list for every alerting rules of max_connections detector"
-  type        = list
-  default     = []
-}
-
-variable "max_connections_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of max_connections detector"
-  type        = list
-  default     = []
-}
-
-variable "max_connections_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of max_connections detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for max_connections detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "max_connections_aggregation_function" {
@@ -387,21 +333,9 @@ variable "replication_lag_disabled_warning" {
 }
 
 variable "replication_lag_notifications" {
-  description = "Notification recipients list for every alerting rules of replication_lag detector"
-  type        = list
-  default     = []
-}
-
-variable "replication_lag_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of replication_lag detector"
-  type        = list
-  default     = []
-}
-
-variable "replication_lag_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of replication_lag detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for replication_lag detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "replication_lag_aggregation_function" {
@@ -437,9 +371,9 @@ variable "replication_state_disabled" {
 }
 
 variable "replication_state_notifications" {
-  description = "Notification recipients list for every alerting rules of replication_state detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for replication_state detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "replication_state_aggregation_function" {

--- a/database/redis/detectors-redis.tf
+++ b/database/redis/detectors-redis.tf
@@ -13,7 +13,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.heartbeat_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.heartbeat_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.heartbeat_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
 }
@@ -32,7 +32,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.evicted_keys_disabled_critical, var.evicted_keys_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.evicted_keys_notifications_critical, var.evicted_keys_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.evicted_keys_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -41,7 +41,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.evicted_keys_disabled_warning, var.evicted_keys_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.evicted_keys_notifications_warning, var.evicted_keys_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.evicted_keys_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -60,7 +60,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.expirations_disabled_critical, var.expirations_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.expirations_notifications_critical, var.expirations_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.expirations_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -69,7 +69,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.expirations_disabled_warning, var.expirations_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.expirations_notifications_warning, var.expirations_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.expirations_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -90,7 +90,7 @@ EOF
     severity              = "Major"
     detect_label          = "MAJOR"
     disabled              = coalesce(var.blocked_clients_disabled_major, var.blocked_clients_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.blocked_clients_notifications_major, var.blocked_clients_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.blocked_clients_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -99,7 +99,7 @@ EOF
     severity              = "Minor"
     detect_label          = "MINOR"
     disabled              = coalesce(var.blocked_clients_disabled_minor, var.blocked_clients_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.blocked_clients_notifications_minor, var.blocked_clients_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.blocked_clients_notifications, "minor", []), var.notifications.minor)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -117,7 +117,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.keyspace_full_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.keyspace_full_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.keyspace_full_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -138,7 +138,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.memory_used_max_disabled_critical, var.memory_used_max_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.memory_used_max_notifications_critical, var.memory_used_max_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.memory_used_max_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -147,7 +147,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.memory_used_max_disabled_warning, var.memory_used_max_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.memory_used_max_notifications_warning, var.memory_used_max_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.memory_used_max_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -168,7 +168,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.memory_used_total_disabled_critical, var.memory_used_total_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.memory_used_total_notifications_critical, var.memory_used_total_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.memory_used_total_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -177,7 +177,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.memory_used_total_disabled_warning, var.memory_used_total_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.memory_used_total_notifications_warning, var.memory_used_total_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.memory_used_total_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -198,7 +198,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.memory_frag_high_disabled_critical, var.memory_frag_high_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.memory_frag_high_notifications_critical, var.memory_frag_high_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.memory_frag_high_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -207,7 +207,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.memory_frag_high_disabled_warning, var.memory_frag_high_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.memory_frag_high_notifications_warning, var.memory_frag_high_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.memory_frag_high_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -228,7 +228,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.memory_frag_low_disabled_critical, var.memory_frag_low_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.memory_frag_low_notifications_critical, var.memory_frag_low_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.memory_frag_low_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -237,7 +237,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.memory_frag_low_disabled_warning, var.memory_frag_low_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.memory_frag_low_notifications_warning, var.memory_frag_low_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.memory_frag_low_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -256,7 +256,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.rejected_connections_disabled_critical, var.rejected_connections_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.rejected_connections_notifications_critical, var.rejected_connections_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.rejected_connections_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -265,7 +265,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.rejected_connections_disabled_warning, var.rejected_connections_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.rejected_connections_notifications_warning, var.rejected_connections_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.rejected_connections_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -286,7 +286,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.hitrate_disabled_critical, var.hitrate_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.hitrate_notifications_critical, var.hitrate_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.hitrate_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -295,7 +295,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.hitrate_disabled_warning, var.hitrate_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.hitrate_notifications_warning, var.hitrate_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.hitrate_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/database/redis/variables.tf
+++ b/database/redis/variables.tf
@@ -8,8 +8,14 @@ variable "environment" {
 # SignalFx module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -45,9 +51,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_notifications" {
-  description = "Notification recipients list for every alerting rules of heartbeat detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for heartbeat detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "heartbeat_timeframe" {
@@ -77,21 +83,9 @@ variable "evicted_keys_disabled_warning" {
 }
 
 variable "evicted_keys_notifications" {
-  description = "Notification recipients list for every alerting rules of evicted_keys detector"
-  type        = list
-  default     = []
-}
-
-variable "evicted_keys_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of evicted_keys detector"
-  type        = list
-  default     = []
-}
-
-variable "evicted_keys_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of evicted_keys detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for evicted_keys detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "evicted_keys_aggregation_function" {
@@ -139,21 +133,9 @@ variable "expirations_disabled_warning" {
 }
 
 variable "expirations_notifications" {
-  description = "Notification recipients list for every alerting rules of expirations detector"
-  type        = list
-  default     = []
-}
-
-variable "expirations_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of expirations detector"
-  type        = list
-  default     = []
-}
-
-variable "expirations_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of expirations detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for expirations detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "expirations_aggregation_function" {
@@ -201,21 +183,9 @@ variable "blocked_clients_disabled_minor" {
 }
 
 variable "blocked_clients_notifications" {
-  description = "Notification recipients list for every alerting rules of blocked_clients detector"
-  type        = list
-  default     = []
-}
-
-variable "blocked_clients_notifications_minor" {
-  description = "Notification recipients list for minor alerting rule of blocked_clients detector"
-  type        = list
-  default     = []
-}
-
-variable "blocked_clients_notifications_major" {
-  description = "Notification recipients list for major alerting rule of blocked_clients detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for blocked_clients detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "blocked_clients_aggregation_function" {
@@ -251,9 +221,9 @@ variable "keyspace_full_disabled" {
 }
 
 variable "keyspace_full_notifications" {
-  description = "Notification recipients list for every alerting rules of keyspace_full detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for keyspace_full detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "keyspace_full_aggregation_function" {
@@ -289,21 +259,9 @@ variable "memory_used_max_disabled_warning" {
 }
 
 variable "memory_used_max_notifications" {
-  description = "Notification recipients list for every alerting rules of memory_used_max detector"
-  type        = list
-  default     = []
-}
-
-variable "memory_used_max_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of memory_used_max detector"
-  type        = list
-  default     = []
-}
-
-variable "memory_used_max_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of memory_used_max detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for memory_used_max detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "memory_used_max_aggregation_function" {
@@ -351,21 +309,9 @@ variable "memory_used_total_disabled_warning" {
 }
 
 variable "memory_used_total_notifications" {
-  description = "Notification recipients list for every alerting rules of memory_used_total detector"
-  type        = list
-  default     = []
-}
-
-variable "memory_used_total_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of memory_used_total detector"
-  type        = list
-  default     = []
-}
-
-variable "memory_used_total_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of memory_used_total detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for memory_used_total detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "memory_used_total_aggregation_function" {
@@ -413,21 +359,9 @@ variable "memory_frag_high_disabled_warning" {
 }
 
 variable "memory_frag_high_notifications" {
-  description = "Notification recipients list for every alerting rules of memory_frag_high detector"
-  type        = list
-  default     = []
-}
-
-variable "memory_frag_high_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of memory_frag_high detector"
-  type        = list
-  default     = []
-}
-
-variable "memory_frag_high_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of memory_frag_high detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for memory_frag_high detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "memory_frag_high_aggregation_function" {
@@ -475,21 +409,9 @@ variable "memory_frag_low_disabled_warning" {
 }
 
 variable "memory_frag_low_notifications" {
-  description = "Notification recipients list for every alerting rules of memory_frag_low detector"
-  type        = list
-  default     = []
-}
-
-variable "memory_frag_low_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of memory_frag_low detector"
-  type        = list
-  default     = []
-}
-
-variable "memory_frag_low_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of memory_frag_low detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for memory_frag_low detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "memory_frag_low_aggregation_function" {
@@ -537,21 +459,9 @@ variable "rejected_connections_disabled_warning" {
 }
 
 variable "rejected_connections_notifications" {
-  description = "Notification recipients list for every alerting rules of rejected_connections detector"
-  type        = list
-  default     = []
-}
-
-variable "rejected_connections_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of rejected_connections detector"
-  type        = list
-  default     = []
-}
-
-variable "rejected_connections_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of rejected_connections detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for rejected_connections detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "rejected_connections_aggregation_function" {
@@ -599,21 +509,9 @@ variable "hitrate_disabled_warning" {
 }
 
 variable "hitrate_notifications" {
-  description = "Notification recipients list for every alerting rules of hitrate detector"
-  type        = list
-  default     = []
-}
-
-variable "hitrate_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of hitrate detector"
-  type        = list
-  default     = []
-}
-
-variable "hitrate_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of hitrate detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for hitrate detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "hitrate_aggregation_function" {

--- a/database/solr/detectors-solr.tf
+++ b/database/solr/detectors-solr.tf
@@ -13,7 +13,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.heartbeat_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.heartbeat_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.heartbeat_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
 }
@@ -32,7 +32,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.errors_disabled_critical, var.errors_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.errors_notifications_critical, var.errors_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.errors_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -41,7 +41,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.errors_disabled_warning, var.errors_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.errors_notifications_warning, var.errors_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.errors_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -60,7 +60,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.searcher_warmup_time_disabled_critical, var.searcher_warmup_time_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.searcher_warmup_time_notifications_critical, var.searcher_warmup_time_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.searcher_warmup_time_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -69,7 +69,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.searcher_warmup_time_disabled_warning, var.searcher_warmup_time_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.searcher_warmup_time_notifications_warning, var.searcher_warmup_time_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.searcher_warmup_time_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/database/solr/variables.tf
+++ b/database/solr/variables.tf
@@ -8,8 +8,14 @@ variable "environment" {
 # SignalFx module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -45,9 +51,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_notifications" {
-  description = "Notification recipients list for every alerting rules of heartbeat detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for heartbeat detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "heartbeat_timeframe" {
@@ -77,21 +83,9 @@ variable "errors_disabled_warning" {
 }
 
 variable "errors_notifications" {
-  description = "Notification recipients list for every alerting rules of errors detector"
-  type        = list
-  default     = []
-}
-
-variable "errors_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of errors detector"
-  type        = list
-  default     = []
-}
-
-variable "errors_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of errors detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for errors detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "errors_aggregation_function" {
@@ -139,21 +133,9 @@ variable "searcher_warmup_time_disabled_warning" {
 }
 
 variable "searcher_warmup_time_notifications" {
-  description = "Notification recipients list for every alerting rules of searcher_warmup_time detector"
-  type        = list
-  default     = []
-}
-
-variable "searcher_warmup_time_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of searcher_warmup_time detector"
-  type        = list
-  default     = []
-}
-
-variable "searcher_warmup_time_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of searcher_warmup_time detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for searcher_warmup_time detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "searcher_warmup_time_aggregation_function" {

--- a/database/zookeeper/detectors-zookeeper.tf
+++ b/database/zookeeper/detectors-zookeeper.tf
@@ -13,7 +13,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.heartbeat_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.heartbeat_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.heartbeat_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
 }
@@ -31,7 +31,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.zookeeper_health_disabled_critical, var.zookeeper_health_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.zookeeper_health_notifications_critical, var.zookeeper_health_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.zookeeper_health_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -50,7 +50,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.zookeeper_latency_disabled_critical, var.zookeeper_latency_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.zookeeper_latency_notifications_critical, var.zookeeper_latency_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.zookeeper_latency_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -59,7 +59,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.zookeeper_latency_disabled_warning, var.zookeeper_latency_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.zookeeper_latency_notifications_warning, var.zookeeper_latency_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.zookeeper_latency_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -80,7 +80,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.file_descriptors_disabled_critical, var.file_descriptors_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.file_descriptors_notifications_critical, var.file_descriptors_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.file_descriptors_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -89,7 +89,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.file_descriptors_disabled_warning, var.file_descriptors_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.file_descriptors_notifications_warning, var.file_descriptors_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.file_descriptors_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/database/zookeeper/variables.tf
+++ b/database/zookeeper/variables.tf
@@ -8,8 +8,14 @@ variable "environment" {
 # SignalFx module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -45,9 +51,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_notifications" {
-  description = "Notification recipients list for every alerting rules of heartbeat detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for heartbeat detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "heartbeat_timeframe" {
@@ -71,15 +77,9 @@ variable "zookeeper_health_disabled_critical" {
 }
 
 variable "zookeeper_health_notifications" {
-  description = "Notification recipients list for every alerting rules of zookeeper_health detector"
-  type        = list
-  default     = []
-}
-
-variable "zookeeper_health_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of zookeeper_health detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for zookeeper_health detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "zookeeper_health_aggregation_function" {
@@ -115,21 +115,9 @@ variable "zookeeper_latency_disabled_warning" {
 }
 
 variable "zookeeper_latency_notifications" {
-  description = "Notification recipients list for every alerting rules of zookeeper_latency detector"
-  type        = list
-  default     = []
-}
-
-variable "zookeeper_latency_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of zookeeper_latency detector"
-  type        = list
-  default     = []
-}
-
-variable "zookeeper_latency_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of zookeeper_latency detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for zookeeper_latency detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "zookeeper_latency_aggregation_function" {
@@ -177,21 +165,9 @@ variable "file_descriptors_disabled_warning" {
 }
 
 variable "file_descriptors_notifications" {
-  description = "Notification recipients list for every alerting rules of file_descriptors detector"
-  type        = list
-  default     = []
-}
-
-variable "file_descriptors_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of file_descriptors detector"
-  type        = list
-  default     = []
-}
-
-variable "file_descriptors_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of file_descriptors detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for file_descriptors detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "file_descriptors_aggregation_function" {

--- a/middleware/apache/detectors-apache.tf
+++ b/middleware/apache/detectors-apache.tf
@@ -13,7 +13,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.heartbeat_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.heartbeat_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.heartbeat_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
 }
@@ -34,7 +34,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.apache_workers_disabled_critical, var.apache_workers_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.apache_workers_notifications_critical, var.apache_workers_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.apache_workers_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -43,7 +43,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.apache_workers_disabled_warning, var.apache_workers_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.apache_workers_notifications_warning, var.apache_workers_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.apache_workers_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/middleware/apache/variables.tf
+++ b/middleware/apache/variables.tf
@@ -8,8 +8,14 @@ variable "environment" {
 # SignalFx module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -45,9 +51,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_notifications" {
-  description = "Notification recipients list for every alerting rules of heartbeat detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for heartbeat detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "heartbeat_timeframe" {
@@ -77,21 +83,9 @@ variable "apache_workers_disabled_warning" {
 }
 
 variable "apache_workers_notifications" {
-  description = "Notification recipients list for every alerting rules of apache_workers detector"
-  type        = list
-  default     = []
-}
-
-variable "apache_workers_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of apache_workers detector"
-  type        = list
-  default     = []
-}
-
-variable "apache_workers_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of apache_workers detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for apache_workers detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "apache_workers_aggregation_function" {

--- a/middleware/haproxy/detectors-haproxy.tf
+++ b/middleware/haproxy/detectors-haproxy.tf
@@ -13,7 +13,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.heartbeat_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.heartbeat_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.heartbeat_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
 }
@@ -31,7 +31,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.server_status_disabled_critical, var.server_status_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.server_status_notifications_critical, var.server_status_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.server_status_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -49,7 +49,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.backend_status_disabled_critical, var.backend_status_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.backend_status_notifications_critical, var.backend_status_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.backend_status_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -70,7 +70,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.session_limit_disabled_critical, var.session_limit_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.session_limit_notifications_critical, var.session_limit_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.session_limit_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -79,7 +79,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.session_limit_disabled_warning, var.session_limit_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.session_limit_notifications_warning, var.session_limit_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.session_limit_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -100,7 +100,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.http_5xx_response_disabled_critical, var.http_5xx_response_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.http_5xx_response_notifications_critical, var.http_5xx_response_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.http_5xx_response_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -109,7 +109,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.http_5xx_response_disabled_warning, var.http_5xx_response_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.http_5xx_response_notifications_warning, var.http_5xx_response_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.http_5xx_response_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -130,7 +130,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.http_4xx_response_disabled_critical, var.http_4xx_response_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.http_4xx_response_notifications_critical, var.http_4xx_response_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.http_4xx_response_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -139,7 +139,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.http_4xx_response_disabled_warning, var.http_4xx_response_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.http_4xx_response_notifications_warning, var.http_4xx_response_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.http_4xx_response_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/middleware/haproxy/variables.tf
+++ b/middleware/haproxy/variables.tf
@@ -8,8 +8,14 @@ variable "environment" {
 # SignalFx module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -45,9 +51,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_notifications" {
-  description = "Notification recipients list for every alerting rules of heartbeat detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for heartbeat detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "heartbeat_timeframe" {
@@ -69,15 +75,9 @@ variable "server_status_disabled_critical" {
 }
 
 variable "server_status_notifications" {
-  description = "Notification recipients list for every alerting rules of server status detector"
-  type        = list
-  default     = []
-}
-
-variable "server_status_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of server status detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for server status detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "server_status_aggregation_function" {
@@ -105,15 +105,9 @@ variable "backend_status_disabled_critical" {
 }
 
 variable "backend_status_notifications" {
-  description = "Notification recipients list for every alerting rules of backend status detector"
-  type        = list
-  default     = []
-}
-
-variable "backend_status_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of backend status detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for backend status detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "backend_status_aggregation_function" {
@@ -147,21 +141,9 @@ variable "session_limit_disabled_critical" {
 }
 
 variable "session_limit_notifications" {
-  description = "Notification recipients list for every alerting rules of session limit detector"
-  type        = list
-  default     = []
-}
-
-variable "session_limit_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of session limit detector"
-  type        = list
-  default     = []
-}
-
-variable "session_limit_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of session limit detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for session limit detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "session_limit_aggregation_function" {
@@ -207,21 +189,9 @@ variable "http_5xx_response_disabled_critical" {
 }
 
 variable "http_5xx_response_notifications" {
-  description = "Notification recipients list for every alerting rules of http_5xx_response detector"
-  type        = list
-  default     = []
-}
-
-variable "http_5xx_response_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of http_5xx_response detector"
-  type        = list
-  default     = []
-}
-
-variable "http_5xx_response_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of http_5xx_response detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for http_5xx_response detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "http_5xx_response_aggregation_function" {
@@ -267,21 +237,9 @@ variable "http_4xx_response_disabled_critical" {
 }
 
 variable "http_4xx_response_notifications" {
-  description = "Notification recipients list for every alerting rules of http_4xx_response detector"
-  type        = list
-  default     = []
-}
-
-variable "http_4xx_response_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of http_4xx_response detector"
-  type        = list
-  default     = []
-}
-
-variable "http_4xx_response_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of http_4xx_response detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for http_4xx_response detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "http_4xx_response_aggregation_function" {

--- a/middleware/kong/detectors-kong.tf
+++ b/middleware/kong/detectors-kong.tf
@@ -13,7 +13,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.heartbeat_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.heartbeat_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.heartbeat_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
 }
@@ -34,7 +34,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.treatment_limit_disabled_critical, var.treatment_limit_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.treatment_limit_notifications_critical, var.treatment_limit_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.treatment_limit_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -43,7 +43,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.treatment_limit_disabled_warning, var.treatment_limit_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.treatment_limit_notifications_warning, var.treatment_limit_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.treatment_limit_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/middleware/kong/variables.tf
+++ b/middleware/kong/variables.tf
@@ -8,8 +8,14 @@ variable "environment" {
 # SignalFx Module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -45,9 +51,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_notifications" {
-  description = "Notification recipients list for every alerting rules of heartbeat detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for heartbeat detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "heartbeat_timeframe" {
@@ -77,21 +83,9 @@ variable "treatment_limit_disabled_warning" {
 }
 
 variable "treatment_limit_notifications" {
-  description = "Notification recipients list for every alerting rules of treatment limit detector"
-  type        = list
-  default     = []
-}
-
-variable "treatment_limit_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of treatment limit detector"
-  type        = list
-  default     = []
-}
-
-variable "treatment_limit_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of treatment limit detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for treatment limit detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "treatment_limit_aggregation_function" {

--- a/middleware/nginx/detectors-nginx.tf
+++ b/middleware/nginx/detectors-nginx.tf
@@ -13,7 +13,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.heartbeat_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.heartbeat_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.heartbeat_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
 }
@@ -32,7 +32,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.dropped_connections_disabled_critical, var.dropped_connections_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.dropped_connections_notifications_critical, var.dropped_connections_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.dropped_connections_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -41,7 +41,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.dropped_connections_disabled_warning, var.dropped_connections_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.dropped_connections_notifications_warning, var.dropped_connections_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.dropped_connections_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/middleware/nginx/variables.tf
+++ b/middleware/nginx/variables.tf
@@ -8,8 +8,14 @@ variable "environment" {
 # SignalFx module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -45,9 +51,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_notifications" {
-  description = "Notification recipients list for every alerting rules of heartbeat detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for heartbeat detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "heartbeat_timeframe" {
@@ -75,21 +81,9 @@ variable "dropped_connections_disabled_warning" {
 }
 
 variable "dropped_connections_notifications" {
-  description = "Notification recipients list for every alerting rules of dropped connections detector"
-  type        = list
-  default     = []
-}
-
-variable "dropped_connections_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of dropped connections detector"
-  type        = list
-  default     = []
-}
-
-variable "dropped_connections_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of dropped connections detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for dropped connections detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "dropped_connections_aggregation_function" {

--- a/middleware/php-fpm/detectors-fpm.tf
+++ b/middleware/php-fpm/detectors-fpm.tf
@@ -13,7 +13,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.heartbeat_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.heartbeat_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.heartbeat_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
 }
@@ -34,7 +34,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.php_fpm_connect_idle_disabled_critical, var.php_fpm_connect_idle_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.php_fpm_connect_idle_notifications_critical, var.php_fpm_connect_idle_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.php_fpm_connect_idle_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -43,7 +43,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.php_fpm_connect_idle_disabled_warning, var.php_fpm_connect_idle_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.php_fpm_connect_idle_notifications_warning, var.php_fpm_connect_idle_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.php_fpm_connect_idle_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/middleware/php-fpm/variables.tf
+++ b/middleware/php-fpm/variables.tf
@@ -8,8 +8,14 @@ variable "environment" {
 # SignalFx module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -45,9 +51,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_notifications" {
-  description = "Notification recipients list for every alerting rules of heartbeat detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for heartbeat detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "heartbeat_timeframe" {
@@ -77,21 +83,9 @@ variable "php_fpm_connect_idle_disabled_warning" {
 }
 
 variable "php_fpm_connect_idle_notifications" {
-  description = "Notification recipients list for every alerting rules of php_fpm_connect_idle detector"
-  type        = list
-  default     = []
-}
-
-variable "php_fpm_connect_idle_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of php_fpm_connect_idle detector"
-  type        = list
-  default     = []
-}
-
-variable "php_fpm_connect_idle_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of php_fpm_connect_idle detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for php_fpm_connect_idle detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "php_fpm_connect_idle_aggregation_function" {

--- a/middleware/rabbitmq/node/detectors-rabbitmq-node.tf
+++ b/middleware/rabbitmq/node/detectors-rabbitmq-node.tf
@@ -13,7 +13,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.heartbeat_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.heartbeat_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.heartbeat_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
 }
@@ -34,7 +34,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.file_descriptors_disabled_critical, var.file_descriptors_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.file_descriptors_notifications_critical, var.file_descriptors_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.file_descriptors_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -43,7 +43,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.file_descriptors_disabled_warning, var.file_descriptors_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.file_descriptors_notifications_warning, var.file_descriptors_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.file_descriptors_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -64,7 +64,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.processes_disabled_critical, var.processes_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.processes_notifications_critical, var.processes_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.processes_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -73,7 +73,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.processes_disabled_warning, var.processes_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.processes_notifications_warning, var.processes_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.processes_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -94,7 +94,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.sockets_disabled_critical, var.sockets_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.sockets_notifications_critical, var.sockets_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.sockets_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -103,7 +103,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.sockets_disabled_warning, var.sockets_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.sockets_notifications_warning, var.sockets_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.sockets_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -124,7 +124,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.vm_memory_disabled_critical, var.vm_memory_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.vm_memory_notifications_critical, var.vm_memory_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.vm_memory_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -133,7 +133,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.vm_memory_disabled_warning, var.vm_memory_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.vm_memory_notifications_warning, var.vm_memory_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.vm_memory_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/middleware/rabbitmq/node/variables.tf
+++ b/middleware/rabbitmq/node/variables.tf
@@ -8,8 +8,14 @@ variable "environment" {
 # SignalFx module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -45,9 +51,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_notifications" {
-  description = "Notification recipients list for every alerting rules of heartbeat detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for heartbeat detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "heartbeat_timeframe" {
@@ -75,21 +81,9 @@ variable "file_descriptors_disabled_warning" {
 }
 
 variable "file_descriptors_notifications" {
-  description = "Notification recipients list for every alerting rules of file descriptors detector"
-  type        = list
-  default     = []
-}
-
-variable "file_descriptors_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of file descriptors detector"
-  type        = list
-  default     = []
-}
-
-variable "file_descriptors_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of file descriptors detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for file descriptors detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "file_descriptors_aggregation_function" {
@@ -135,21 +129,9 @@ variable "processes_disabled_warning" {
 }
 
 variable "processes_notifications" {
-  description = "Notification recipients list for every alerting rules of processes detector"
-  type        = list
-  default     = []
-}
-
-variable "processes_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of processes detector"
-  type        = list
-  default     = []
-}
-
-variable "processes_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of processes detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for processes detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "processes_aggregation_function" {
@@ -195,21 +177,9 @@ variable "sockets_disabled_warning" {
 }
 
 variable "sockets_notifications" {
-  description = "Notification recipients list for every alerting rules of sockets detector"
-  type        = list
-  default     = []
-}
-
-variable "sockets_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of sockets detector"
-  type        = list
-  default     = []
-}
-
-variable "sockets_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of sockets detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for sockets detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "sockets_aggregation_function" {
@@ -255,21 +225,9 @@ variable "vm_memory_disabled_warning" {
 }
 
 variable "vm_memory_notifications" {
-  description = "Notification recipients list for every alerting rules of vm_memory detector"
-  type        = list
-  default     = []
-}
-
-variable "vm_memory_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of vm_memory detector"
-  type        = list
-  default     = []
-}
-
-variable "vm_memory_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of vm_memory detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for vm_memory detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "vm_memory_aggregation_function" {

--- a/middleware/rabbitmq/queue/detectors-rabbitmq-queue.tf
+++ b/middleware/rabbitmq/queue/detectors-rabbitmq-queue.tf
@@ -12,7 +12,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.messages_ready_disabled_critical, var.messages_ready_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.messages_ready_notifications_critical, var.messages_ready_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.messages_ready_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -21,7 +21,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.messages_ready_disabled_warning, var.messages_ready_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.messages_ready_notifications_warning, var.messages_ready_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.messages_ready_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -40,7 +40,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.messages_unacknowledged_disabled_critical, var.messages_unacknowledged_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.messages_unacknowledged_notifications_critical, var.messages_unacknowledged_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.messages_unacknowledged_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -49,7 +49,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.messages_unacknowledged_disabled_warning, var.messages_unacknowledged_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.messages_unacknowledged_notifications_warning, var.messages_unacknowledged_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.messages_unacknowledged_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -69,7 +69,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.messages_ack_rate_disabled_critical, var.messages_ack_rate_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.messages_ack_rate_notifications_critical, var.messages_ack_rate_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.messages_ack_rate_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -78,7 +78,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.messages_ack_rate_disabled_warning, var.messages_ack_rate_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.messages_ack_rate_notifications_warning, var.messages_ack_rate_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.messages_ack_rate_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -98,7 +98,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.consumer_use_disabled_critical, var.consumer_use_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.consumer_use_notifications_critical, var.consumer_use_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.consumer_use_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -107,7 +107,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.consumer_use_disabled_warning, var.consumer_use_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.consumer_use_notifications_warning, var.consumer_use_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.consumer_use_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/middleware/rabbitmq/queue/variables.tf
+++ b/middleware/rabbitmq/queue/variables.tf
@@ -8,8 +8,14 @@ variable "environment" {
 # SignalFx module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -57,21 +63,9 @@ variable "messages_ready_disabled_warning" {
 }
 
 variable "messages_ready_notifications" {
-  description = "Notification recipients list for every alerting rules of messages_ready detector"
-  type        = list
-  default     = []
-}
-
-variable "messages_ready_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of messages_ready detector"
-  type        = list
-  default     = []
-}
-
-variable "messages_ready_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of messages_ready detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for messages_ready detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "messages_ready_aggregation_function" {
@@ -117,21 +111,9 @@ variable "messages_unacknowledged_disabled_warning" {
 }
 
 variable "messages_unacknowledged_notifications" {
-  description = "Notification recipients list for every alerting rules of messages_unacknowledged detector"
-  type        = list
-  default     = []
-}
-
-variable "messages_unacknowledged_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of messages_unacknowledged detector"
-  type        = list
-  default     = []
-}
-
-variable "messages_unacknowledged_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of messages_unacknowledged detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for messages_unacknowledged detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "messages_unacknowledged_aggregation_function" {
@@ -177,21 +159,9 @@ variable "messages_ack_rate_disabled_warning" {
 }
 
 variable "messages_ack_rate_notifications" {
-  description = "Notification recipients list for every alerting rules of messages_ack_rate detector"
-  type        = list
-  default     = []
-}
-
-variable "messages_ack_rate_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of messages_ack_rate detector"
-  type        = list
-  default     = []
-}
-
-variable "messages_ack_rate_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of messages_ack_rate detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for messages_ack_rate detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "messages_ack_rate_aggregation_function" {
@@ -243,21 +213,9 @@ variable "consumer_use_disabled_warning" {
 }
 
 variable "consumer_use_notifications" {
-  description = "Notification recipients list for every alerting rules of consumer_use detector"
-  type        = list
-  default     = []
-}
-
-variable "consumer_use_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of consumer_use detector"
-  type        = list
-  default     = []
-}
-
-variable "consumer_use_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of consumer_use detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for consumer_use detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "consumer_use_aggregation_function" {

--- a/middleware/supervisor/detectors-supervisor.tf
+++ b/middleware/supervisor/detectors-supervisor.tf
@@ -13,7 +13,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.heartbeat_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.heartbeat_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.heartbeat_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
 }
@@ -32,7 +32,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.process_state_disabled_critical, var.process_state_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.process_state_notifications_critical, var.process_state_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.process_state_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -41,7 +41,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.process_state_disabled_warning, var.process_state_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.process_state_notifications_warning, var.process_state_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.process_state_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/middleware/supervisor/variables.tf
+++ b/middleware/supervisor/variables.tf
@@ -8,8 +8,14 @@ variable "environment" {
 # SignalFx module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -45,9 +51,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_notifications" {
-  description = "Notification recipients list for every alerting rules of heartbeat detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for heartbeat detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "heartbeat_timeframe" {
@@ -75,21 +81,9 @@ variable "process_state_disabled_warning" {
 }
 
 variable "process_state_notifications" {
-  description = "Notification recipients list for every alerting rules of process state detector"
-  type        = list
-  default     = []
-}
-
-variable "process_state_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of process state detector"
-  type        = list
-  default     = []
-}
-
-variable "process_state_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of process state detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for process state detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "process_state_aggregation_function" {

--- a/middleware/varnish/detectors-varnish.tf
+++ b/middleware/varnish/detectors-varnish.tf
@@ -71,16 +71,16 @@ EOF
     description           = "is too low > ${var.varnish_cache_hit_rate_threshold_warning}"
     severity              = "Warning"
     detect_label          = "WARN"
-    disabled              = coalesce(var.varnish_cache_hit_rate_disabled_warning, var.detectors_disabled)
-    notifications         = coalescelist(var.varnish_cache_hit_rate_notifications_warning, var.notifications)
+    disabled              = coalesce(var.varnish_cache_hit_rate_disabled_warning, var.varnish_cache_hit_rate_disabled, var.detectors_disabled)
+    notifications         = coalescelist(var.varnish_cache_hit_rate_notifications_warning, var.varnish_cache_hit_rate_notifications, var.notifications)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
   rule {
     description           = "is too low > ${var.varnish_cache_hit_rate_threshold_major}"
     severity              = "Major"
     detect_label          = "MAJOR"
-    disabled              = coalesce(var.varnish_cache_hit_rate_disabled_major, var.detectors_disabled)
-    notifications         = coalescelist(var.varnish_cache_hit_rate_notifications_major, var.notifications)
+    disabled              = coalesce(var.varnish_cache_hit_rate_disabled_major, var.varnish_cache_hit_rate_disabled, var.detectors_disabled)
+    notifications         = coalescelist(var.varnish_cache_hit_rate_notifications_major, var.varnish_cache_hit_rate_notifications, var.notifications)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
 }
@@ -101,16 +101,17 @@ EOF
     description           = "is too low > ${var.varnish_memory_usage_threshold_warning}"
     severity              = "Critical"
     detect_label          = "CRIT"
-    disabled              = coalesce(var.varnish_memory_usage_disabled_critical, var.detectors_disabled)
-    notifications         = coalescelist(var.varnish_memory_usage_notifications_critical, var.notifications)
+    disabled              = coalesce(var.varnish_memory_usage_disabled_critical, var.varnish_memory_usage_disabled, var.detectors_disabled)
+    notifications         = coalescelist(var.varnish_memory_usage_notifications_critical, var.varnish_memory_usage_notifications, var.notifications)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
   rule {
     description           = "is too low > ${var.varnish_memory_usage_threshold_warning}"
     severity              = "Warning"
     detect_label          = "WARN"
-    disabled              = coalesce(var.varnish_memory_usage_disabled_warning, var.detectors_disabled)
-    notifications         = coalescelist(var.varnish_memory_usage_notifications_warning, var.notifications)
+    disabled              = coalesce(var.varnish_memory_usage_disabled_warning, var.varnish_memory_usage_disabled, var.detectors_disabled)
+    notifications         = coalescelist(var.varnish_memory_usage_notifications_warning, var.varnish_memory_usage_notifications, var.notifications)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
 }
+

--- a/middleware/varnish/detectors-varnish.tf
+++ b/middleware/varnish/detectors-varnish.tf
@@ -12,7 +12,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.varnish_backend_failed_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.varnish_backend_failed_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.varnish_backend_failed_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
 }
@@ -31,7 +31,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.varnish_threads_number_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.varnish_threads_number_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.varnish_threads_number_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
 }
@@ -50,7 +50,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.varnish_session_dropped_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.varnish_session_dropped_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.varnish_session_dropped_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
 }
@@ -72,7 +72,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.varnish_cache_hit_rate_disabled_warning, var.varnish_cache_hit_rate_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.varnish_cache_hit_rate_notifications_warning, var.varnish_cache_hit_rate_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.varnish_cache_hit_rate_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
   rule {
@@ -80,7 +80,7 @@ EOF
     severity              = "Major"
     detect_label          = "MAJOR"
     disabled              = coalesce(var.varnish_cache_hit_rate_disabled_major, var.varnish_cache_hit_rate_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.varnish_cache_hit_rate_notifications_major, var.varnish_cache_hit_rate_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.varnish_cache_hit_rate_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
 }
@@ -102,7 +102,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.varnish_memory_usage_disabled_critical, var.varnish_memory_usage_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.varnish_memory_usage_notifications_critical, var.varnish_memory_usage_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.varnish_memory_usage_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
   rule {
@@ -110,7 +110,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.varnish_memory_usage_disabled_warning, var.varnish_memory_usage_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.varnish_memory_usage_notifications_warning, var.varnish_memory_usage_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.varnish_memory_usage_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
 }

--- a/middleware/varnish/variables.tf
+++ b/middleware/varnish/variables.tf
@@ -42,8 +42,9 @@ variable "varnish_backend_failed_disabled" {
 }
 
 variable "varnish_backend_failed_notifications" {
-  type    = list
-  default = []
+  description = "Notification recipients list for every alerting rules of backend_failed detector"
+  type        = list
+  default     = []
 }
 
 variable "varnish_threads_number_disabled" {
@@ -52,8 +53,9 @@ variable "varnish_threads_number_disabled" {
 }
 
 variable "varnish_threads_number_notifications" {
-  type    = list
-  default = []
+  description = "Notification recipients list for every alerting rules of threads_number detector"
+  type        = list
+  default     = []
 }
 
 variable "varnish_session_dropped_disabled" {
@@ -62,48 +64,81 @@ variable "varnish_session_dropped_disabled" {
 }
 
 variable "varnish_session_dropped_notifications" {
-  type    = list
-  default = []
+  description = "Notification recipients list for every alerting rules of session_dropped detector"
+  type        = list
+  default     = []
+}
+
+variable "varnish_cache_hit_rate_disabled" {
+  description = "Disable all alerting rules for cache_hit_rate detector"
+  type        = bool
+  default     = null
 }
 
 variable "varnish_cache_hit_rate_disabled_warning" {
-  type    = bool
-  default = null
-}
-
-variable "varnish_cache_hit_rate_notifications_warning" {
-  type    = list
-  default = []
+  description = "Disable warning alerting rule for cache_hit_rate detector"
+  type        = bool
+  default     = null
 }
 
 variable "varnish_cache_hit_rate_disabled_major" {
-  type    = bool
-  default = null
+  description = "Disable major alerting rule for cache_hit_rate detector"
+  type        = bool
+  default     = null
+}
+
+variable "varnish_cache_hit_rate_notifications" {
+  description = "Notification recipients list for every alerting rules of cache_hit_rate detector"
+  type        = list
+  default     = []
+}
+
+variable "varnish_cache_hit_rate_notifications_warning" {
+  description = "Notification recipients list for warning alerting rule of cache_hit_rate detector"
+  type        = list
+  default     = []
 }
 
 variable "varnish_cache_hit_rate_notifications_major" {
-  type    = list
-  default = []
+  description = "Notification recipients list for major alerting rule of cache_hit_rate detector"
+  type        = list
+  default     = []
 }
 
-variable "varnish_memory_usage_disabled_warning" {
-  type    = bool
-  default = null
-}
-
-variable "varnish_memory_usage_notifications_warning" {
-  type    = list
-  default = []
+variable "varnish_memory_usage_disabled" {
+  description = "Disable all alerting rules for memory_usage detector"
+  type        = bool
+  default     = null
 }
 
 variable "varnish_memory_usage_disabled_critical" {
-  type    = bool
-  default = null
+  description = "Disable critical alerting rule for memory_usage detector"
+  type        = bool
+  default     = null
+}
+
+variable "varnish_memory_usage_disabled_warning" {
+  description = "Disable warning alerting rule for memory_usage detector"
+  type        = bool
+  default     = null
+}
+
+variable "varnish_memory_usage_notifications" {
+  description = "Notification recipients list for every alerting rules of memory_usage detector"
+  type        = list
+  default     = []
 }
 
 variable "varnish_memory_usage_notifications_critical" {
-  type    = list
-  default = []
+  description = "Notification recipients list for critical alerting rule of memory_usage detector"
+  type        = list
+  default     = []
+}
+
+variable "varnish_memory_usage_notifications_warning" {
+  description = "Notification recipients list for warning alerting rule of memory_usage detector"
+  type        = list
+  default     = []
 }
 
 # Varnish detectors specific
@@ -211,3 +246,4 @@ variable "varnish_memory_usage_threshold_critical" {
   type        = number
   default     = 90
 }
+

--- a/middleware/varnish/variables.tf
+++ b/middleware/varnish/variables.tf
@@ -8,8 +8,14 @@ variable "environment" {
 # SignalFx module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -42,9 +48,9 @@ variable "varnish_backend_failed_disabled" {
 }
 
 variable "varnish_backend_failed_notifications" {
-  description = "Notification recipients list for every alerting rules of backend_failed detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for backend_failed detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "varnish_threads_number_disabled" {
@@ -53,9 +59,9 @@ variable "varnish_threads_number_disabled" {
 }
 
 variable "varnish_threads_number_notifications" {
-  description = "Notification recipients list for every alerting rules of threads_number detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for threads_number detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "varnish_session_dropped_disabled" {
@@ -64,9 +70,9 @@ variable "varnish_session_dropped_disabled" {
 }
 
 variable "varnish_session_dropped_notifications" {
-  description = "Notification recipients list for every alerting rules of session_dropped detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for session_dropped detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "varnish_cache_hit_rate_disabled" {
@@ -88,21 +94,9 @@ variable "varnish_cache_hit_rate_disabled_major" {
 }
 
 variable "varnish_cache_hit_rate_notifications" {
-  description = "Notification recipients list for every alerting rules of cache_hit_rate detector"
-  type        = list
-  default     = []
-}
-
-variable "varnish_cache_hit_rate_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of cache_hit_rate detector"
-  type        = list
-  default     = []
-}
-
-variable "varnish_cache_hit_rate_notifications_major" {
-  description = "Notification recipients list for major alerting rule of cache_hit_rate detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for cache_hit_rate detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "varnish_memory_usage_disabled" {
@@ -124,21 +118,9 @@ variable "varnish_memory_usage_disabled_warning" {
 }
 
 variable "varnish_memory_usage_notifications" {
-  description = "Notification recipients list for every alerting rules of memory_usage detector"
-  type        = list
-  default     = []
-}
-
-variable "varnish_memory_usage_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of memory_usage detector"
-  type        = list
-  default     = []
-}
-
-variable "varnish_memory_usage_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of memory_usage detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for memory_usage detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 # Varnish detectors specific

--- a/network/dns/detectors-dns.tf
+++ b/network/dns/detectors-dns.tf
@@ -13,7 +13,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.heartbeat_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.heartbeat_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.heartbeat_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
 }
@@ -32,7 +32,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.dns_query_time_disabled_critical, var.dns_query_time_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.dns_query_time_notifications_critical, var.dns_query_time_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.dns_query_time_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -41,7 +41,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.dns_query_time_disabled_warning, var.dns_query_time_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.dns_query_time_notifications_warning, var.dns_query_time_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.dns_query_time_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -59,7 +59,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.dns_result_code_disabled_critical, var.dns_result_code_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.dns_result_code_notifications_critical, var.dns_result_code_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.dns_result_code_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 

--- a/network/dns/variables.tf
+++ b/network/dns/variables.tf
@@ -8,8 +8,14 @@ variable "environment" {
 # SignalFx module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -45,9 +51,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_notifications" {
-  description = "Notification recipients list for every alerting rules of heartbeat detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for heartbeat detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "heartbeat_timeframe" {
@@ -77,21 +83,9 @@ variable "dns_query_time_disabled_warning" {
 }
 
 variable "dns_query_time_notifications" {
-  description = "Notification recipients list for every alerting rules of dns_query_time detector"
-  type        = list
-  default     = []
-}
-
-variable "dns_query_time_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of dns_query_time detector"
-  type        = list
-  default     = []
-}
-
-variable "dns_query_time_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of dns_query_time detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for dns_query_time detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "dns_query_time_aggregation_function" {
@@ -133,15 +127,9 @@ variable "dns_result_code_disabled_critical" {
 }
 
 variable "dns_result_code_notifications" {
-  description = "Notification recipients list for every alerting rules of dns_result_code detector"
-  type        = list
-  default     = []
-}
-
-variable "dns_result_code_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of dns_result_code detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for dns_result_code detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "dns_result_code_aggregation_function" {

--- a/network/http/detectors-http.tf
+++ b/network/http/detectors-http.tf
@@ -13,7 +13,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.heartbeat_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.heartbeat_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.heartbeat_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
 }
@@ -31,7 +31,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.http_code_matched_disabled_critical, var.http_code_matched_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.http_code_matched_notifications_critical, var.http_code_matched_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.http_code_matched_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -50,7 +50,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.http_regex_matched_disabled_critical, var.http_regex_matched_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.http_regex_matched_notifications_critical, var.http_regex_matched_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.http_regex_matched_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -70,7 +70,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.http_response_time_disabled_critical, var.http_response_time_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.http_response_time_notifications_critical, var.http_response_time_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.http_response_time_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -79,7 +79,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.http_response_time_disabled_warning, var.http_response_time_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.http_response_time_notifications_warning, var.http_response_time_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.http_response_time_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -97,7 +97,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.http_content_length_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.http_content_length_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.http_content_length_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -117,7 +117,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.certificate_expiration_date_disabled_critical, var.certificate_expiration_date_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.certificate_expiration_date_notifications_critical, var.certificate_expiration_date_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.certificate_expiration_date_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -126,7 +126,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.certificate_expiration_date_disabled_warning, var.certificate_expiration_date_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.certificate_expiration_date_notifications_warning, var.certificate_expiration_date_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.certificate_expiration_date_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -144,7 +144,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.invalid_tls_certificate_disabled_critical, var.invalid_tls_certificate_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.invalid_tls_certificate_notifications_critical, var.invalid_tls_certificate_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.invalid_tls_certificate_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 

--- a/network/http/variables.tf
+++ b/network/http/variables.tf
@@ -8,8 +8,14 @@ variable "environment" {
 # SignalFx module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -45,9 +51,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_notifications" {
-  description = "Notification recipients list for every alerting rules of heartbeat detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for heartbeat detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "heartbeat_timeframe" {
@@ -71,15 +77,9 @@ variable "http_code_matched_disabled_critical" {
 }
 
 variable "http_code_matched_notifications" {
-  description = "Notification recipients list for every alerting rules of http_code_matched detector"
-  type        = list
-  default     = []
-}
-
-variable "http_code_matched_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of http_code_matched detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for http_code_matched detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "http_code_matched_aggregation_function" {
@@ -109,15 +109,9 @@ variable "http_regex_matched_disabled_critical" {
 }
 
 variable "http_regex_matched_notifications" {
-  description = "Notification recipients list for every alerting rules of http_regex_matched detector"
-  type        = list
-  default     = []
-}
-
-variable "http_regex_matched_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of http_regex_matched detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for http_regex_matched detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "http_regex_matched_aggregation_function" {
@@ -153,21 +147,9 @@ variable "http_response_time_disabled_warning" {
 }
 
 variable "http_response_time_notifications" {
-  description = "Notification recipients list for every alerting rules of http_response_time detector"
-  type        = list
-  default     = []
-}
-
-variable "http_response_time_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of http_response_time detector"
-  type        = list
-  default     = []
-}
-
-variable "http_response_time_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of http_response_time detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for http_response_time detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "http_response_time_aggregation_function" {
@@ -203,9 +185,9 @@ variable "http_content_length_disabled" {
 }
 
 variable "http_content_length_notifications" {
-  description = "Notification recipients list for every alerting rules of http_content_length detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for http_content_length detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "http_content_length_aggregation_function" {
@@ -247,21 +229,9 @@ variable "certificate_expiration_date_disabled_warning" {
 }
 
 variable "certificate_expiration_date_notifications" {
-  description = "Notification recipients list for every alerting rules of certificate_expiration_date detector"
-  type        = list
-  default     = []
-}
-
-variable "certificate_expiration_date_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of certificate_expiration_date detector"
-  type        = list
-  default     = []
-}
-
-variable "certificate_expiration_date_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of certificate_expiration_date detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for certificate_expiration_date detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "certificate_expiration_date_aggregation_function" {
@@ -303,15 +273,9 @@ variable "invalid_tls_certificate_disabled_critical" {
 }
 
 variable "invalid_tls_certificate_notifications" {
-  description = "Notification recipients list for every alerting rules of invalid_tls_certificate detector"
-  type        = list
-  default     = []
-}
-
-variable "invalid_tls_certificate_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of invalid_tls_certificate detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for invalid_tls_certificate detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "invalid_tls_certificate_aggregation_function" {

--- a/organization/usage/detectors-usage.tf
+++ b/organization/usage/detectors-usage.tf
@@ -12,7 +12,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.hosts_limit_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.hosts_limit_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.hosts_limit_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}} > {{inputs.limit.value}}) on {{{dimensions}}}"
     parameterized_body    = local.parameterized_body
     runbook_url           = var.runbook_url
@@ -36,7 +36,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.containers_limit_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.containers_limit_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.containers_limit_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}} > {{inputs.limit.value}}) on {{{dimensions}}}"
     parameterized_body    = local.parameterized_body
     runbook_url           = var.runbook_url
@@ -60,7 +60,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.custom_metrics_limit_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.custom_metrics_limit_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.custom_metrics_limit_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}} > {{inputs.limit.value}}) on {{{dimensions}}}"
     parameterized_body    = local.parameterized_body
     runbook_url           = var.runbook_url
@@ -85,7 +85,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.containers_ratio_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.containers_ratio_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.containers_ratio_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
     parameterized_body    = local.parameterized_body
     runbook_url           = var.runbook_url
@@ -112,7 +112,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.custom_metrics_ratio_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.custom_metrics_ratio_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.custom_metrics_ratio_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
     parameterized_body    = local.parameterized_body
     runbook_url           = var.runbook_url

--- a/organization/usage/variables.tf
+++ b/organization/usage/variables.tf
@@ -27,8 +27,14 @@ variable "multiplier" {
 # SignalFx module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -54,9 +60,9 @@ variable "hosts_limit_disabled" {
 }
 
 variable "hosts_limit_notifications" {
-  description = "Notification recipients list for every alerting rules of hosts_limit detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for hosts_limit detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "hosts_limit_transformation_function" {
@@ -74,9 +80,9 @@ variable "containers_limit_disabled" {
 }
 
 variable "containers_limit_notifications" {
-  description = "Notification recipients list for every alerting rules of containers_limit detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for containers_limit detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "containers_limit_transformation_function" {
@@ -94,9 +100,9 @@ variable "custom_metrics_limit_disabled" {
 }
 
 variable "custom_metrics_limit_notifications" {
-  description = "Notification recipients list for every alerting rules of custom_metrics_limit detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for custom_metrics_limit detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "custom_metrics_limit_transformation_function" {
@@ -114,9 +120,9 @@ variable "containers_ratio_disabled" {
 }
 
 variable "containers_ratio_notifications" {
-  description = "Notification recipients list for every alerting rules of containers_ratio detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for containers_ratio detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "containers_ratio_transformation_function" {
@@ -140,9 +146,9 @@ variable "custom_metrics_ratio_disabled" {
 }
 
 variable "custom_metrics_ratio_notifications" {
-  description = "Notification recipients list for every alerting rules of custom_metrics_ratio detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for custom_metrics_ratio detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "custom_metrics_ratio_transformation_function" {

--- a/saas/new-relic/detectors-new-relic.tf
+++ b/saas/new-relic/detectors-new-relic.tf
@@ -12,7 +12,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.heartbeat_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.heartbeat_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.heartbeat_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
 }
@@ -31,7 +31,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.error_rate_disabled_critical, var.error_rate_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.error_rate_notifications_critical, var.error_rate_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.error_rate_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -40,7 +40,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.error_rate_disabled_warning, var.error_rate_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.error_rate_notifications_warning, var.error_rate_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.error_rate_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -60,7 +60,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.apdex_disabled_critical, var.apdex_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.apdex_notifications_critical, var.apdex_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.apdex_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -69,7 +69,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.apdex_disabled_warning, var.apdex_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.apdex_notifications_warning, var.apdex_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.apdex_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/saas/new-relic/variables.tf
+++ b/saas/new-relic/variables.tf
@@ -8,8 +8,14 @@ variable "environment" {
 # SignalFx module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -45,9 +51,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_notifications" {
-  description = "Notification recipients list for every alerting rules of heartbeat detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for heartbeat detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "heartbeat_timeframe" {
@@ -77,21 +83,9 @@ variable "error_rate_disabled_warning" {
 }
 
 variable "error_rate_notifications" {
-  description = "Notification recipients list for every alerting rules of error_rate detector"
-  type        = list
-  default     = []
-}
-
-variable "error_rate_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of error_rate detector"
-  type        = list
-  default     = []
-}
-
-variable "error_rate_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of error_rate detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for error_rate detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "error_rate_aggregation_function" {
@@ -139,21 +133,9 @@ variable "apdex_disabled_warning" {
 }
 
 variable "apdex_notifications" {
-  description = "Notification recipients list for every alerting rules of apdex detector"
-  type        = list
-  default     = []
-}
-
-variable "apdex_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of apdex detector"
-  type        = list
-  default     = []
-}
-
-variable "apdex_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of apdex detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for apdex detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "apdex_aggregation_function" {

--- a/scripts/gen_tf.sh
+++ b/scripts/gen_tf.sh
@@ -24,7 +24,7 @@ esac
 
 module_vars=$(cat <<-EOF
 	  environment   = var.environment
-	  notifications = [local.pagerduty_notification]
+	  notifications = local.notifications
 EOF
 )
 env_vars=$(terraform-config-inspect $(dirname $0)/../test --json | jq -cr '.variables[] | select(.required) | .name')

--- a/system/generic/detectors-system.tf
+++ b/system/generic/detectors-system.tf
@@ -13,7 +13,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.heartbeat_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.heartbeat_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.heartbeat_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
 }
@@ -32,7 +32,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.cpu_disabled_critical, var.cpu_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.cpu_notifications_critical, var.cpu_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.cpu_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -41,7 +41,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.cpu_disabled_warning, var.cpu_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.cpu_notifications_warning, var.cpu_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.cpu_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -60,7 +60,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.load_disabled_critical, var.load_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.load_notifications_critical, var.load_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.load_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -69,7 +69,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.load_disabled_warning, var.load_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.load_notifications_warning, var.load_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.load_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -88,7 +88,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.disk_space_disabled_critical, var.disk_space_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.disk_space_notifications_critical, var.disk_space_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.disk_space_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -97,7 +97,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.disk_space_disabled_warning, var.disk_space_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.disk_space_notifications_warning, var.disk_space_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.disk_space_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -116,7 +116,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.disk_inodes_disabled_critical, var.disk_inodes_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.disk_inodes_notifications_critical, var.disk_inodes_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.disk_inodes_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -125,7 +125,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.disk_inodes_disabled_warning, var.disk_inodes_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.disk_inodes_notifications_warning, var.disk_inodes_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.disk_inodes_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -144,7 +144,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.disk_running_out_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.disk_running_out_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.disk_running_out_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
 }
@@ -163,7 +163,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.memory_disabled_critical, var.memory_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.memory_notifications_critical, var.memory_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.memory_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -172,7 +172,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.memory_disabled_warning, var.memory_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.memory_notifications_warning, var.memory_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.memory_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/system/generic/variables.tf
+++ b/system/generic/variables.tf
@@ -8,8 +8,14 @@ variable "environment" {
 # SignalFx Module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -45,9 +51,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_notifications" {
-  description = "Notification recipients list for every alerting rules of heartbeat detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for heartbeat detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "heartbeat_timeframe" {
@@ -77,21 +83,9 @@ variable "cpu_disabled_warning" {
 }
 
 variable "cpu_notifications" {
-  description = "Notification recipients list for every alerting rules of cpu detector"
-  type        = list
-  default     = []
-}
-
-variable "cpu_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of cpu detector"
-  type        = list
-  default     = []
-}
-
-variable "cpu_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of cpu detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for cpu detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "cpu_aggregation_function" {
@@ -139,21 +133,9 @@ variable "load_disabled_warning" {
 }
 
 variable "load_notifications" {
-  description = "Notification recipients list for every alerting rules of load detector"
-  type        = list
-  default     = []
-}
-
-variable "load_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of load detector"
-  type        = list
-  default     = []
-}
-
-variable "load_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of load detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for load detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "load_aggregation_function" {
@@ -201,21 +183,9 @@ variable "disk_space_disabled_warning" {
 }
 
 variable "disk_space_notifications" {
-  description = "Notification recipients list for every alerting rules of disk space detector"
-  type        = list
-  default     = []
-}
-
-variable "disk_space_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of disk space detector"
-  type        = list
-  default     = []
-}
-
-variable "disk_space_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of disk space detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for disk space detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "disk_space_aggregation_function" {
@@ -263,21 +233,9 @@ variable "disk_inodes_disabled_warning" {
 }
 
 variable "disk_inodes_notifications" {
-  description = "Notification recipients list for every alerting rules of disk inodes detector"
-  type        = list
-  default     = []
-}
-
-variable "disk_inodes_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of disk inodes detector"
-  type        = list
-  default     = []
-}
-
-variable "disk_inodes_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of disk inodes detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for disk inodes detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "disk_inodes_aggregation_function" {
@@ -361,9 +319,9 @@ variable "disk_running_out_use_ewma" {
 }
 
 variable "disk_running_out_notifications" {
-  description = "Notification recipients list for every alerting rules of disk running out detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for disk running out detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 #####
@@ -387,21 +345,9 @@ variable "memory_disabled_warning" {
 }
 
 variable "memory_notifications" {
-  description = "Notification recipients list for every alerting rules of memory detector"
-  type        = list
-  default     = []
-}
-
-variable "memory_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of memory detector"
-  type        = list
-  default     = []
-}
-
-variable "memory_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of memory detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for memory detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "memory_aggregation_function" {

--- a/system/nagios-status-check/README.md
+++ b/system/nagios-status-check/README.md
@@ -18,7 +18,9 @@ Creates SignalFx detectors with the following checks:
 
 - Nagios check status
 
-This module has been designed to alert with the same behavior as [Nagios](https://nagios-plugins.org/doc/guidelines.html#AEN78), basically a gauge which is equal to 1 will trigger à `WARNING` and equal to 2 a `CRITICAL`. 
+This module has been designed to alert with the same behavior as [Nagios](https://nagios-plugins.org/doc/guidelines.html#AEN78), basically a gauge equal to 1, 2 and 3 respectively triggering `WARNING`, `CRITICAL` and `UNKNOWN` alert. 
+
+While SignalFx does not provide `Unknown` severity this module uses the `Major` severity for unknown alerts.
 
 On the agent side, you need to send your metrics with the [telegraf exec plugin][https://docs.signalfx.com/en/latest/integrations/agent/monitors/telegraf-exec.html] which includes a [parser for nagios](https://github.com/influxdata/telegraf/blob/master/plugins/parsers/nagios/parser.go). The metric is named `nagios_state.state`, you need to add an `extraDimensions` to your monitor in order to be able to differantiate multiple script states.
 
@@ -54,12 +56,12 @@ Here is an example :
 | status\_check\_aggregation\_function | Aggregation function and group by for status\_check detector \(i.e. ".mean\(by=\['host'\]\)."\) | string | `""` | no |
 | status\_check\_disabled | Disable all alerting rules for status\_check detector | bool | `"null"` | no |
 | status\_check\_disabled\_critical | Disable critical alerting rule for status\_check detector | bool | `"null"` | no |
-| status\_check\_disabled\_unknown | Disable unknown alerting rule for status\_check detector | bool | `"null"` | no |
+| status\_check\_disabled\_major | Disable major alerting rule for status\_check detector | bool | `"null"` | no |
 | status\_check\_disabled\_warning | Disable warning alerting rule for status\_check detector | bool | `"null"` | no |
 | status\_check\_lasting\_duration\_seconds | Minimum duration that conditions must be true before raising alert \(in seconds\) | string | `"900"` | no |
 | status\_check\_notifications | Notification recipients list for every alerting rules of status\_check detector | list | `[]` | no |
 | status\_check\_notifications\_critical | Notification recipients list for critical alerting rule of status\_check detector | list | `[]` | no |
-| status\_check\_notifications\_unknown | Notification recipients list for unknown alerting rule of status\_check detector | list | `[]` | no |
+| status\_check\_notifications\_major | Notification recipients list for major alerting rule of status\_check detector | list | `[]` | no |
 | status\_check\_notifications\_warning | Notification recipients list for warning alerting rule of status\_check detector | list | `[]` | no |
 | status\_check\_transformation\_function | Transformation function for status\_check detector \(i.e. ".mean\(over='5m'\)"\) | string | `""` | no |
 
@@ -75,3 +77,4 @@ Here is an example :
 - [Nagios documentation](https://nagios-plugins.org/doc/guidelines.html#AEN78)
 - [Telegraf exec plugin](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/exec)
 - [Telegraf nagios parser](https://github.com/influxdata/telegraf/tree/master/plugins/parsers/nagios)
+

--- a/system/nagios-status-check/detectors-nagios-status-check.tf
+++ b/system/nagios-status-check/detectors-nagios-status-check.tf
@@ -13,7 +13,7 @@ resource "signalfx_detector" "status_check" {
     severity              = "Major"
     detect_label          = "MAJOR"
     disabled              = coalesce(var.status_check_disabled_major, var.status_check_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.status_check_notifications_major, var.status_check_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.status_check_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -22,7 +22,7 @@ resource "signalfx_detector" "status_check" {
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.status_check_disabled_critical, var.status_check_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.status_check_notifications_critical, var.status_check_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.status_check_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -31,7 +31,7 @@ resource "signalfx_detector" "status_check" {
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.status_check_disabled_warning, var.status_check_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.status_check_notifications_warning, var.status_check_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.status_check_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/system/nagios-status-check/detectors-nagios-status-check.tf
+++ b/system/nagios-status-check/detectors-nagios-status-check.tf
@@ -5,15 +5,15 @@ resource "signalfx_detector" "status_check" {
         signal = data('nagios_state.state', filter=${module.filter-tags.filter_custom})${var.status_check_aggregation_function}${var.status_check_transformation_function}.publish('signal')
         detect(when(signal == 1, lasting='${var.status_check_lasting_duration_seconds}s')).publish('WARN')
         detect(when(signal == 2, lasting='${var.status_check_lasting_duration_seconds}s')).publish('CRIT')
-        detect(when(signal == 3, lasting='${var.status_check_lasting_duration_seconds}s')).publish('UNKN')
+        detect(when(signal == 3, lasting='${var.status_check_lasting_duration_seconds}s')).publish('MAJOR')
   EOF
 
   rule {
     description           = "is UNKNOWN, please check the script output on the host"
-    severity              = "Critical"
-    detect_label          = "UNKN"
-    disabled              = coalesce(var.status_check_disabled_unknown, var.status_check_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.status_check_notifications_unknown, var.status_check_notifications, var.notifications)
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.status_check_disabled_major, var.status_check_disabled, var.detectors_disabled)
+    notifications         = coalescelist(var.status_check_notifications_major, var.status_check_notifications, var.notifications)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -35,3 +35,4 @@ resource "signalfx_detector" "status_check" {
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
+

--- a/system/nagios-status-check/variables.tf
+++ b/system/nagios-status-check/variables.tf
@@ -8,8 +8,14 @@ variable "environment" {
 # SignalFx Module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -63,27 +69,9 @@ variable "status_check_disabled_major" {
 }
 
 variable "status_check_notifications" {
-  description = "Notification recipients list for every alerting rules of status_check detector"
-  type        = list
-  default     = []
-}
-
-variable "status_check_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of status_check detector"
-  type        = list
-  default     = []
-}
-
-variable "status_check_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of status_check detector"
-  type        = list
-  default     = []
-}
-
-variable "status_check_notifications_major" {
-  description = "Notification recipients list for major alerting rule of status_check detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for status_check detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "status_check_aggregation_function" {

--- a/system/nagios-status-check/variables.tf
+++ b/system/nagios-status-check/variables.tf
@@ -56,8 +56,8 @@ variable "status_check_disabled_warning" {
   default     = null
 }
 
-variable "status_check_disabled_unknown" {
-  description = "Disable unknown alerting rule for status_check detector"
+variable "status_check_disabled_major" {
+  description = "Disable major alerting rule for status_check detector"
   type        = bool
   default     = null
 }
@@ -80,8 +80,8 @@ variable "status_check_notifications_critical" {
   default     = []
 }
 
-variable "status_check_notifications_unknown" {
-  description = "Notification recipients list for unknown alerting rule of status_check detector"
+variable "status_check_notifications_major" {
+  description = "Notification recipients list for major alerting rule of status_check detector"
   type        = list
   default     = []
 }
@@ -103,3 +103,4 @@ variable "status_check_lasting_duration_seconds" {
   type        = string
   default     = "900"
 }
+

--- a/system/ntp/detectors-ntp.tf
+++ b/system/ntp/detectors-ntp.tf
@@ -13,7 +13,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.heartbeat_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.heartbeat_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.heartbeat_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
 }
@@ -31,7 +31,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.ntp_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.ntp_notifications_warning, var.ntp_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.ntp_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/system/ntp/variables.tf
+++ b/system/ntp/variables.tf
@@ -8,8 +8,14 @@ variable "environment" {
 # SignalFx Module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -45,9 +51,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_notifications" {
-  description = "Notification recipients list for every alerting rules of heartbeat detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for heartbeat detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "heartbeat_timeframe" {
@@ -65,15 +71,9 @@ variable "ntp_disabled" {
 }
 
 variable "ntp_notifications" {
-  description = "Notification recipients list for every alerting rules of ntp detector"
-  type        = list
-  default     = []
-}
-
-variable "ntp_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of ntp detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for ntp detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "ntp_aggregation_function" {

--- a/system/processes/detectors-processes.tf
+++ b/system/processes/detectors-processes.tf
@@ -12,7 +12,7 @@ EOF
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.processes_disabled_critical, var.processes_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.processes_notifications_critical, var.processes_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.processes_notifications, "critical", []), var.notifications.critical)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -21,7 +21,7 @@ EOF
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.processes_disabled_warning, var.processes_disabled, var.detectors_disabled)
-    notifications         = coalescelist(var.processes_notifications_warning, var.processes_notifications, var.notifications)
+    notifications         = coalescelist(lookup(var.processes_notifications, "warning", []), var.notifications.warning)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/system/processes/variables.tf
+++ b/system/processes/variables.tf
@@ -8,8 +8,14 @@ variable "environment" {
 # SignalFx Module specific
 
 variable "notifications" {
-  description = "Notification recipients list for every detectors"
-  type        = list
+  description = "Default notification recipients list per severity"
+  type = object({
+    critical = list(string)
+    major    = list(string)
+    minor    = list(string)
+    warning  = list(string)
+    info     = list(string)
+  })
 }
 
 variable "prefixes" {
@@ -57,21 +63,9 @@ variable "processes_disabled_warning" {
 }
 
 variable "processes_notifications" {
-  description = "Notification recipients list for every alerting rules of processes detector"
-  type        = list
-  default     = []
-}
-
-variable "processes_notifications_warning" {
-  description = "Notification recipients list for warning alerting rule of processes detector"
-  type        = list
-  default     = []
-}
-
-variable "processes_notifications_critical" {
-  description = "Notification recipients list for critical alerting rule of processes detector"
-  type        = list
-  default     = []
+  description = "Notification recipients list per severity overridden for processes detector"
+  type        = map(list(string))
+  default     = {}
 }
 
 variable "processes_aggregation_function" {

--- a/test/locals.tf
+++ b/test/locals.tf
@@ -1,3 +1,11 @@
 locals {
   pagerduty_notification = format("PagerDuty,%s", var.pagerduty_integration_id)
+  notifications = {
+    critical = [local.pagerduty_notification]
+    major    = [local.pagerduty_notification]
+    minor    = [local.pagerduty_notification]
+    warning  = ["Email,docs@example.org"]
+    info     = []
+  }
 }
+


### PR DESCRIPTION
this PR includes:

- update varnish module to be compliant with usage practices (cc @nicolasvion )
- update nagios module to use existing signalfx severity for unknown alerts (cc @cvauvarin)
- replace global `notifications` variable to use object and force user to define every severities explicitely (safety feature to avoid undesired binding)
- replace per detector notifications variable to use simple map which allow use to only define relevant severities (not all) but will fail if required severity is not set
- delete per detector per severity variable as they now belongs to the per detector map variable

this should provide a safer but also easier approach to define notifications and remains flexible enough, every suggestions are welcome.

in breaking 0.12 compatibility we can probably go further using https://www.terraform.io/docs/configuration/variables.html#custom-validation-rules  