### PR TITLE
#93 reorder severities following signalfx levels

### DIFF
--- a/cloud/aws/alb/variables.tf
+++ b/cloud/aws/alb/variables.tf
@@ -82,8 +82,8 @@ variable "no_healthy_instances_disabled_critical" {
   default     = null
 }
 
-variable "no_healthy_instances_disabled_warning" {
-  description = "Disable warning alerting rule for No_healthy_instances detector"
+variable "no_healthy_instances_disabled_major" {
+  description = "Disable major alerting rule for No_healthy_instances detector"
   type        = bool
   default     = null
 }
@@ -112,8 +112,8 @@ variable "no_healthy_instances_threshold_critical" {
   default     = 1
 }
 
-variable "no_healthy_instances_threshold_warning" {
-  description = "Warning threshold for No_healthy_instances detector"
+variable "no_healthy_instances_threshold_major" {
+  description = "Major threshold for No_healthy_instances detector"
   type        = number
   default     = 100
 }
@@ -132,8 +132,8 @@ variable "latency_disabled_critical" {
   default     = null
 }
 
-variable "latency_disabled_warning" {
-  description = "Disable warning alerting rule for latency detector"
+variable "latency_disabled_major" {
+  description = "Disable major alerting rule for latency detector"
   type        = bool
   default     = null
 }
@@ -174,8 +174,8 @@ variable "latency_threshold_critical" {
   default     = 3
 }
 
-variable "latency_threshold_warning" {
-  description = "Warning threshold for latency detector"
+variable "latency_threshold_major" {
+  description = "Major threshold for latency detector"
   type        = number
   default     = 1
 }
@@ -194,8 +194,8 @@ variable "alb_5xx_disabled_critical" {
   default     = null
 }
 
-variable "alb_5xx_disabled_warning" {
-  description = "Disable warning alerting rule for alb_5xx detector"
+variable "alb_5xx_disabled_major" {
+  description = "Disable major alerting rule for alb_5xx detector"
   type        = bool
   default     = null
 }
@@ -236,8 +236,8 @@ variable "alb_5xx_threshold_critical" {
   default     = 10
 }
 
-variable "alb_5xx_threshold_warning" {
-  description = "Warning threshold for alb_5xx detector"
+variable "alb_5xx_threshold_major" {
+  description = "Major threshold for alb_5xx detector"
   type        = number
   default     = 5
 }
@@ -256,8 +256,8 @@ variable "alb_4xx_disabled_critical" {
   default     = null
 }
 
-variable "alb_4xx_disabled_warning" {
-  description = "Disable warning alerting rule for alb_4xx detector"
+variable "alb_4xx_disabled_major" {
+  description = "Disable major alerting rule for alb_4xx detector"
   type        = bool
   default     = null
 }
@@ -298,8 +298,8 @@ variable "alb_4xx_threshold_critical" {
   default     = 40
 }
 
-variable "alb_4xx_threshold_warning" {
-  description = "Warning threshold for alb_4xx detector"
+variable "alb_4xx_threshold_major" {
+  description = "Major threshold for alb_4xx detector"
   type        = number
   default     = 20
 }
@@ -318,8 +318,8 @@ variable "target_5xx_disabled_critical" {
   default     = null
 }
 
-variable "target_5xx_disabled_warning" {
-  description = "Disable warning alerting rule for target_5xx detector"
+variable "target_5xx_disabled_major" {
+  description = "Disable major alerting rule for target_5xx detector"
   type        = bool
   default     = null
 }
@@ -360,8 +360,8 @@ variable "target_5xx_threshold_critical" {
   default     = 10
 }
 
-variable "target_5xx_threshold_warning" {
-  description = "Warning threshold for target_5xx detector"
+variable "target_5xx_threshold_major" {
+  description = "Major threshold for target_5xx detector"
   type        = number
   default     = 5
 }
@@ -380,8 +380,8 @@ variable "target_4xx_disabled_critical" {
   default     = null
 }
 
-variable "target_4xx_disabled_warning" {
-  description = "Disable warning alerting rule for target_4xx detector"
+variable "target_4xx_disabled_major" {
+  description = "Disable major alerting rule for target_4xx detector"
   type        = bool
   default     = null
 }
@@ -422,8 +422,8 @@ variable "target_4xx_threshold_critical" {
   default     = 40
 }
 
-variable "target_4xx_threshold_warning" {
-  description = "Warning threshold for target_4xx detector"
+variable "target_4xx_threshold_major" {
+  description = "Major threshold for target_4xx detector"
   type        = number
   default     = 20
 }

--- a/cloud/aws/apigateway/detectors-api.tf
+++ b/cloud/aws/apigateway/detectors-api.tf
@@ -5,7 +5,7 @@ resource "signalfx_detector" "latency" {
   program_text = <<-EOF
     signal = data('Latency', filter=filter('namespace', 'AWS/ApiGateway') and filter('stat', 'sum') and (not filter('Stage', '*')) and (not filter('Method', '*')) and (not filter('Resource', '*')) and ${module.filter-tags.filter_custom}, extrapolation='zero', rollup='average')${var.latency_aggregation_function}${var.latency_transformation_function}.publish('signal')
     detect(when(signal > threshold(${var.latency_threshold_critical}), lasting='${var.latency_lasting_duration_seconds}s', at_least=${var.latency_at_least_percentage})).publish('CRIT')
-    detect((when(signal > threshold(${var.latency_threshold_warning}), lasting='${var.latency_lasting_duration_seconds}s', at_least=${var.latency_at_least_percentage}) and when(signal <= ${var.latency_threshold_critical})), off=(when(signal <= ${var.latency_threshold_warning}, lasting='${var.latency_lasting_duration_seconds / 2}s') or when(signal >= ${var.latency_threshold_critical}, lasting='${var.latency_lasting_duration_seconds}s', at_least=${var.latency_at_least_percentage})), mode='paired').publish('WARN')
+    detect((when(signal > threshold(${var.latency_threshold_major}), lasting='${var.latency_lasting_duration_seconds}s', at_least=${var.latency_at_least_percentage}) and when(signal <= ${var.latency_threshold_critical})), off=(when(signal <= ${var.latency_threshold_major}, lasting='${var.latency_lasting_duration_seconds / 2}s') or when(signal >= ${var.latency_threshold_critical}, lasting='${var.latency_lasting_duration_seconds}s', at_least=${var.latency_at_least_percentage})), mode='paired').publish('MAJOR')
 EOF
 
   rule {
@@ -18,11 +18,11 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.latency_threshold_warning}ms"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.latency_disabled_warning, var.latency_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.latency_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.latency_threshold_major}ms"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.latency_disabled_major, var.latency_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.latency_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -36,7 +36,7 @@ resource "signalfx_detector" "http_5xx" {
     B = data('Count', filter=filter('namespace', 'AWS/ApiGateway') and filter('stat', 'sum') and (not filter('Stage', '*')) and (not filter('Method', '*')) and (not filter('Resource', '*')) and ${module.filter-tags.filter_custom}, extrapolation='zero', rollup='sum')${var.http_5xx_aggregation_function}${var.http_5xx_transformation_function}
     signal = (A/B).scale(100).fill(value=0).publish('signal')
     detect(when(signal > threshold(${var.http_5xx_threshold_critical}), lasting='${var.http_5xx_lasting_duration_seconds}s', at_least=${var.http_5xx_at_least_percentage}) and when(B > ${var.minimum_traffic})).publish('CRIT')
-    detect((when(signal > threshold(${var.http_5xx_threshold_warning}), lasting='${var.http_5xx_lasting_duration_seconds}s', at_least=${var.http_5xx_at_least_percentage}) and when(signal <= ${var.http_5xx_threshold_critical}) and when(B > ${var.minimum_traffic})), off=(when(signal <= ${var.http_5xx_threshold_warning}, lasting='${var.http_5xx_lasting_duration_seconds / 2}s') or when(signal >= ${var.http_5xx_threshold_critical}, lasting='${var.http_5xx_lasting_duration_seconds}s', at_least=${var.http_5xx_at_least_percentage})), mode='paired').publish('WARN')
+    detect((when(signal > threshold(${var.http_5xx_threshold_major}), lasting='${var.http_5xx_lasting_duration_seconds}s', at_least=${var.http_5xx_at_least_percentage}) and when(signal <= ${var.http_5xx_threshold_critical}) and when(B > ${var.minimum_traffic})), off=(when(signal <= ${var.http_5xx_threshold_major}, lasting='${var.http_5xx_lasting_duration_seconds / 2}s') or when(signal >= ${var.http_5xx_threshold_critical}, lasting='${var.http_5xx_lasting_duration_seconds}s', at_least=${var.http_5xx_at_least_percentage})), mode='paired').publish('MAJOR')
 EOF
 
   rule {
@@ -49,11 +49,11 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.http_5xx_threshold_warning}%"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.http_5xx_disabled_warning, var.http_5xx_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.http_5xx_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.http_5xx_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.http_5xx_disabled_major, var.http_5xx_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.http_5xx_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -67,7 +67,7 @@ resource "signalfx_detector" "http_4xx" {
     B = data('Count', filter=filter('namespace', 'AWS/ApiGateway') and filter('stat', 'sum') and (not filter('Stage', '*')) and (not filter('Method', '*')) and (not filter('Resource', '*')) and ${module.filter-tags.filter_custom}, extrapolation='zero', rollup='sum')${var.http_4xx_aggregation_function}${var.http_4xx_transformation_function}
     signal = (A/B).scale(100).fill(value=0).publish('signal')
     detect(when(signal > threshold(${var.http_4xx_threshold_critical}), lasting='${var.http_4xx_lasting_duration_seconds}s', at_least=${var.http_4xx_at_least_percentage}) and when(B > ${var.minimum_traffic})).publish('CRIT')
-    detect((when(signal > threshold(${var.http_4xx_threshold_warning}), lasting='${var.http_4xx_lasting_duration_seconds}s', at_least=${var.http_4xx_at_least_percentage}) and when(signal <= ${var.http_4xx_threshold_critical}) and when(B > ${var.minimum_traffic})), off=(when(signal <= ${var.http_4xx_threshold_warning}, lasting='${var.http_4xx_lasting_duration_seconds / 2}s') or when(signal >= ${var.http_4xx_threshold_critical}, lasting='${var.http_4xx_lasting_duration_seconds}s', at_least=${var.http_4xx_at_least_percentage})), mode='paired').publish('WARN')
+    detect((when(signal > threshold(${var.http_4xx_threshold_major}), lasting='${var.http_4xx_lasting_duration_seconds}s', at_least=${var.http_4xx_at_least_percentage}) and when(signal <= ${var.http_4xx_threshold_critical}) and when(B > ${var.minimum_traffic})), off=(when(signal <= ${var.http_4xx_threshold_major}, lasting='${var.http_4xx_lasting_duration_seconds / 2}s') or when(signal >= ${var.http_4xx_threshold_critical}, lasting='${var.http_4xx_lasting_duration_seconds}s', at_least=${var.http_4xx_at_least_percentage})), mode='paired').publish('MAJOR')
 EOF
 
   rule {
@@ -80,11 +80,11 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.http_4xx_threshold_warning}%"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.http_4xx_disabled_warning, var.http_4xx_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.http_4xx_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.http_4xx_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.http_4xx_disabled_major, var.http_4xx_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.http_4xx_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/aws/apigateway/variables.tf
+++ b/cloud/aws/apigateway/variables.tf
@@ -70,8 +70,8 @@ variable "latency_disabled_critical" {
   default     = null
 }
 
-variable "latency_disabled_warning" {
-  description = "Disable warning alerting rule for latency detector"
+variable "latency_disabled_major" {
+  description = "Disable major alerting rule for latency detector"
   type        = bool
   default     = null
 }
@@ -112,8 +112,8 @@ variable "latency_threshold_critical" {
   default     = 3000
 }
 
-variable "latency_threshold_warning" {
-  description = "Warning threshold for latency detector"
+variable "latency_threshold_major" {
+  description = "Major threshold for latency detector"
   type        = number
   default     = 1000
 }
@@ -132,8 +132,8 @@ variable "http_5xx_disabled_critical" {
   default     = null
 }
 
-variable "http_5xx_disabled_warning" {
-  description = "Disable warning alerting rule for http_5xx detector"
+variable "http_5xx_disabled_major" {
+  description = "Disable major alerting rule for http_5xx detector"
   type        = bool
   default     = null
 }
@@ -174,8 +174,8 @@ variable "http_5xx_threshold_critical" {
   default     = 10
 }
 
-variable "http_5xx_threshold_warning" {
-  description = "Warning threshold for http_5xx detector"
+variable "http_5xx_threshold_major" {
+  description = "Major threshold for http_5xx detector"
   type        = number
   default     = 5
 }
@@ -194,8 +194,8 @@ variable "http_4xx_disabled_critical" {
   default     = null
 }
 
-variable "http_4xx_disabled_warning" {
-  description = "Disable warning alerting rule for http_4xx detector"
+variable "http_4xx_disabled_major" {
+  description = "Disable major alerting rule for http_4xx detector"
   type        = bool
   default     = null
 }
@@ -236,8 +236,8 @@ variable "http_4xx_threshold_critical" {
   default     = 40
 }
 
-variable "http_4xx_threshold_warning" {
-  description = "Warning threshold for http_4xx detector"
+variable "http_4xx_threshold_major" {
+  description = "Major threshold for http_4xx detector"
   type        = number
   default     = 20
 }

--- a/cloud/aws/beanstalk/detectors-beanstalk.tf
+++ b/cloud/aws/beanstalk/detectors-beanstalk.tf
@@ -23,7 +23,7 @@ resource "signalfx_detector" "health" {
   program_text = <<-EOF
     signal = data('EnvironmentHealth', filter=filter('namespace', 'AWS/ElasticBeanstalk') and filter('stat', 'upper') and ${module.filter-tags.filter_custom})${var.health_aggregation_function}${var.health_transformation_function}.publish('signal')
     detect(when(signal >= ${var.health_threshold_critical})).publish('CRIT')
-    detect(when(signal >= ${var.health_threshold_warning}) and when(signal < ${var.health_threshold_critical})).publish('WARN')
+    detect(when(signal >= ${var.health_threshold_major}) and when(signal < ${var.health_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -36,11 +36,11 @@ EOF
   }
 
   rule {
-    description           = "is too high >= ${var.health_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.health_disabled_warning, var.health_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.health_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high >= ${var.health_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.health_disabled_major, var.health_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.health_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -51,7 +51,7 @@ resource "signalfx_detector" "latency_p90" {
   program_text = <<-EOF
     signal = data('ApplicationLatencyP90', filter=filter('namespace', 'AWS/ElasticBeanstalk') and filter('stat', 'lower') and (not filter('InstanceId', '*')) and ${module.filter-tags.filter_custom})${var.latency_p90_aggregation_function}${var.latency_p90_transformation_function}.publish('signal')
     detect(when(signal >= ${var.latency_p90_threshold_critical})).publish('CRIT')
-    detect(when(signal >= ${var.latency_p90_threshold_warning}) and when(signal < ${var.latency_p90_threshold_critical})).publish('WARN')
+    detect(when(signal >= ${var.latency_p90_threshold_major}) and when(signal < ${var.latency_p90_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -64,11 +64,11 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.latency_p90_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.latency_p90_disabled_warning, var.latency_p90_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.latency_p90_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.latency_p90_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.latency_p90_disabled_major, var.latency_p90_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.latency_p90_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -81,7 +81,7 @@ resource "signalfx_detector" "app_5xx_error_rate" {
     B = data('ApplicationRequestsTotal', filter=filter('namespace', 'AWS/ElasticBeanstalk') and filter('stat', 'sum') and (not filter('InstanceId', '*')) and ${module.filter-tags.filter_custom})${var.app_5xx_error_rate_aggregation_function}${var.app_5xx_error_rate_transformation_function}
     signal = (A/B).scale(100).publish('signal')
     detect(when(signal > ${var.app_5xx_error_rate_threshold_critical})).publish('CRIT')
-    detect(when(signal > ${var.app_5xx_error_rate_threshold_warning}) and when(signal <= ${var.app_5xx_error_rate_threshold_critical})).publish('WARN')
+    detect(when(signal > ${var.app_5xx_error_rate_threshold_major}) and when(signal <= ${var.app_5xx_error_rate_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -94,11 +94,11 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.app_5xx_error_rate_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.app_5xx_error_rate_disabled_warning, var.app_5xx_error_rate_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.app_5xx_error_rate_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.app_5xx_error_rate_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.app_5xx_error_rate_disabled_major, var.app_5xx_error_rate_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.app_5xx_error_rate_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -110,7 +110,7 @@ resource "signalfx_detector" "root_filesystem_usage" {
   program_text = <<-EOF
     signal = data('RootFilesystemUtil', filter=filter('namespace', 'AWS/ElasticBeanstalk') and filter('stat', 'lower') and (not filter('InstanceId', '*')) and ${module.filter-tags.filter_custom})${var.root_filesystem_usage_aggregation_function}${var.root_filesystem_usage_transformation_function}.publish('signal')
     detect(when(signal > ${var.root_filesystem_usage_threshold_critical})).publish('CRIT')
-    detect(when(signal > ${var.root_filesystem_usage_threshold_warning}) and when(signal <= ${var.root_filesystem_usage_threshold_critical})).publish('WARN')
+    detect(when(signal > ${var.root_filesystem_usage_threshold_major}) and when(signal <= ${var.root_filesystem_usage_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -123,11 +123,11 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.root_filesystem_usage_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.root_filesystem_usage_disabled_warning, var.root_filesystem_usage_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.root_filesystem_usage_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.root_filesystem_usage_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.root_filesystem_usage_disabled_major, var.root_filesystem_usage_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.root_filesystem_usage_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/aws/beanstalk/variables.tf
+++ b/cloud/aws/beanstalk/variables.tf
@@ -76,8 +76,8 @@ variable "health_disabled_critical" {
   default     = null
 }
 
-variable "health_disabled_warning" {
-  description = "Disable warning alerting rule for health detector"
+variable "health_disabled_major" {
+  description = "Disable major alerting rule for health detector"
   type        = bool
   default     = null
 }
@@ -106,8 +106,8 @@ variable "health_threshold_critical" {
   default     = 20
 }
 
-variable "health_threshold_warning" {
-  description = "Warning threshold for health detector"
+variable "health_threshold_major" {
+  description = "Major threshold for health detector"
   type        = number
   default     = 15
 }
@@ -126,8 +126,8 @@ variable "latency_p90_disabled_critical" {
   default     = null
 }
 
-variable "latency_p90_disabled_warning" {
-  description = "Disable warning alerting rule for latency_p90 detector"
+variable "latency_p90_disabled_major" {
+  description = "Disable major alerting rule for latency_p90 detector"
   type        = bool
   default     = null
 }
@@ -156,8 +156,8 @@ variable "latency_p90_threshold_critical" {
   default     = 0.5
 }
 
-variable "latency_p90_threshold_warning" {
-  description = "Warning threshold for latency_p90 detector"
+variable "latency_p90_threshold_major" {
+  description = "Major threshold for latency_p90 detector"
   type        = number
   default     = 0.3
 }
@@ -176,8 +176,8 @@ variable "app_5xx_error_rate_disabled_critical" {
   default     = null
 }
 
-variable "app_5xx_error_rate_disabled_warning" {
-  description = "Disable warning alerting rule for 5xx_error_rate detector"
+variable "app_5xx_error_rate_disabled_major" {
+  description = "Disable major alerting rule for 5xx_error_rate detector"
   type        = bool
   default     = null
 }
@@ -206,8 +206,8 @@ variable "app_5xx_error_rate_threshold_critical" {
   default     = 5
 }
 
-variable "app_5xx_error_rate_threshold_warning" {
-  description = "Warning threshold for 5xx_error_rate detector"
+variable "app_5xx_error_rate_threshold_major" {
+  description = "Major threshold for 5xx_error_rate detector"
   type        = number
   default     = 3
 }
@@ -226,8 +226,8 @@ variable "root_filesystem_usage_disabled_critical" {
   default     = null
 }
 
-variable "root_filesystem_usage_disabled_warning" {
-  description = "Disable warning alerting rule for root_filesystem_usage detector"
+variable "root_filesystem_usage_disabled_major" {
+  description = "Disable major alerting rule for root_filesystem_usage detector"
   type        = bool
   default     = null
 }
@@ -256,8 +256,8 @@ variable "root_filesystem_usage_threshold_critical" {
   default     = 90
 }
 
-variable "root_filesystem_usage_threshold_warning" {
-  description = "Warning threshold for root_filesystem_usage detector"
+variable "root_filesystem_usage_threshold_major" {
+  description = "Major threshold for root_filesystem_usage detector"
   type        = number
   default     = 80
 }

--- a/cloud/aws/ecs/cluster/detectors-ecs-cluster.tf
+++ b/cloud/aws/ecs/cluster/detectors-ecs-cluster.tf
@@ -23,7 +23,7 @@ resource "signalfx_detector" "cpu_utilization" {
   program_text = <<-EOF
     signal = data('CPUUtilization', filter=filter('namespace', 'AWS/ECS') and filter('stat', 'mean') and not filter('ServiceName', '*') and ${module.filter-tags.filter_custom}).mean(by=['ClusterName'])${var.cpu_utilization_aggregation_function}${var.cpu_utilization_transformation_function}.publish('signal')
     detect(when(signal > ${var.cpu_utilization_threshold_critical})).publish('CRIT')
-    detect(when(signal > ${var.cpu_utilization_threshold_warning}) and when(signal <= ${var.cpu_utilization_threshold_critical})).publish('WARN')
+    detect(when(signal > ${var.cpu_utilization_threshold_major}) and when(signal <= ${var.cpu_utilization_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -36,11 +36,11 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.cpu_utilization_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.cpu_utilization_disabled_warning, var.cpu_utilization_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.cpu_utilization_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.cpu_utilization_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.cpu_utilization_disabled_major, var.cpu_utilization_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.cpu_utilization_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -51,7 +51,7 @@ resource "signalfx_detector" "memory_utilization" {
   program_text = <<-EOF
     signal = data('MemoryUtilization', filter=filter('namespace', 'AWS/ECS') and filter('stat', 'mean') and not filter('ServiceName', '*') and ${module.filter-tags.filter_custom}).mean(by=['ClusterName'])${var.memory_utilization_aggregation_function}${var.memory_utilization_transformation_function}.publish('signal')
     detect(when(signal > ${var.memory_utilization_threshold_critical})).publish('CRIT')
-    detect(when(signal > ${var.memory_utilization_threshold_warning}) and when(signal <= ${var.memory_utilization_threshold_critical})).publish('WARN')
+    detect(when(signal > ${var.memory_utilization_threshold_major}) and when(signal <= ${var.memory_utilization_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -64,11 +64,11 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.memory_utilization_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.memory_utilization_disabled_warning, var.memory_utilization_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.memory_utilization_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.memory_utilization_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.memory_utilization_disabled_major, var.memory_utilization_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.memory_utilization_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/aws/ecs/cluster/variables.tf
+++ b/cloud/aws/ecs/cluster/variables.tf
@@ -76,8 +76,8 @@ variable "cpu_utilization_disabled_critical" {
   default     = null
 }
 
-variable "cpu_utilization_disabled_warning" {
-  description = "Disable warning alerting rule for cpu_utilization detector"
+variable "cpu_utilization_disabled_major" {
+  description = "Disable major alerting rule for cpu_utilization detector"
   type        = bool
   default     = null
 }
@@ -106,8 +106,8 @@ variable "cpu_utilization_threshold_critical" {
   default     = 90
 }
 
-variable "cpu_utilization_threshold_warning" {
-  description = "Warning threshold for cpu_utilization detector"
+variable "cpu_utilization_threshold_major" {
+  description = "Major threshold for cpu_utilization detector"
   type        = number
   default     = 85
 }
@@ -126,8 +126,8 @@ variable "memory_utilization_disabled_critical" {
   default     = null
 }
 
-variable "memory_utilization_disabled_warning" {
-  description = "Disable warning alerting rule for memory_utilization detector"
+variable "memory_utilization_disabled_major" {
+  description = "Disable major alerting rule for memory_utilization detector"
   type        = bool
   default     = null
 }
@@ -156,8 +156,8 @@ variable "memory_utilization_threshold_critical" {
   default     = 90
 }
 
-variable "memory_utilization_threshold_warning" {
-  description = "Warning threshold for memory_utilization detector"
+variable "memory_utilization_threshold_major" {
+  description = "Major threshold for memory_utilization detector"
   type        = number
   default     = 85
 }

--- a/cloud/aws/ecs/service/detectors-ecs-service.tf
+++ b/cloud/aws/ecs/service/detectors-ecs-service.tf
@@ -24,7 +24,7 @@ resource "signalfx_detector" "cpu_utilization" {
   program_text = <<-EOF
     signal = data('CPUUtilization', filter=filter('namespace', 'AWS/ECS') and filter('stat', 'mean') and filter('ServiceName', '*') and ${module.filter-tags.filter_custom}).mean(by=['ServiceName'])${var.cpu_utilization_aggregation_function}${var.cpu_utilization_transformation_function}.publish('signal')
     detect(when(signal > ${var.cpu_utilization_threshold_critical})).publish('CRIT')
-    detect(when(signal > ${var.cpu_utilization_threshold_warning}) and when(signal <= ${var.cpu_utilization_threshold_critical})).publish('WARN')
+    detect(when(signal > ${var.cpu_utilization_threshold_major}) and when(signal <= ${var.cpu_utilization_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -37,11 +37,11 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.cpu_utilization_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.cpu_utilization_disabled_warning, var.cpu_utilization_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.cpu_utilization_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.cpu_utilization_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.cpu_utilization_disabled_major, var.cpu_utilization_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.cpu_utilization_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -52,7 +52,7 @@ resource "signalfx_detector" "memory_utilization" {
   program_text = <<-EOF
     signal = data('Memoryutilization', filter=filter('namespace', 'AWS/ECS') and filter('stat', 'mean') and filter('ServiceName', '*') and ${module.filter-tags.filter_custom}).mean(by=['ServiceName'])${var.memory_utilization_aggregation_function}${var.memory_utilization_transformation_function}.publish('signal')
     detect(when(signal > ${var.memory_utilization_threshold_critical})).publish('CRIT')
-    detect(when(signal > ${var.memory_utilization_threshold_warning}) and when(signal <= ${var.memory_utilization_threshold_critical})).publish('WARN')
+    detect(when(signal > ${var.memory_utilization_threshold_major}) and when(signal <= ${var.memory_utilization_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -65,11 +65,11 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.memory_utilization_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.memory_utilization_disabled_warning, var.memory_utilization_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.memory_utilization_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.memory_utilization_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.memory_utilization_disabled_major, var.memory_utilization_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.memory_utilization_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/aws/ecs/service/variables.tf
+++ b/cloud/aws/ecs/service/variables.tf
@@ -76,8 +76,8 @@ variable "cpu_utilization_disabled_critical" {
   default     = null
 }
 
-variable "cpu_utilization_disabled_warning" {
-  description = "Disable warning alerting rule for cpu_utilization detector"
+variable "cpu_utilization_disabled_major" {
+  description = "Disable major alerting rule for cpu_utilization detector"
   type        = bool
   default     = null
 }
@@ -106,8 +106,8 @@ variable "cpu_utilization_threshold_critical" {
   default     = 90
 }
 
-variable "cpu_utilization_threshold_warning" {
-  description = "Warning threshold for cpu_utilization detector"
+variable "cpu_utilization_threshold_major" {
+  description = "Major threshold for cpu_utilization detector"
   type        = number
   default     = 80
 }
@@ -126,8 +126,8 @@ variable "memory_utilization_disabled_critical" {
   default     = null
 }
 
-variable "memory_utilization_disabled_warning" {
-  description = "Disable warning alerting rule for memory_utilization detector"
+variable "memory_utilization_disabled_major" {
+  description = "Disable major alerting rule for memory_utilization detector"
   type        = bool
   default     = null
 }
@@ -156,8 +156,8 @@ variable "memory_utilization_threshold_critical" {
   default     = 90
 }
 
-variable "memory_utilization_threshold_warning" {
-  description = "Warning threshold for memory_utilization detector"
+variable "memory_utilization_threshold_major" {
+  description = "Major threshold for memory_utilization detector"
   type        = number
   default     = 85
 }

--- a/cloud/aws/elasticache/common/detectors-elasticache.tf
+++ b/cloud/aws/elasticache/common/detectors-elasticache.tf
@@ -23,7 +23,7 @@ resource "signalfx_detector" "evictions" {
   program_text = <<-EOF
     signal = data('Evictions', filter=filter('namespace', 'AWS/ElastiCache') and filter('stat', 'mean') and filter('CacheNodeId', '*') and ${module.filter-tags.filter_custom})${var.evictions_aggregation_function}${var.evictions_transformation_function}.publish('signal')
     detect(when(signal > ${var.evictions_threshold_critical})).publish('CRIT')
-    detect(when(signal > ${var.evictions_threshold_warning}) and when(signal <= ${var.evictions_threshold_critical})).publish('WARN')
+    detect(when(signal > ${var.evictions_threshold_major}) and when(signal <= ${var.evictions_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -36,11 +36,11 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.evictions_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.evictions_disabled_warning, var.evictions_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.evictions_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.evictions_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.evictions_disabled_major, var.evictions_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.evictions_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -87,7 +87,7 @@ resource "signalfx_detector" "swap" {
   program_text = <<-EOF
     signal = data('SwapUsage', filter=filter('namespace', 'AWS/ElastiCache') and filter('stat', 'upper') and filter('CacheNodeId', '*') and ${module.filter-tags.filter_custom})${var.swap_aggregation_function}${var.swap_transformation_function}.publish('signal')
     detect(when(signal > ${var.swap_threshold_critical})).publish('CRIT')
-    detect(when(signal > ${var.swap_threshold_warning}) and when(signal <= ${var.swap_threshold_critical})).publish('WARN')
+    detect(when(signal > ${var.swap_threshold_major}) and when(signal <= ${var.swap_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -100,11 +100,11 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.swap_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.swap_disabled_warning, var.swap_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.swap_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.swap_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.swap_disabled_major, var.swap_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.swap_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -115,7 +115,7 @@ resource "signalfx_detector" "free_memory" {
   program_text = <<-EOF
     signal = data('FreeableMemory', filter=filter('namespace', 'AWS/ElastiCache') and filter('stat', 'lower') and filter('CacheNodeId', '*') and ${module.filter-tags.filter_custom}).rateofchange()${var.free_memory_aggregation_function}${var.free_memory_transformation_function}.publish('signal')
     detect(when(signal < ${var.free_memory_threshold_critical})).publish('CRIT')
-    detect(when(signal < ${var.free_memory_threshold_warning}) and when(signal >= ${var.free_memory_threshold_critical})).publish('WARN')
+    detect(when(signal < ${var.free_memory_threshold_major}) and when(signal >= ${var.free_memory_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -128,11 +128,11 @@ EOF
   }
 
   rule {
-    description           = "is too low < ${var.free_memory_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.free_memory_disabled_warning, var.free_memory_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.free_memory_notifications, "warning", []), var.notifications.warning)
+    description           = "is too low < ${var.free_memory_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.free_memory_disabled_major, var.free_memory_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.free_memory_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -143,7 +143,7 @@ resource "signalfx_detector" "evictions_growing" {
   program_text = <<-EOF
     signal = data('Evictions', filter=filter('namespace', 'AWS/ElastiCache') and filter('stat', 'mean') and filter('CacheNodeId', '*') and ${module.filter-tags.filter_custom})${var.evictions_growing_aggregation_function}${var.evictions_growing_transformation_function}.rateofchange().scale(100).publish('signal')
     detect(when(signal > ${var.evictions_growing_threshold_critical})).publish('CRIT')
-    detect(when(signal > ${var.evictions_growing_threshold_warning}) and when(signal <= ${var.evictions_growing_threshold_critical})).publish('WARN')
+    detect(when(signal > ${var.evictions_growing_threshold_major}) and when(signal <= ${var.evictions_growing_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -156,11 +156,11 @@ EOF
   }
 
   rule {
-    description           = "too fast > ${var.evictions_growing_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.evictions_growing_disabled_warning, var.evictions_growing_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.evictions_growing_notifications, "warning", []), var.notifications.warning)
+    description           = "too fast > ${var.evictions_growing_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.evictions_growing_disabled_major, var.evictions_growing_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.evictions_growing_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/aws/elasticache/common/variables.tf
+++ b/cloud/aws/elasticache/common/variables.tf
@@ -76,8 +76,8 @@ variable "evictions_disabled_critical" {
   default     = null
 }
 
-variable "evictions_disabled_warning" {
-  description = "Disable warning alerting rule for evictions detector"
+variable "evictions_disabled_major" {
+  description = "Disable major alerting rule for evictions detector"
   type        = bool
   default     = null
 }
@@ -106,8 +106,8 @@ variable "evictions_threshold_critical" {
   default     = 30
 }
 
-variable "evictions_threshold_warning" {
-  description = "Warning threshold for evictions detector"
+variable "evictions_threshold_major" {
+  description = "Major threshold for evictions detector"
   type        = number
   default     = 0
 }
@@ -202,8 +202,8 @@ variable "swap_disabled_critical" {
   default     = null
 }
 
-variable "swap_disabled_warning" {
-  description = "Disable warning alerting rule for swap detector"
+variable "swap_disabled_major" {
+  description = "Disable major alerting rule for swap detector"
   type        = bool
   default     = null
 }
@@ -232,8 +232,8 @@ variable "swap_threshold_critical" {
   default     = 50000000
 }
 
-variable "swap_threshold_warning" {
-  description = "Warning threshold for swap detector"
+variable "swap_threshold_major" {
+  description = "Major threshold for swap detector"
   type        = number
   default     = 0
 }
@@ -252,8 +252,8 @@ variable "free_memory_disabled_critical" {
   default     = null
 }
 
-variable "free_memory_disabled_warning" {
-  description = "Disable warning alerting rule for free_memory detector"
+variable "free_memory_disabled_major" {
+  description = "Disable major alerting rule for free_memory detector"
   type        = bool
   default     = null
 }
@@ -282,8 +282,8 @@ variable "free_memory_threshold_critical" {
   default     = -70
 }
 
-variable "free_memory_threshold_warning" {
-  description = "Warning threshold for free_memory detector"
+variable "free_memory_threshold_major" {
+  description = "Major threshold for free_memory detector"
   type        = number
   default     = -50
 }
@@ -302,8 +302,8 @@ variable "evictions_growing_disabled_critical" {
   default     = null
 }
 
-variable "evictions_growing_disabled_warning" {
-  description = "Disable warning alerting rule for evictions_growing detector"
+variable "evictions_growing_disabled_major" {
+  description = "Disable major alerting rule for evictions_growing detector"
   type        = bool
   default     = null
 }
@@ -332,8 +332,8 @@ variable "evictions_growing_threshold_critical" {
   default     = 30
 }
 
-variable "evictions_growing_threshold_warning" {
-  description = "Warning threshold for evictions_growing detector"
+variable "evictions_growing_threshold_major" {
+  description = "Major threshold for evictions_growing detector"
   type        = number
   default     = 10
 }

--- a/cloud/aws/elasticache/memcached/detectors-memcached.tf
+++ b/cloud/aws/elasticache/memcached/detectors-memcached.tf
@@ -6,7 +6,7 @@ resource "signalfx_detector" "hit_ratio" {
     B = data('GetMisses', filter=filter('namespace', 'AWS/ElastiCache') and filter('stat', 'mean') and filter('CacheNodeId', '*') and ${module.filter-tags.filter_custom}, extrapolation='zero', rollup='sum')${var.hit_ratio_aggregation_function}${var.hit_ratio_transformation_function}
     signal = (A / (A+B)).fill(value=1).scale(100).publish('signal')
     detect(when(signal < threshold(${var.hit_ratio_threshold_critical}), lasting='${var.hit_ratio_lasting_duration_seconds}s', at_least=${var.hit_ratio_at_least_percentage})).publish('CRIT')
-    detect((when(signal < threshold(${var.hit_ratio_threshold_warning}), lasting='${var.hit_ratio_lasting_duration_seconds}s', at_least=${var.hit_ratio_at_least_percentage}) and when(signal >= ${var.hit_ratio_threshold_critical})), off=(when(signal >= ${var.hit_ratio_threshold_warning}, lasting='${var.hit_ratio_lasting_duration_seconds / 2}s') or when(signal <= ${var.hit_ratio_threshold_critical}, lasting='${var.hit_ratio_lasting_duration_seconds}s', at_least=${var.hit_ratio_at_least_percentage})), mode='paired').publish('WARN')
+    detect((when(signal < threshold(${var.hit_ratio_threshold_major}), lasting='${var.hit_ratio_lasting_duration_seconds}s', at_least=${var.hit_ratio_at_least_percentage}) and when(signal >= ${var.hit_ratio_threshold_critical})), off=(when(signal >= ${var.hit_ratio_threshold_major}, lasting='${var.hit_ratio_lasting_duration_seconds / 2}s') or when(signal <= ${var.hit_ratio_threshold_critical}, lasting='${var.hit_ratio_lasting_duration_seconds}s', at_least=${var.hit_ratio_at_least_percentage})), mode='paired').publish('MAJOR')
 EOF
 
   rule {
@@ -19,11 +19,11 @@ EOF
   }
 
   rule {
-    description           = "is too low < ${var.hit_ratio_threshold_warning}%"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.hit_ratio_disabled_warning, var.hit_ratio_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.hit_ratio_notifications, "warning", []), var.notifications.warning)
+    description           = "is too low < ${var.hit_ratio_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.hit_ratio_disabled_major, var.hit_ratio_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.hit_ratio_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -34,7 +34,7 @@ resource "signalfx_detector" "cpu" {
   program_text = <<-EOF
     signal = data('CPUUtilization', filter=filter('namespace', 'AWS/ElastiCache') and filter('stat', 'mean') and filter('CacheNodeId', '*') and ${module.filter-tags.filter_custom})${var.cpu_aggregation_function}${var.cpu_transformation_function}.publish('signal')
     detect(when(signal > ${var.cpu_threshold_critical})).publish('CRIT')
-    detect(when(signal > ${var.cpu_threshold_warning}) and when(signal <= ${var.cpu_threshold_critical})).publish('WARN')
+    detect(when(signal > ${var.cpu_threshold_major}) and when(signal <= ${var.cpu_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -47,11 +47,11 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.cpu_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.cpu_disabled_warning, var.cpu_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.cpu_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.cpu_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.cpu_disabled_major, var.cpu_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.cpu_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/aws/elasticache/memcached/variables.tf
+++ b/cloud/aws/elasticache/memcached/variables.tf
@@ -58,8 +58,8 @@ variable "hit_ratio_disabled_critical" {
   default     = null
 }
 
-variable "hit_ratio_disabled_warning" {
-  description = "Disable warning alerting rule for hit_ratio detector"
+variable "hit_ratio_disabled_major" {
+  description = "Disable major alerting rule for hit_ratio detector"
   type        = bool
   default     = null
 }
@@ -100,8 +100,8 @@ variable "hit_ratio_threshold_critical" {
   default     = 60
 }
 
-variable "hit_ratio_threshold_warning" {
-  description = "Warning threshold for hit_ratio detector"
+variable "hit_ratio_threshold_major" {
+  description = "Major threshold for hit_ratio detector"
   type        = number
   default     = 80
 }
@@ -120,8 +120,8 @@ variable "cpu_disabled_critical" {
   default     = null
 }
 
-variable "cpu_disabled_warning" {
-  description = "Disable warning alerting rule for httpcode 5xx erros detector"
+variable "cpu_disabled_major" {
+  description = "Disable major alerting rule for httpcode 5xx erros detector"
   type        = bool
   default     = null
 }
@@ -150,8 +150,8 @@ variable "cpu_threshold_critical" {
   default     = 90
 }
 
-variable "cpu_threshold_warning" {
-  description = "Warning threshold for cpu detector"
+variable "cpu_threshold_major" {
+  description = "Major threshold for cpu detector"
   type        = number
   default     = 75
 }

--- a/cloud/aws/elasticache/redis/variables.tf
+++ b/cloud/aws/elasticache/redis/variables.tf
@@ -58,8 +58,8 @@ variable "cache_hits_disabled_critical" {
   default     = null
 }
 
-variable "cache_hits_disabled_warning" {
-  description = "Disable warning alerting rule for cache_hits detector"
+variable "cache_hits_disabled_major" {
+  description = "Disable major alerting rule for cache_hits detector"
   type        = bool
   default     = null
 }
@@ -100,8 +100,8 @@ variable "cache_hits_threshold_critical" {
   default     = 60
 }
 
-variable "cache_hits_threshold_warning" {
-  description = "Warning threshold for cache_hits detector"
+variable "cache_hits_threshold_major" {
+  description = "Major threshold for cache_hits detector"
   type        = number
   default     = 80
 }
@@ -120,8 +120,8 @@ variable "cpu_high_disabled_critical" {
   default     = null
 }
 
-variable "cpu_high_disabled_warning" {
-  description = "Disable warning alerting rule for httpcode 5xx erros detector"
+variable "cpu_high_disabled_major" {
+  description = "Disable major alerting rule for httpcode 5xx erros detector"
   type        = bool
   default     = null
 }
@@ -150,8 +150,8 @@ variable "cpu_high_threshold_critical" {
   default     = 90
 }
 
-variable "cpu_high_threshold_warning" {
-  description = "Warning threshold for cpu_high detector"
+variable "cpu_high_threshold_major" {
+  description = "Major threshold for cpu_high detector"
   type        = number
   default     = 75
 }
@@ -170,8 +170,8 @@ variable "replication_lag_disabled_critical" {
   default     = null
 }
 
-variable "replication_lag_disabled_warning" {
-  description = "Disable warning alerting rule for replication_lag detector"
+variable "replication_lag_disabled_major" {
+  description = "Disable major alerting rule for replication_lag detector"
   type        = bool
   default     = null
 }
@@ -200,8 +200,8 @@ variable "replication_lag_threshold_critical" {
   default     = 180
 }
 
-variable "replication_lag_threshold_warning" {
-  description = "Warning threshold for replication_lag detector"
+variable "replication_lag_threshold_major" {
+  description = "Major threshold for replication_lag detector"
   type        = number
   default     = 90
 }
@@ -220,8 +220,8 @@ variable "commands_disabled_critical" {
   default     = null
 }
 
-variable "commands_disabled_warning" {
-  description = "Disable warning alerting rule for commands detector"
+variable "commands_disabled_major" {
+  description = "Disable major alerting rule for commands detector"
   type        = bool
   default     = null
 }
@@ -251,8 +251,8 @@ variable "commands_threshold_critical" {
   default = -1 # impossible to raise alert by default but make it possible to customize
 }
 
-variable "commands_threshold_warning" {
-  description = "Warning threshold for commands detector"
+variable "commands_threshold_major" {
+  description = "Major threshold for commands detector"
   type        = number
   default     = 0
 }

--- a/cloud/aws/elasticsearch/detectors-elasticsearch.tf
+++ b/cloud/aws/elasticsearch/detectors-elasticsearch.tf
@@ -24,7 +24,7 @@ resource "signalfx_detector" "cluster_status" {
     A = data('ClusterStatus.red', filter=filter('namespace', 'AWS/ES') and filter('stat', 'upper') and ${module.filter-tags.filter_custom})${var.cluster_status_aggregation_function}${var.cluster_status_transformation_function}.publish('A')
     B = data('ClusterStatus.yellow', filter=filter('namespace', 'AWS/ES') and filter('stat', 'upper') and ${module.filter-tags.filter_custom})${var.cluster_status_aggregation_function}${var.cluster_status_transformation_function}.publish('B')
     detect(when(A >= 1)).publish('CRIT')
-    detect(when(B >= 1)).publish('WARN')
+    detect(when(B >= 1)).publish('MAJOR')
 EOF
 
   rule {
@@ -38,10 +38,10 @@ EOF
 
   rule {
     description           = "is yellow"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.cluster_status_disabled_warning, var.cluster_status_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.cluster_status_notifications, "warning", []), var.notifications.warning)
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.cluster_status_disabled_major, var.cluster_status_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.cluster_status_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
 }
@@ -52,7 +52,7 @@ resource "signalfx_detector" "free_space" {
   program_text = <<-EOF
     signal = data('FreeStorageSpace', filter=filter('namespace', 'AWS/ES') and filter('stat', 'lower') and filter('NodeId', '*') and ${module.filter-tags.filter_custom})${var.free_space_aggregation_function}${var.free_space_transformation_function}.publish('signal')
     detect(when(signal < ${var.free_space_threshold_critical})).publish('CRIT')
-    detect(when(signal < ${var.free_space_threshold_warning}) and when(signal >= ${var.free_space_threshold_critical})).publish('WARN')
+    detect(when(signal < ${var.free_space_threshold_major}) and when(signal >= ${var.free_space_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -65,11 +65,11 @@ EOF
   }
 
   rule {
-    description           = "is too low < ${var.free_space_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.free_space_disabled_warning, var.free_space_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.free_space_notifications, "warning", []), var.notifications.warning)
+    description           = "is too low < ${var.free_space_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.free_space_disabled_major, var.free_space_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.free_space_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -80,7 +80,7 @@ resource "signalfx_detector" "cpu_90_15min" {
   program_text = <<-EOF
     signal = data('CPUUtilization', filter=filter('namespace', 'AWS/ES') and filter('stat', 'upper') and filter('NodeId', '*') and ${module.filter-tags.filter_custom})${var.cpu_90_15min_aggregation_function}${var.cpu_90_15min_transformation_function}.publish('signal')
     detect(when(signal > ${var.cpu_90_15min_threshold_critical})).publish('CRIT')
-    detect(when(signal > ${var.cpu_90_15min_threshold_warning}) and when(signal <= ${var.cpu_90_15min_threshold_critical})).publish('WARN')
+    detect(when(signal > ${var.cpu_90_15min_threshold_major}) and when(signal <= ${var.cpu_90_15min_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -93,11 +93,11 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.cpu_90_15min_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.cpu_90_15min_disabled_warning, var.cpu_90_15min_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.cpu_90_15min_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.cpu_90_15min_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.cpu_90_15min_disabled_major, var.cpu_90_15min_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.cpu_90_15min_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/aws/elasticsearch/variables.tf
+++ b/cloud/aws/elasticsearch/variables.tf
@@ -76,8 +76,8 @@ variable "cluster_status_disabled_critical" {
   default     = null
 }
 
-variable "cluster_status_disabled_warning" {
-  description = "Disable warning alerting rule for cluster_status detector"
+variable "cluster_status_disabled_major" {
+  description = "Disable major alerting rule for cluster_status detector"
   type        = bool
   default     = null
 }
@@ -114,8 +114,8 @@ variable "free_space_disabled_critical" {
   default     = null
 }
 
-variable "free_space_disabled_warning" {
-  description = "Disable warning alerting rule for free_space detector"
+variable "free_space_disabled_major" {
+  description = "Disable major alerting rule for free_space detector"
   type        = bool
   default     = null
 }
@@ -144,8 +144,8 @@ variable "free_space_threshold_critical" {
   default     = 20480
 }
 
-variable "free_space_threshold_warning" {
-  description = "Warning threshold for free_space detector"
+variable "free_space_threshold_major" {
+  description = "Major threshold for free_space detector"
   type        = number
   default     = 40960
 }
@@ -164,8 +164,8 @@ variable "cpu_90_15min_disabled_critical" {
   default     = null
 }
 
-variable "cpu_90_15min_disabled_warning" {
-  description = "Disable warning alerting rule for cpu_90_15min detector"
+variable "cpu_90_15min_disabled_major" {
+  description = "Disable major alerting rule for cpu_90_15min detector"
   type        = bool
   default     = null
 }
@@ -194,8 +194,8 @@ variable "cpu_90_15min_threshold_critical" {
   default     = 90
 }
 
-variable "cpu_90_15min_threshold_warning" {
-  description = "Warning threshold for cpu_90_15min detector"
+variable "cpu_90_15min_threshold_major" {
+  description = "Major threshold for cpu_90_15min detector"
   type        = number
   default     = 80
 }

--- a/cloud/aws/elb/detectors-elb.tf
+++ b/cloud/aws/elb/detectors-elb.tf
@@ -25,7 +25,7 @@ resource "signalfx_detector" "no_healthy_instances" {
     B = data('UnHealthyHostCount', filter=filter('namespace', 'AWS/ELB') and filter('stat', 'upper') and (not filter('AvailabilityZone', '*')) and filter('LoadBalancerName', '*') and ${module.filter-tags.filter_custom})${var.no_healthy_instances_aggregation_function}${var.no_healthy_instances_transformation_function}
     signal = (A / (A+B)).scale(100).publish('signal')
     detect(when(signal < ${var.no_healthy_instances_threshold_critical})).publish('CRIT')
-    detect(when(signal < ${var.no_healthy_instances_threshold_warning}) and when(signal >= ${var.no_healthy_instances_threshold_critical})).publish('WARN')
+    detect(when(signal < ${var.no_healthy_instances_threshold_major}) and when(signal >= ${var.no_healthy_instances_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -38,11 +38,11 @@ EOF
   }
 
   rule {
-    description           = "is below nominal capacity < ${var.no_healthy_instances_threshold_warning}%"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.no_healthy_instances_disabled_warning, var.no_healthy_instances_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.no_healthy_instances_notifications, "warning", []), var.notifications.warning)
+    description           = "is below nominal capacity < ${var.no_healthy_instances_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.no_healthy_instances_disabled_major, var.no_healthy_instances_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.no_healthy_instances_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -55,7 +55,7 @@ resource "signalfx_detector" "elb_4xx" {
     B = data('RequestCount', filter=filter('namespace', 'AWS/ELB') and filter('stat', 'sum') and (not filter('AvailabilityZone', '*')) and filter('LoadBalancerName', '*') and ${module.filter-tags.filter_custom}, rollup='sum', extrapolation='zero')${var.elb_4xx_aggregation_function}${var.elb_4xx_transformation_function}
     signal = (A/B).scale(100).fill(value=0).publish('signal')
     detect(when(signal > threshold(${var.elb_4xx_threshold_critical}), lasting='${var.elb_4xx_lasting_duration_seconds}s', at_least=${var.elb_4xx_at_least_percentage}) and when(B > ${var.minimum_traffic})).publish('CRIT')
-    detect((when(signal > threshold(${var.elb_4xx_threshold_warning}), lasting='${var.elb_4xx_lasting_duration_seconds}s', at_least=${var.elb_4xx_at_least_percentage}) and when(signal <= ${var.elb_4xx_threshold_critical}) and when(B > ${var.minimum_traffic})), off=(when(signal <= ${var.elb_4xx_threshold_warning}, lasting='${var.elb_4xx_lasting_duration_seconds / 2}s') or when(signal >= ${var.elb_4xx_threshold_critical}, lasting='${var.elb_4xx_lasting_duration_seconds}s', at_least=${var.elb_4xx_at_least_percentage})), mode='paired').publish('WARN')
+    detect((when(signal > threshold(${var.elb_4xx_threshold_major}), lasting='${var.elb_4xx_lasting_duration_seconds}s', at_least=${var.elb_4xx_at_least_percentage}) and when(signal <= ${var.elb_4xx_threshold_critical}) and when(B > ${var.minimum_traffic})), off=(when(signal <= ${var.elb_4xx_threshold_major}, lasting='${var.elb_4xx_lasting_duration_seconds / 2}s') or when(signal >= ${var.elb_4xx_threshold_critical}, lasting='${var.elb_4xx_lasting_duration_seconds}s', at_least=${var.elb_4xx_at_least_percentage})), mode='paired').publish('MAJOR')
 EOF
 
   rule {
@@ -68,11 +68,11 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.elb_4xx_threshold_warning}%"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.elb_4xx_disabled_warning, var.elb_4xx_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.elb_4xx_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.elb_4xx_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.elb_4xx_disabled_major, var.elb_4xx_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.elb_4xx_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -85,7 +85,7 @@ resource "signalfx_detector" "elb_5xx" {
     B = data('RequestCount', filter=filter('namespace', 'AWS/ELB') and filter('stat', 'sum') and (not filter('AvailabilityZone', '*')) and filter('LoadBalancerName', '*') and ${module.filter-tags.filter_custom}, rollup='sum', extrapolation='zero')${var.elb_5xx_aggregation_function}${var.elb_5xx_transformation_function}
     signal = (A/B).scale(100).fill(value=0).publish('signal')
     detect(when(signal > threshold(${var.elb_5xx_threshold_critical}), lasting='${var.elb_5xx_lasting_duration_seconds}s', at_least=${var.elb_5xx_at_least_percentage}) and when(B > ${var.minimum_traffic})).publish('CRIT')
-    detect((when(signal > threshold(${var.elb_5xx_threshold_warning}), lasting='${var.elb_5xx_lasting_duration_seconds}s', at_least=${var.elb_5xx_at_least_percentage}) and when(signal <= ${var.elb_5xx_threshold_critical}) and when(B > ${var.minimum_traffic})), off=(when(signal <= ${var.elb_5xx_threshold_warning}, lasting='${var.elb_5xx_lasting_duration_seconds / 2}s') or when(signal >= ${var.elb_5xx_threshold_critical}, lasting='${var.elb_5xx_lasting_duration_seconds}s', at_least=${var.elb_5xx_at_least_percentage})), mode='paired').publish('WARN')
+    detect((when(signal > threshold(${var.elb_5xx_threshold_major}), lasting='${var.elb_5xx_lasting_duration_seconds}s', at_least=${var.elb_5xx_at_least_percentage}) and when(signal <= ${var.elb_5xx_threshold_critical}) and when(B > ${var.minimum_traffic})), off=(when(signal <= ${var.elb_5xx_threshold_major}, lasting='${var.elb_5xx_lasting_duration_seconds / 2}s') or when(signal >= ${var.elb_5xx_threshold_critical}, lasting='${var.elb_5xx_lasting_duration_seconds}s', at_least=${var.elb_5xx_at_least_percentage})), mode='paired').publish('MAJOR')
 EOF
 
   rule {
@@ -98,11 +98,11 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.elb_5xx_threshold_warning}%"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.elb_5xx_disabled_warning, var.elb_5xx_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.elb_5xx_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.elb_5xx_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.elb_5xx_disabled_major, var.elb_5xx_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.elb_5xx_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -115,7 +115,7 @@ resource "signalfx_detector" "backend_4xx" {
     B = data('RequestCount', filter=filter('namespace', 'AWS/ELB') and filter('stat', 'sum') and (not filter('AvailabilityZone', '*')) and filter('LoadBalancerName', '*') and ${module.filter-tags.filter_custom}, rollup='sum', extrapolation='zero')${var.backend_4xx_aggregation_function}${var.backend_4xx_transformation_function}
     signal = (A/B).scale(100).fill(value=0).publish('signal')
     detect(when(signal > threshold(${var.backend_4xx_threshold_critical}), lasting='${var.backend_4xx_lasting_duration_seconds}s', at_least=${var.backend_4xx_at_least_percentage}) and when(B > ${var.minimum_traffic})).publish('CRIT')
-    detect((when(signal > threshold(${var.backend_4xx_threshold_warning}), lasting='${var.backend_4xx_lasting_duration_seconds}s', at_least=${var.backend_4xx_at_least_percentage}) and when(signal <= ${var.backend_4xx_threshold_critical}) and when(B > ${var.minimum_traffic})), off=(when(signal <= ${var.backend_4xx_threshold_warning}, lasting='${var.backend_4xx_lasting_duration_seconds / 2}s') or when(signal >= ${var.backend_4xx_threshold_critical}, lasting='${var.backend_4xx_lasting_duration_seconds}s', at_least=${var.backend_4xx_at_least_percentage})), mode='paired').publish('WARN')
+    detect((when(signal > threshold(${var.backend_4xx_threshold_major}), lasting='${var.backend_4xx_lasting_duration_seconds}s', at_least=${var.backend_4xx_at_least_percentage}) and when(signal <= ${var.backend_4xx_threshold_critical}) and when(B > ${var.minimum_traffic})), off=(when(signal <= ${var.backend_4xx_threshold_major}, lasting='${var.backend_4xx_lasting_duration_seconds / 2}s') or when(signal >= ${var.backend_4xx_threshold_critical}, lasting='${var.backend_4xx_lasting_duration_seconds}s', at_least=${var.backend_4xx_at_least_percentage})), mode='paired').publish('MAJOR')
 EOF
 
   rule {
@@ -128,11 +128,11 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.backend_4xx_threshold_warning}%"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.backend_4xx_disabled_warning, var.backend_4xx_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.backend_4xx_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.backend_4xx_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.backend_4xx_disabled_major, var.backend_4xx_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.backend_4xx_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -145,7 +145,7 @@ resource "signalfx_detector" "backend_5xx" {
     B = data('RequestCount', filter=filter('namespace', 'AWS/ELB') and filter('stat', 'sum') and (not filter('AvailabilityZone', '*')) and filter('LoadBalancerName', '*') and ${module.filter-tags.filter_custom}, extrapolation='zero', rollup='sum')${var.backend_5xx_aggregation_function}${var.backend_5xx_transformation_function}
     signal = (A/B).scale(100).fill(value=0).publish('signal')
     detect(when(signal > threshold(${var.backend_5xx_threshold_critical}), lasting='${var.backend_5xx_lasting_duration_seconds}s', at_least=${var.backend_5xx_at_least_percentage}) and when(B > ${var.minimum_traffic})).publish('CRIT')
-    detect((when(signal > threshold(${var.backend_5xx_threshold_warning}), lasting='${var.backend_5xx_lasting_duration_seconds}s', at_least=${var.backend_5xx_at_least_percentage}) and when(signal <= ${var.backend_5xx_threshold_critical}) and when(B > ${var.minimum_traffic})), off=(when(signal <= ${var.backend_5xx_threshold_warning}, lasting='${var.backend_5xx_lasting_duration_seconds / 2}s') or when(signal >= ${var.backend_5xx_threshold_critical}, lasting='${var.backend_5xx_lasting_duration_seconds}s', at_least=${var.backend_5xx_at_least_percentage})), mode='paired').publish('WARN')
+    detect((when(signal > threshold(${var.backend_5xx_threshold_major}), lasting='${var.backend_5xx_lasting_duration_seconds}s', at_least=${var.backend_5xx_at_least_percentage}) and when(signal <= ${var.backend_5xx_threshold_critical}) and when(B > ${var.minimum_traffic})), off=(when(signal <= ${var.backend_5xx_threshold_major}, lasting='${var.backend_5xx_lasting_duration_seconds / 2}s') or when(signal >= ${var.backend_5xx_threshold_critical}, lasting='${var.backend_5xx_lasting_duration_seconds}s', at_least=${var.backend_5xx_at_least_percentage})), mode='paired').publish('MAJOR')
 EOF
 
   rule {
@@ -158,11 +158,11 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.backend_5xx_threshold_warning}%"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.backend_5xx_disabled_warning, var.backend_5xx_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.backend_5xx_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.backend_5xx_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.backend_5xx_disabled_major, var.backend_5xx_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.backend_5xx_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -173,7 +173,7 @@ resource "signalfx_detector" "backend_latency" {
   program_text = <<-EOF
     signal = data('Latency', filter=filter('namespace', 'AWS/ELB') and filter('stat', 'mean') and (not filter('AvailabilityZone', '*')) and filter('LoadBalancerName', '*') and ${module.filter-tags.filter_custom}, extrapolation='zero', rollup='average')${var.backend_latency_aggregation_function}${var.backend_latency_transformation_function}.publish('signal')
     detect(when(signal > threshold(${var.backend_latency_threshold_critical}), lasting='${var.backend_latency_lasting_duration_seconds}s', at_least=${var.backend_latency_at_least_percentage})).publish('CRIT')
-    detect((when(signal > threshold(${var.backend_latency_threshold_warning}), lasting='${var.backend_latency_lasting_duration_seconds}s', at_least=${var.backend_latency_at_least_percentage}) and when(signal <= ${var.backend_latency_threshold_critical})), off=(when(signal <= ${var.backend_latency_threshold_warning}, lasting='${var.backend_latency_lasting_duration_seconds / 2}s') or when(signal >= ${var.backend_latency_threshold_critical}, lasting='${var.backend_latency_lasting_duration_seconds}s', at_least=${var.backend_latency_at_least_percentage})), mode='paired').publish('WARN')
+    detect((when(signal > threshold(${var.backend_latency_threshold_major}), lasting='${var.backend_latency_lasting_duration_seconds}s', at_least=${var.backend_latency_at_least_percentage}) and when(signal <= ${var.backend_latency_threshold_critical})), off=(when(signal <= ${var.backend_latency_threshold_major}, lasting='${var.backend_latency_lasting_duration_seconds / 2}s') or when(signal >= ${var.backend_latency_threshold_critical}, lasting='${var.backend_latency_lasting_duration_seconds}s', at_least=${var.backend_latency_at_least_percentage})), mode='paired').publish('MAJOR')
 EOF
 
   rule {
@@ -186,11 +186,11 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.backend_latency_threshold_warning}s"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.backend_latency_disabled_warning, var.backend_latency_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.backend_latency_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.backend_latency_threshold_major}s"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.backend_latency_disabled_major, var.backend_latency_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.backend_latency_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/aws/elb/variables.tf
+++ b/cloud/aws/elb/variables.tf
@@ -82,8 +82,8 @@ variable "no_healthy_instances_disabled_critical" {
   default     = null
 }
 
-variable "no_healthy_instances_disabled_warning" {
-  description = "Disable warning alerting rule for no_healthy_instances detector"
+variable "no_healthy_instances_disabled_major" {
+  description = "Disable major alerting rule for no_healthy_instances detector"
   type        = bool
   default     = null
 }
@@ -112,8 +112,8 @@ variable "no_healthy_instances_threshold_critical" {
   default     = 1
 }
 
-variable "no_healthy_instances_threshold_warning" {
-  description = "Warning threshold for no_healthy_instances detector"
+variable "no_healthy_instances_threshold_major" {
+  description = "Major threshold for no_healthy_instances detector"
   type        = number
   default     = 100
 }
@@ -132,8 +132,8 @@ variable "elb_4xx_disabled_critical" {
   default     = null
 }
 
-variable "elb_4xx_disabled_warning" {
-  description = "Disable warning alerting rule for httpcode 4xx erros detector"
+variable "elb_4xx_disabled_major" {
+  description = "Disable major alerting rule for httpcode 4xx erros detector"
   type        = bool
   default     = null
 }
@@ -174,8 +174,8 @@ variable "elb_4xx_threshold_critical" {
   default     = 40
 }
 
-variable "elb_4xx_threshold_warning" {
-  description = "Warning threshold for 4xx detector"
+variable "elb_4xx_threshold_major" {
+  description = "Major threshold for 4xx detector"
   type        = number
   default     = 20
 }
@@ -194,8 +194,8 @@ variable "elb_5xx_disabled_critical" {
   default     = null
 }
 
-variable "elb_5xx_disabled_warning" {
-  description = "Disable warning alerting rule for 5xx detector"
+variable "elb_5xx_disabled_major" {
+  description = "Disable major alerting rule for 5xx detector"
   type        = bool
   default     = null
 }
@@ -236,8 +236,8 @@ variable "elb_5xx_threshold_critical" {
   default     = 10
 }
 
-variable "elb_5xx_threshold_warning" {
-  description = "Warning threshold for 5xx detector"
+variable "elb_5xx_threshold_major" {
+  description = "Major threshold for 5xx detector"
   type        = number
   default     = 5
 }
@@ -256,8 +256,8 @@ variable "backend_4xx_disabled_critical" {
   default     = null
 }
 
-variable "backend_4xx_disabled_warning" {
-  description = "Disable warning alerting rule for backend_4xx detector"
+variable "backend_4xx_disabled_major" {
+  description = "Disable major alerting rule for backend_4xx detector"
   type        = bool
   default     = null
 }
@@ -298,8 +298,8 @@ variable "backend_4xx_threshold_critical" {
   default     = 40
 }
 
-variable "backend_4xx_threshold_warning" {
-  description = "Warning threshold for backend_4xx detector"
+variable "backend_4xx_threshold_major" {
+  description = "Major threshold for backend_4xx detector"
   type        = number
   default     = 20
 }
@@ -318,8 +318,8 @@ variable "backend_5xx_disabled_critical" {
   default     = null
 }
 
-variable "backend_5xx_disabled_warning" {
-  description = "Disable warning alerting rule for backend_5xx detector"
+variable "backend_5xx_disabled_major" {
+  description = "Disable major alerting rule for backend_5xx detector"
   type        = bool
   default     = null
 }
@@ -360,8 +360,8 @@ variable "backend_5xx_threshold_critical" {
   default     = 10
 }
 
-variable "backend_5xx_threshold_warning" {
-  description = "Warning threshold for backend_5xx detector"
+variable "backend_5xx_threshold_major" {
+  description = "Major threshold for backend_5xx detector"
   type        = number
   default     = 5
 }
@@ -380,8 +380,8 @@ variable "backend_latency_disabled_critical" {
   default     = null
 }
 
-variable "backend_latency_disabled_warning" {
-  description = "Disable warning alerting rule for backend_latency detector"
+variable "backend_latency_disabled_major" {
+  description = "Disable major alerting rule for backend_latency detector"
   type        = bool
   default     = null
 }
@@ -422,8 +422,8 @@ variable "backend_latency_threshold_critical" {
   default     = 3
 }
 
-variable "backend_latency_threshold_warning" {
-  description = "Warning threshold for backend_latency detector"
+variable "backend_latency_threshold_major" {
+  description = "Major threshold for backend_latency detector"
   type        = number
   default     = 1
 }

--- a/cloud/aws/kinesis-firehose/detectors-kinesis-firehose.tf
+++ b/cloud/aws/kinesis-firehose/detectors-kinesis-firehose.tf
@@ -23,7 +23,7 @@ resource "signalfx_detector" "incoming_records" {
   program_text = <<-EOF
     signal = data('IncomingRecords', filter=filter('namespace', 'AWS/Kinesis') and filter('stat', 'lower') and (not filter('ShardId', '*')) and ${module.filter-tags.filter_custom})${var.incoming_records_aggregation_function}${var.incoming_records_transformation_function}.publish('signal')
     detect(when(signal <= ${var.incoming_records_threshold_critical})).publish('CRIT')
-    detect(when(signal <= ${var.incoming_records_threshold_warning}) and when(signal > ${var.incoming_records_threshold_critical})).publish('WARN')
+    detect(when(signal <= ${var.incoming_records_threshold_major}) and when(signal > ${var.incoming_records_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -36,11 +36,11 @@ EOF
   }
 
   rule {
-    description           = "are too low <= ${var.incoming_records_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.incoming_records_disabled_warning, var.incoming_records_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.incoming_records_notifications, "warning", []), var.notifications.warning)
+    description           = "are too low <= ${var.incoming_records_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.incoming_records_disabled_major, var.incoming_records_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.incoming_records_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/aws/kinesis-firehose/variables.tf
+++ b/cloud/aws/kinesis-firehose/variables.tf
@@ -76,8 +76,8 @@ variable "incoming_records_disabled_critical" {
   default     = null
 }
 
-variable "incoming_records_disabled_warning" {
-  description = "Disable warning alerting rule for incoming_records detector"
+variable "incoming_records_disabled_major" {
+  description = "Disable major alerting rule for incoming_records detector"
   type        = bool
   default     = null
 }
@@ -106,8 +106,8 @@ variable "incoming_records_threshold_critical" {
   default     = 0
 }
 
-variable "incoming_records_threshold_warning" {
-  description = "Warning threshold for incoming_records detector"
+variable "incoming_records_threshold_major" {
+  description = "Major threshold for incoming_records detector"
   type        = number
   default     = 1
 }

--- a/cloud/aws/lambda/detectors-lambda.tf
+++ b/cloud/aws/lambda/detectors-lambda.tf
@@ -6,7 +6,7 @@ resource "signalfx_detector" "pct_errors" {
     B = data('Invocations', filter=filter('namespace', 'AWS/Lambda') and filter('stat', 'mean') and filter('Resource', '*') and ${module.filter-tags.filter_custom}, extrapolation='last_value', rollup='average')${var.pct_errors_aggregation_function}${var.pct_errors_transformation_function}
     signal = (A/B).scale(100).fill(value=0).publish('signal')
     detect(when(signal > threshold(${var.pct_errors_threshold_critical}), lasting='${var.pct_errors_lasting_duration_seconds}s')).publish('CRIT')
-    detect((when(signal > threshold(${var.pct_errors_threshold_warning}), lasting='${var.pct_errors_lasting_duration_seconds}s') and when(signal <= ${var.pct_errors_threshold_critical}, lasting='${var.pct_errors_lasting_duration_seconds}s'))).publish('WARN')
+    detect((when(signal > threshold(${var.pct_errors_threshold_major}), lasting='${var.pct_errors_lasting_duration_seconds}s') and when(signal <= ${var.pct_errors_threshold_critical}, lasting='${var.pct_errors_lasting_duration_seconds}s'))).publish('MAJOR')
 EOF
 
   rule {
@@ -19,11 +19,11 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.pct_errors_threshold_warning}%"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.pct_errors_disabled_warning, var.pct_errors_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.pct_errors_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.pct_errors_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.pct_errors_disabled_major, var.pct_errors_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.pct_errors_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -34,7 +34,7 @@ resource "signalfx_detector" "throttles" {
   program_text = <<-EOF
     signal = data('Throttles', filter=filter('namespace', 'AWS/Lambda') and filter('stat', 'mean') and filter('Resource', '*') and ${module.filter-tags.filter_custom}, extrapolation='last_value', rollup='average')${var.throttles_aggregation_function}${var.throttles_transformation_function}.publish('signal')
     detect(when(signal > threshold(${var.throttles_threshold_critical}))).publish('CRIT')
-    detect((when(signal > threshold(${var.throttles_threshold_warning})) and when(signal <= ${var.throttles_threshold_critical}))).publish('WARN')
+    detect((when(signal > threshold(${var.throttles_threshold_major})) and when(signal <= ${var.throttles_threshold_critical}))).publish('MAJOR')
 EOF
 
   rule {
@@ -47,11 +47,11 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.throttles_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.throttles_disabled_warning, var.throttles_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.throttles_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.throttles_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.throttles_disabled_major, var.throttles_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.throttles_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -61,15 +61,15 @@ resource "signalfx_detector" "invocations" {
 
   program_text = <<-EOF
     signal = data('Invocations', filter=filter('namespace', 'AWS/Lambda') and filter('stat', 'mean') and filter('Resource', '*') and ${module.filter-tags.filter_custom}, extrapolation='last_value', rollup='average')${var.invocations_aggregation_function}${var.invocations_transformation_function}.publish('signal')
-    detect(when(signal < threshold(${var.invocations_threshold_warning}))).publish('WARN')
+    detect(when(signal < threshold(${var.invocations_threshold_major}))).publish('MAJOR')
 EOF
 
   rule {
-    description           = "is too low < ${var.invocations_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
+    description           = "is too low < ${var.invocations_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
     disabled              = coalesce(var.invocations_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.invocations_notifications, "warning", []), var.notifications.warning)
+    notifications         = coalescelist(lookup(var.invocations_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/aws/lambda/variables.tf
+++ b/cloud/aws/lambda/variables.tf
@@ -58,8 +58,8 @@ variable "pct_errors_disabled_critical" {
   default     = null
 }
 
-variable "pct_errors_disabled_warning" {
-  description = "Disable warning alerting rule for pct_errors detector"
+variable "pct_errors_disabled_major" {
+  description = "Disable major alerting rule for pct_errors detector"
   type        = bool
   default     = null
 }
@@ -94,8 +94,8 @@ variable "pct_errors_threshold_critical" {
   default     = 25
 }
 
-variable "pct_errors_threshold_warning" {
-  description = "Warning threshold for pct_errors detector"
+variable "pct_errors_threshold_major" {
+  description = "Major threshold for pct_errors detector"
   type        = number
   default     = 0
 }
@@ -114,8 +114,8 @@ variable "throttles_disabled_critical" {
   default     = null
 }
 
-variable "throttles_disabled_warning" {
-  description = "Disable warning alerting rule for throttles detector"
+variable "throttles_disabled_major" {
+  description = "Disable major alerting rule for throttles detector"
   type        = bool
   default     = null
 }
@@ -144,8 +144,8 @@ variable "throttles_threshold_critical" {
   default     = 1
 }
 
-variable "throttles_threshold_warning" {
-  description = "Warning threshold for throttles detector"
+variable "throttles_threshold_major" {
+  description = "Major threshold for throttles detector"
   type        = number
   default     = 0
 }
@@ -176,8 +176,8 @@ variable "invocations_transformation_function" {
   default     = ".sum(over='1h')"
 }
 
-variable "invocations_threshold_warning" {
-  description = "Warning threshold for invocations detector"
+variable "invocations_threshold_major" {
+  description = "Major threshold for invocations detector"
   type        = number
   default     = 1
 }

--- a/cloud/aws/nlb/detectors-nlb.tf
+++ b/cloud/aws/nlb/detectors-nlb.tf
@@ -25,7 +25,7 @@ resource "signalfx_detector" "no_healthy_instances" {
     B = data('UnHealthyHostCount', filter=filter('namespace', 'AWS/NetworkELB') and filter('stat', 'upper') and (not filter('AvailabilityZone', '*')) and ${module.filter-tags.filter_custom})${var.no_healthy_instances_aggregation_function}${var.no_healthy_instances_transformation_function}
     signal = (A / (A+B)).scale(100).publish('signal')
     detect(when(signal < ${var.no_healthy_instances_threshold_critical})).publish('CRIT')
-    detect(when(signal < ${var.no_healthy_instances_threshold_warning}) and when(signal >= ${var.no_healthy_instances_threshold_critical})).publish('WARN')
+    detect(when(signal < ${var.no_healthy_instances_threshold_major}) and when(signal >= ${var.no_healthy_instances_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -38,11 +38,11 @@ EOF
   }
 
   rule {
-    description           = "is below nominal capacity < ${var.no_healthy_instances_threshold_warning}%"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.no_healthy_instances_disabled_warning, var.no_healthy_instances_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.no_healthy_instances_notifications, "warning", []), var.notifications.warning)
+    description           = "is below nominal capacity < ${var.no_healthy_instances_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.no_healthy_instances_disabled_major, var.no_healthy_instances_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.no_healthy_instances_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/aws/nlb/variables.tf
+++ b/cloud/aws/nlb/variables.tf
@@ -76,8 +76,8 @@ variable "no_healthy_instances_disabled_critical" {
   default     = null
 }
 
-variable "no_healthy_instances_disabled_warning" {
-  description = "Disable warning alerting rule for no_healthy_instances detector"
+variable "no_healthy_instances_disabled_major" {
+  description = "Disable major alerting rule for no_healthy_instances detector"
   type        = bool
   default     = null
 }
@@ -106,8 +106,8 @@ variable "no_healthy_instances_threshold_critical" {
   default     = 1
 }
 
-variable "no_healthy_instances_threshold_warning" {
-  description = "Warning threshold for no_healthy_instances detector"
+variable "no_healthy_instances_threshold_major" {
+  description = "Major threshold for no_healthy_instances detector"
   type        = number
   default     = 100
 }

--- a/cloud/aws/rds/aurora/mysql/detectors-rds-aurora-mysql.tf
+++ b/cloud/aws/rds/aurora/mysql/detectors-rds-aurora-mysql.tf
@@ -4,7 +4,7 @@ resource "signalfx_detector" "aurora_mysql_replica_lag" {
   program_text = <<-EOF
     signal = data('AuroraReplicaLag', filter=filter('namespace', 'AWS/RDS') and filter('stat', 'mean') and filter('DBInstanceIdentifier', '*') and ${module.filter-tags.filter_custom})${var.aurora_mysql_replica_lag_aggregation_function}${var.aurora_mysql_replica_lag_transformation_function}.publish('signal')
     detect(when(signal > ${var.aurora_mysql_replica_lag_threshold_critical})).publish('CRIT')
-    detect(when(signal > ${var.aurora_mysql_replica_lag_threshold_warning}) and when(signal <= ${var.aurora_mysql_replica_lag_threshold_critical})).publish('WARN')
+    detect(when(signal > ${var.aurora_mysql_replica_lag_threshold_major}) and when(signal <= ${var.aurora_mysql_replica_lag_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -17,11 +17,11 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.aurora_mysql_replica_lag_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.aurora_mysql_replica_lag_disabled_warning, var.aurora_mysql_replica_lag_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.aurora_mysql_replica_lag_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.aurora_mysql_replica_lag_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.aurora_mysql_replica_lag_disabled_major, var.aurora_mysql_replica_lag_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.aurora_mysql_replica_lag_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/aws/rds/aurora/mysql/variables.tf
+++ b/cloud/aws/rds/aurora/mysql/variables.tf
@@ -56,8 +56,8 @@ variable "aurora_mysql_replica_lag_disabled_critical" {
   default     = null
 }
 
-variable "aurora_mysql_replica_lag_disabled_warning" {
-  description = "Disable warning alerting rule for aurora_mysql_replica_lag detector"
+variable "aurora_mysql_replica_lag_disabled_major" {
+  description = "Disable major alerting rule for aurora_mysql_replica_lag detector"
   type        = bool
   default     = null
 }
@@ -86,8 +86,8 @@ variable "aurora_mysql_replica_lag_threshold_critical" {
   default     = 200
 }
 
-variable "aurora_mysql_replica_lag_threshold_warning" {
-  description = "Warning threshold for aurora_mysql_replica_lag detector"
+variable "aurora_mysql_replica_lag_threshold_major" {
+  description = "Major threshold for aurora_mysql_replica_lag detector"
   type        = number
   default     = 100
 }

--- a/cloud/aws/rds/aurora/postgresql/detectors-rds-aurora-postgresql.tf
+++ b/cloud/aws/rds/aurora/postgresql/detectors-rds-aurora-postgresql.tf
@@ -4,7 +4,7 @@ resource "signalfx_detector" "aurora_postgresql_replica_lag" {
   program_text = <<-EOF
     signal = data('RDSToAuroraPostgreSQLReplicaLag', filter=filter('namespace', 'AWS/RDS') and filter('stat', 'mean') and filter('DBInstanceIdentifier', '*') and ${module.filter-tags.filter_custom})${var.aurora_postgresql_replica_lag_aggregation_function}${var.aurora_postgresql_replica_lag_transformation_function}.publish('signal')
     detect(when(signal > ${var.aurora_postgresql_replica_lag_threshold_critical})).publish('CRIT')
-    detect(when(signal > ${var.aurora_postgresql_replica_lag_threshold_warning}) and when(signal <= ${var.aurora_postgresql_replica_lag_threshold_critical})).publish('WARN')
+    detect(when(signal > ${var.aurora_postgresql_replica_lag_threshold_major}) and when(signal <= ${var.aurora_postgresql_replica_lag_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -17,11 +17,11 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.aurora_postgresql_replica_lag_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.aurora_postgresql_replica_lag_disabled_warning, var.aurora_postgresql_replica_lag_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.aurora_postgresql_replica_lag_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.aurora_postgresql_replica_lag_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.aurora_postgresql_replica_lag_disabled_major, var.aurora_postgresql_replica_lag_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.aurora_postgresql_replica_lag_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/aws/rds/aurora/postgresql/variables.tf
+++ b/cloud/aws/rds/aurora/postgresql/variables.tf
@@ -58,8 +58,8 @@ variable "aurora_postgresql_replica_lag_disabled_critical" {
   default     = null
 }
 
-variable "aurora_postgresql_replica_lag_disabled_warning" {
-  description = "Disable warning alerting rule for aurora_postgresql_replica_lag detector"
+variable "aurora_postgresql_replica_lag_disabled_major" {
+  description = "Disable major alerting rule for aurora_postgresql_replica_lag detector"
   type        = bool
   default     = null
 }
@@ -88,8 +88,8 @@ variable "aurora_postgresql_replica_lag_threshold_critical" {
   default     = 200
 }
 
-variable "aurora_postgresql_replica_lag_threshold_warning" {
-  description = "Warning threshold for aurora_postgresql_replica_lag detector"
+variable "aurora_postgresql_replica_lag_threshold_major" {
+  description = "Major threshold for aurora_postgresql_replica_lag detector"
   type        = number
   default     = 100
 }

--- a/cloud/aws/rds/common/detectors-rds-common.tf
+++ b/cloud/aws/rds/common/detectors-rds-common.tf
@@ -23,7 +23,7 @@ resource "signalfx_detector" "cpu_90_15min" {
   program_text = <<-EOF
     signal = data('CPUUtilization', filter=filter('namespace', 'AWS/RDS') and filter('stat', 'mean') and filter('DBInstanceIdentifier', '*') and ${module.filter-tags.filter_custom})${var.cpu_90_15min_aggregation_function}${var.cpu_90_15min_transformation_function}.publish('signal')
     detect(when(signal > ${var.cpu_90_15min_threshold_critical})).publish('CRIT')
-    detect(when(signal > ${var.cpu_90_15min_threshold_warning}) and when(signal <= ${var.cpu_90_15min_threshold_critical})).publish('WARN')
+    detect(when(signal > ${var.cpu_90_15min_threshold_major}) and when(signal <= ${var.cpu_90_15min_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -36,11 +36,11 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.cpu_90_15min_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.cpu_90_15min_disabled_warning, var.cpu_90_15min_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.cpu_90_15min_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.cpu_90_15min_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.cpu_90_15min_disabled_major, var.cpu_90_15min_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.cpu_90_15min_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -51,7 +51,7 @@ resource "signalfx_detector" "free_space_low" {
   program_text = <<-EOF
     signal = data('FreeStorageSpace', filter=filter('namespace', 'AWS/RDS') and filter('stat', 'mean') and filter('DBInstanceIdentifier', '*') and ${module.filter-tags.filter_custom})${var.free_space_low_aggregation_function}${var.free_space_low_transformation_function}.publish('signal')
     detect(when(signal < ${var.free_space_low_threshold_critical})).publish('CRIT')
-    detect(when(signal < ${var.free_space_low_threshold_warning}) and when(signal >= ${var.free_space_low_threshold_critical})).publish('WARN')
+    detect(when(signal < ${var.free_space_low_threshold_major}) and when(signal >= ${var.free_space_low_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -64,11 +64,11 @@ EOF
   }
 
   rule {
-    description           = "is too low < ${var.free_space_low_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.free_space_low_disabled_warning, var.free_space_low_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.free_space_low_notifications, "warning", []), var.notifications.warning)
+    description           = "is too low < ${var.free_space_low_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.free_space_low_disabled_major, var.free_space_low_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.free_space_low_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -79,7 +79,7 @@ resource "signalfx_detector" "replica_lag" {
   program_text = <<-EOF
     signal = data('ReplicaLag', filter=filter('namespace', 'AWS/RDS') and filter('stat', 'mean') and filter('DBInstanceIdentifier', '*') and ${module.filter-tags.filter_custom})${var.replica_lag_aggregation_function}${var.replica_lag_transformation_function}.publish('signal')
     detect(when(signal > ${var.replica_lag_threshold_critical})).publish('CRIT')
-    detect(when(signal > ${var.replica_lag_threshold_warning}) and when(signal <= ${var.replica_lag_threshold_critical})).publish('WARN')
+    detect(when(signal > ${var.replica_lag_threshold_major}) and when(signal <= ${var.replica_lag_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -92,11 +92,11 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.replica_lag_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.replica_lag_disabled_warning, var.replica_lag_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.replica_lag_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.replica_lag_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.replica_lag_disabled_major, var.replica_lag_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.replica_lag_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/aws/rds/common/variables.tf
+++ b/cloud/aws/rds/common/variables.tf
@@ -76,8 +76,8 @@ variable "cpu_90_15min_disabled_critical" {
   default     = null
 }
 
-variable "cpu_90_15min_disabled_warning" {
-  description = "Disable warning alerting rule for cpu_90_15min detector"
+variable "cpu_90_15min_disabled_major" {
+  description = "Disable major alerting rule for cpu_90_15min detector"
   type        = bool
   default     = null
 }
@@ -106,8 +106,8 @@ variable "cpu_90_15min_threshold_critical" {
   default     = 90
 }
 
-variable "cpu_90_15min_threshold_warning" {
-  description = "Warning threshold for cpu_90_15min detector"
+variable "cpu_90_15min_threshold_major" {
+  description = "Major threshold for cpu_90_15min detector"
   type        = number
   default     = 80
 }
@@ -126,8 +126,8 @@ variable "free_space_low_disabled_critical" {
   default     = null
 }
 
-variable "free_space_low_disabled_warning" {
-  description = "Disable warning alerting rule for free_space_low detector"
+variable "free_space_low_disabled_major" {
+  description = "Disable major alerting rule for free_space_low detector"
   type        = bool
   default     = null
 }
@@ -156,8 +156,8 @@ variable "free_space_low_threshold_critical" {
   default     = 20
 }
 
-variable "free_space_low_threshold_warning" {
-  description = "Warning threshold for free_space_low detector"
+variable "free_space_low_threshold_major" {
+  description = "Major threshold for free_space_low detector"
   type        = number
   default     = 40
 }
@@ -176,8 +176,8 @@ variable "replica_lag_disabled_critical" {
   default     = null
 }
 
-variable "replica_lag_disabled_warning" {
-  description = "Disable warning alerting rule for replica_lag detector"
+variable "replica_lag_disabled_major" {
+  description = "Disable major alerting rule for replica_lag detector"
   type        = bool
   default     = null
 }
@@ -206,8 +206,8 @@ variable "replica_lag_threshold_critical" {
   default     = 300
 }
 
-variable "replica_lag_threshold_warning" {
-  description = "Warning threshold for replica_lag detector"
+variable "replica_lag_threshold_major" {
+  description = "Major threshold for replica_lag detector"
   type        = number
   default     = 200
 }

--- a/cloud/aws/sqs/detectors-sqs.tf
+++ b/cloud/aws/sqs/detectors-sqs.tf
@@ -23,7 +23,7 @@ resource "signalfx_detector" "visible_messages" {
   program_text = <<-EOF
     signal = data('ApproximateNumberOfMessagesVisible', filter=filter('namespace', 'AWS/SQS') and filter('stat', 'upper') and ${module.filter-tags.filter_custom})${var.visible_messages_aggregation_function}${var.visible_messages_transformation_function}.publish('signal')
     detect(when(signal > ${var.visible_messages_threshold_critical})).publish('CRIT')
-    detect(when(signal > ${var.visible_messages_threshold_warning}) and when(signal <= ${var.visible_messages_threshold_critical})).publish('WARN')
+    detect(when(signal > ${var.visible_messages_threshold_major}) and when(signal <= ${var.visible_messages_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -36,11 +36,11 @@ EOF
   }
 
   rule {
-    description           = "are too high > ${var.visible_messages_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.visible_messages_disabled_warning, var.visible_messages_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.visible_messages_notifications, "warning", []), var.notifications.warning)
+    description           = "are too high > ${var.visible_messages_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.visible_messages_disabled_major, var.visible_messages_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.visible_messages_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -51,7 +51,7 @@ resource "signalfx_detector" "age_of_oldest_message" {
   program_text = <<-EOF
     signal = data('ApproximateAgeOfOldestMessage', filter=filter('namespace', 'AWS/SQS') and filter('stat', 'upper') and ${module.filter-tags.filter_custom})${var.age_of_oldest_message_aggregation_function}${var.age_of_oldest_message_transformation_function}.publish('signal')
     detect(when(signal > ${var.age_of_oldest_message_threshold_critical})).publish('CRIT')
-    detect(when(signal > ${var.age_of_oldest_message_threshold_warning}) and when(signal <= ${var.age_of_oldest_message_threshold_critical})).publish('WARN')
+    detect(when(signal > ${var.age_of_oldest_message_threshold_major}) and when(signal <= ${var.age_of_oldest_message_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -64,11 +64,11 @@ EOF
   }
 
   rule {
-    description           = "is too old > ${var.age_of_oldest_message_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.age_of_oldest_message_disabled_warning, var.age_of_oldest_message_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.age_of_oldest_message_notifications, "warning", []), var.notifications.warning)
+    description           = "is too old > ${var.age_of_oldest_message_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.age_of_oldest_message_disabled_major, var.age_of_oldest_message_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.age_of_oldest_message_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/aws/sqs/variables.tf
+++ b/cloud/aws/sqs/variables.tf
@@ -76,8 +76,8 @@ variable "visible_messages_disabled_critical" {
   default     = null
 }
 
-variable "visible_messages_disabled_warning" {
-  description = "Disable warning alerting rule for visible_messages detector"
+variable "visible_messages_disabled_major" {
+  description = "Disable major alerting rule for visible_messages detector"
   type        = bool
   default     = null
 }
@@ -106,8 +106,8 @@ variable "visible_messages_threshold_critical" {
   default     = 2
 }
 
-variable "visible_messages_threshold_warning" {
-  description = "Warning threshold for visible_messages detector"
+variable "visible_messages_threshold_major" {
+  description = "Major threshold for visible_messages detector"
   type        = number
   default     = 1
 }
@@ -126,8 +126,8 @@ variable "age_of_oldest_message_disabled_critical" {
   default     = null
 }
 
-variable "age_of_oldest_message_disabled_warning" {
-  description = "Disable warning alerting rule for age_of_oldest_message detector"
+variable "age_of_oldest_message_disabled_major" {
+  description = "Disable major alerting rule for age_of_oldest_message detector"
   type        = bool
   default     = null
 }
@@ -156,8 +156,8 @@ variable "age_of_oldest_message_threshold_critical" {
   default     = 600
 }
 
-variable "age_of_oldest_message_threshold_warning" {
-  description = "Warning threshold for age_of_oldest_message detector"
+variable "age_of_oldest_message_threshold_major" {
+  description = "Major threshold for age_of_oldest_message detector"
   type        = number
   default     = 300
 }

--- a/cloud/azure/app-service-plan/detectors-azure-app-service-plan.tf
+++ b/cloud/azure/app-service-plan/detectors-azure-app-service-plan.tf
@@ -25,7 +25,7 @@ resource "signalfx_detector" "cpu_percentage" {
         base_filter = filter('resource_type', 'Microsoft.Web/serverFarms') and filter('primary_aggregation_type', 'true')
         signal = data('CpuPercentage', filter=base_filter and ${module.filter-tags.filter_custom})${var.cpu_percentage_aggregation_function}.publish('signal')
         detect(when(signal > threshold(${var.cpu_percentage_threshold_critical}), lasting="${var.cpu_percentage_timer}")).publish('CRIT')
-        detect(when(signal > threshold(${var.cpu_percentage_threshold_warning}), lasting="${var.cpu_percentage_timer}") and when(signal <= ${var.cpu_percentage_threshold_critical})).publish('WARN')
+        detect(when(signal > threshold(${var.cpu_percentage_threshold_major}), lasting="${var.cpu_percentage_timer}") and when(signal <= ${var.cpu_percentage_threshold_critical})).publish('MAJOR')
     EOF
 
   rule {
@@ -38,11 +38,11 @@ resource "signalfx_detector" "cpu_percentage" {
   }
 
   rule {
-    description           = "is too high > ${var.cpu_percentage_threshold_warning}%"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.cpu_percentage_disabled_warning, var.cpu_percentage_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.cpu_percentage_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.cpu_percentage_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.cpu_percentage_disabled_major, var.cpu_percentage_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.cpu_percentage_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -54,7 +54,7 @@ resource "signalfx_detector" "memory_percentage" {
         base_filter = filter('resource_type', 'Microsoft.Web/serverFarms') and filter('primary_aggregation_type', 'true')
         signal = data('MemoryPercentage', filter=base_filter and ${module.filter-tags.filter_custom})${var.memory_percentage_aggregation_function}.publish('signal')
         detect(when(signal > threshold(${var.memory_percentage_threshold_critical}), lasting="${var.memory_percentage_timer}")).publish('CRIT')
-        detect(when(signal > threshold(${var.memory_percentage_threshold_warning}), lasting="${var.memory_percentage_timer}") and when(signal <= ${var.memory_percentage_threshold_critical})).publish('WARN')
+        detect(when(signal > threshold(${var.memory_percentage_threshold_major}), lasting="${var.memory_percentage_timer}") and when(signal <= ${var.memory_percentage_threshold_critical})).publish('MAJOR')
     EOF
 
   rule {
@@ -67,11 +67,11 @@ resource "signalfx_detector" "memory_percentage" {
   }
 
   rule {
-    description           = "is too high > ${var.memory_percentage_threshold_warning}%"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.memory_percentage_disabled_warning, var.memory_percentage_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.memory_percentage_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.memory_percentage_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.memory_percentage_disabled_major, var.memory_percentage_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.memory_percentage_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/azure/app-service-plan/variables.tf
+++ b/cloud/azure/app-service-plan/variables.tf
@@ -76,8 +76,8 @@ variable "cpu_percentage_disabled_critical" {
   default     = null
 }
 
-variable "cpu_percentage_disabled_warning" {
-  description = "Disable warning alerting rule for cpu_percentage detector"
+variable "cpu_percentage_disabled_major" {
+  description = "Disable major alerting rule for cpu_percentage detector"
   type        = bool
   default     = null
 }
@@ -106,8 +106,8 @@ variable "cpu_percentage_threshold_critical" {
   default     = 95
 }
 
-variable "cpu_percentage_threshold_warning" {
-  description = "Warning threshold for cpu_percentage detector"
+variable "cpu_percentage_threshold_major" {
+  description = "Major threshold for cpu_percentage detector"
   type        = number
   default     = 90
 }
@@ -126,8 +126,8 @@ variable "memory_percentage_disabled_critical" {
   default     = null
 }
 
-variable "memory_percentage_disabled_warning" {
-  description = "Disable warning alerting rule for memory_percentage detector"
+variable "memory_percentage_disabled_major" {
+  description = "Disable major alerting rule for memory_percentage detector"
   type        = bool
   default     = null
 }
@@ -156,8 +156,8 @@ variable "memory_percentage_threshold_critical" {
   default     = 95
 }
 
-variable "memory_percentage_threshold_warning" {
-  description = "Warning threshold for memory_percentage detector"
+variable "memory_percentage_threshold_major" {
+  description = "Major threshold for memory_percentage detector"
   type        = number
   default     = 90
 }

--- a/cloud/azure/app-service/detectors-app_services.tf
+++ b/cloud/azure/app-service/detectors-app_services.tf
@@ -25,7 +25,7 @@ resource "signalfx_detector" "response_time" {
         base_filter = filter('resource_type', 'Microsoft.Web/sites') and filter('is_Azure_Function', 'false') and filter('primary_aggregation_type', 'true')
         signal = data('HttpResponseTime', extrapolation="last_value", filter=base_filter and ${module.filter-tags.filter_custom})${var.response_time_aggregation_function}.publish('signal')
         detect(when(signal > threshold(${var.response_time_threshold_critical}), lasting="${var.response_time_timer}")).publish('CRIT')
-        detect(when(signal > threshold(${var.response_time_threshold_warning}), lasting="${var.response_time_timer}") and when(signal <= ${var.response_time_threshold_critical})).publish('WARN')
+        detect(when(signal > threshold(${var.response_time_threshold_major}), lasting="${var.response_time_timer}") and when(signal <= ${var.response_time_threshold_critical})).publish('MAJOR')
     EOF
 
   rule {
@@ -38,11 +38,11 @@ resource "signalfx_detector" "response_time" {
   }
 
   rule {
-    description           = "is too high > ${var.response_time_threshold_warning}s"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.response_time_disabled_warning, var.response_time_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.response_time_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.response_time_threshold_major}s"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.response_time_disabled_major, var.response_time_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.response_time_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -55,7 +55,7 @@ resource "signalfx_detector" "memory_usage_count" {
         base_filter = filter('resource_type', 'Microsoft.Web/sites') and filter('is_Azure_Function', 'false') and filter('primary_aggregation_type', 'true')
         signal = data('MemoryWorkingSet', filter=base_filter and ${module.filter-tags.filter_custom})${var.memory_usage_count_aggregation_function}.publish('signal')
         detect(when(signal > threshold(${var.memory_usage_count_threshold_critical}), lasting="${var.memory_usage_count_timer}")).publish('CRIT')
-        detect(when(signal > threshold(${var.memory_usage_count_threshold_warning}), lasting="${var.memory_usage_count_timer}") and when(signal <= ${var.memory_usage_count_threshold_critical})).publish('WARN')
+        detect(when(signal > threshold(${var.memory_usage_count_threshold_major}), lasting="${var.memory_usage_count_timer}") and when(signal <= ${var.memory_usage_count_threshold_critical})).publish('MAJOR')
     EOF
 
   rule {
@@ -68,11 +68,11 @@ resource "signalfx_detector" "memory_usage_count" {
   }
 
   rule {
-    description           = "is too high > ${ceil(var.memory_usage_count_threshold_warning / 1024 / 1024)}Mb"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.memory_usage_count_disabled_warning, var.memory_usage_count_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.memory_usage_count_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${ceil(var.memory_usage_count_threshold_major / 1024 / 1024)}Mb"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.memory_usage_count_disabled_major, var.memory_usage_count_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.memory_usage_count_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -87,7 +87,7 @@ resource "signalfx_detector" "http_5xx_errors_count" {
         B = data('Requests', extrapolation="zero", filter=base_filter and ${module.filter-tags.filter_custom})${var.http_5xx_errors_count_aggregation_function}
         signal = (A/B).scale(100).fill(0).publish('signal')
         detect(when(signal > threshold(${var.http_5xx_errors_count_threshold_critical}), lasting="${var.http_5xx_errors_count_timer}")).publish('CRIT')
-        detect(when(signal > threshold(${var.http_5xx_errors_count_threshold_warning}), lasting="${var.http_5xx_errors_count_timer}") and when(signal <= ${var.http_5xx_errors_count_threshold_critical})).publish('WARN')
+        detect(when(signal > threshold(${var.http_5xx_errors_count_threshold_major}), lasting="${var.http_5xx_errors_count_timer}") and when(signal <= ${var.http_5xx_errors_count_threshold_critical})).publish('MAJOR')
     EOF
 
   rule {
@@ -100,11 +100,11 @@ resource "signalfx_detector" "http_5xx_errors_count" {
   }
 
   rule {
-    description           = "is too high > ${var.http_5xx_errors_count_threshold_warning}%"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.http_5xx_errors_count_disabled_warning, var.http_5xx_errors_count_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.http_5xx_errors_count_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.http_5xx_errors_count_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.http_5xx_errors_count_disabled_major, var.http_5xx_errors_count_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.http_5xx_errors_count_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -119,7 +119,7 @@ resource "signalfx_detector" "http_4xx_errors_count" {
         B = data('Requests', extrapolation="zero", filter=base_filter and ${module.filter-tags.filter_custom})${var.http_4xx_errors_count_aggregation_function}
         signal = (A/B).scale(100).fill(0).publish('signal')
         detect(when(signal > threshold(${var.http_4xx_errors_count_threshold_critical}), lasting="${var.http_4xx_errors_count_timer}")).publish('CRIT')
-        detect(when(signal > threshold(${var.http_4xx_errors_count_threshold_warning}), lasting="${var.http_4xx_errors_count_timer}") and when(signal <= ${var.http_4xx_errors_count_threshold_critical})).publish('WARN')
+        detect(when(signal > threshold(${var.http_4xx_errors_count_threshold_major}), lasting="${var.http_4xx_errors_count_timer}") and when(signal <= ${var.http_4xx_errors_count_threshold_critical})).publish('MAJOR')
     EOF
 
   rule {
@@ -132,11 +132,11 @@ resource "signalfx_detector" "http_4xx_errors_count" {
   }
 
   rule {
-    description           = "is too high > ${var.http_4xx_errors_count_threshold_warning}%"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.http_4xx_errors_count_disabled_warning, var.http_4xx_errors_count_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.http_4xx_errors_count_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.http_4xx_errors_count_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.http_4xx_errors_count_disabled_major, var.http_4xx_errors_count_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.http_4xx_errors_count_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -151,7 +151,7 @@ resource "signalfx_detector" "http_success_status_rate" {
         C = data('Requests', extrapolation="zero", filter=base_filter and ${module.filter-tags.filter_custom})${var.http_success_status_rate_aggregation_function}
         signal = ((A+B)/C).scale(100).fill(100).publish('signal')
         detect(when(signal < threshold(${var.http_success_status_rate_threshold_critical}), lasting="${var.http_success_status_rate_timer}")).publish('CRIT')
-        detect(when(signal < threshold(${var.http_success_status_rate_threshold_warning}), lasting="${var.http_success_status_rate_timer}") and when(signal >= ${var.http_success_status_rate_threshold_critical})).publish('WARN')
+        detect(when(signal < threshold(${var.http_success_status_rate_threshold_major}), lasting="${var.http_success_status_rate_timer}") and when(signal >= ${var.http_success_status_rate_threshold_critical})).publish('MAJOR')
     EOF
 
   rule {
@@ -164,11 +164,11 @@ resource "signalfx_detector" "http_success_status_rate" {
   }
 
   rule {
-    description           = "is too low < ${var.http_success_status_rate_threshold_warning}%"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.http_success_status_rate_disabled_warning, var.http_success_status_rate_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.http_success_status_rate_notifications, "warning", []), var.notifications.warning)
+    description           = "is too low < ${var.http_success_status_rate_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.http_success_status_rate_disabled_major, var.http_success_status_rate_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.http_success_status_rate_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/azure/app-service/variables.tf
+++ b/cloud/azure/app-service/variables.tf
@@ -76,8 +76,8 @@ variable "response_time_disabled_critical" {
   default     = null
 }
 
-variable "response_time_disabled_warning" {
-  description = "Disable warning alerting rule for response_time detector"
+variable "response_time_disabled_major" {
+  description = "Disable major alerting rule for response_time detector"
   type        = bool
   default     = null
 }
@@ -106,8 +106,8 @@ variable "response_time_threshold_critical" {
   default     = 10
 }
 
-variable "response_time_threshold_warning" {
-  description = "Warning threshold for response_time detector"
+variable "response_time_threshold_major" {
+  description = "Major threshold for response_time detector"
   type        = number
   default     = 5
 }
@@ -126,8 +126,8 @@ variable "memory_usage_count_disabled_critical" {
   default     = null
 }
 
-variable "memory_usage_count_disabled_warning" {
-  description = "Disable warning alerting rule for memory_usage_count detector"
+variable "memory_usage_count_disabled_major" {
+  description = "Disable major alerting rule for memory_usage_count detector"
   type        = bool
   default     = null
 }
@@ -156,8 +156,8 @@ variable "memory_usage_count_threshold_critical" {
   default     = 1073741824 # 1Gb
 }
 
-variable "memory_usage_count_threshold_warning" {
-  description = "Warning threshold for memory_usage_count detector"
+variable "memory_usage_count_threshold_major" {
+  description = "Major threshold for memory_usage_count detector"
   type        = number
   default     = 536870912 # 512Mb
 }
@@ -176,8 +176,8 @@ variable "http_5xx_errors_count_disabled_critical" {
   default     = null
 }
 
-variable "http_5xx_errors_count_disabled_warning" {
-  description = "Disable warning alerting rule for http_5xx_errors_count detector"
+variable "http_5xx_errors_count_disabled_major" {
+  description = "Disable major alerting rule for http_5xx_errors_count detector"
   type        = bool
   default     = null
 }
@@ -206,8 +206,8 @@ variable "http_5xx_errors_count_threshold_critical" {
   default     = 90
 }
 
-variable "http_5xx_errors_count_threshold_warning" {
-  description = "Warning threshold for http_5xx_errors_count detector"
+variable "http_5xx_errors_count_threshold_major" {
+  description = "Major threshold for http_5xx_errors_count detector"
   type        = number
   default     = 50
 }
@@ -226,8 +226,8 @@ variable "http_4xx_errors_count_disabled_critical" {
   default     = null
 }
 
-variable "http_4xx_errors_count_disabled_warning" {
-  description = "Disable warning alerting rule for http_4xx_errors_count detector"
+variable "http_4xx_errors_count_disabled_major" {
+  description = "Disable major alerting rule for http_4xx_errors_count detector"
   type        = bool
   default     = null
 }
@@ -256,8 +256,8 @@ variable "http_4xx_errors_count_threshold_critical" {
   default     = 90
 }
 
-variable "http_4xx_errors_count_threshold_warning" {
-  description = "Warning threshold for http_4xx_errors_count detector"
+variable "http_4xx_errors_count_threshold_major" {
+  description = "Major threshold for http_4xx_errors_count detector"
   type        = number
   default     = 50
 }
@@ -276,8 +276,8 @@ variable "http_success_status_rate_disabled_critical" {
   default     = null
 }
 
-variable "http_success_status_rate_disabled_warning" {
-  description = "Disable warning alerting rule for http_success_status_rate detector"
+variable "http_success_status_rate_disabled_major" {
+  description = "Disable major alerting rule for http_success_status_rate detector"
   type        = bool
   default     = null
 }
@@ -306,8 +306,8 @@ variable "http_success_status_rate_threshold_critical" {
   default     = 10
 }
 
-variable "http_success_status_rate_threshold_warning" {
-  description = "Warning threshold for http_success_status_rate detector"
+variable "http_success_status_rate_threshold_major" {
+  description = "Major threshold for http_success_status_rate detector"
   type        = number
   default     = 30
 }

--- a/cloud/azure/application-gateway/detectors-app-gateway.tf
+++ b/cloud/azure/application-gateway/detectors-app-gateway.tf
@@ -45,7 +45,7 @@ resource "signalfx_detector" "backend_connect_time" {
         base_filter = filter('resource_type', 'Microsoft.Network/applicationGateways') and filter('primary_aggregation_type', 'true')
         signal = data('BackendConnectTime', filter=base_filter and ${module.filter-tags.filter_custom})${var.backend_connect_time_aggregation_function}.publish('signal')
         detect(when(signal > threshold(${var.backend_connect_time_threshold_critical}), lasting="${var.backend_connect_time_timer}")).publish('CRIT')
-        detect(when(signal > threshold(${var.backend_connect_time_threshold_warning}), lasting="${var.backend_connect_time_timer}") and when(signal <= ${var.backend_connect_time_threshold_critical})).publish('WARN')
+        detect(when(signal > threshold(${var.backend_connect_time_threshold_major}), lasting="${var.backend_connect_time_timer}") and when(signal <= ${var.backend_connect_time_threshold_critical})).publish('MAJOR')
     EOF
 
   rule {
@@ -58,11 +58,11 @@ resource "signalfx_detector" "backend_connect_time" {
   }
 
   rule {
-    description           = "is too high > ${var.backend_connect_time_threshold_warning}ms"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.backend_connect_time_disabled_warning, var.backend_connect_time_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.backend_connect_time_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.backend_connect_time_threshold_major}ms"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.backend_connect_time_disabled_major, var.backend_connect_time_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.backend_connect_time_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -77,7 +77,7 @@ resource "signalfx_detector" "failed_requests" {
         B = data('TotalRequests', extrapolation='zero', filter=base_filter and ${module.filter-tags.filter_custom})${var.failed_requests_aggregation_function}
         signal = (A/B).scale(100).fill(0).publish('signal')
         detect(when(signal > threshold(${var.failed_requests_threshold_critical}), lasting="${var.failed_requests_timer}")).publish('CRIT')
-        detect(when(signal > threshold(${var.failed_requests_threshold_warning}), lasting="${var.failed_requests_timer}") and when(signal <= ${var.failed_requests_threshold_critical})).publish('WARN')
+        detect(when(signal > threshold(${var.failed_requests_threshold_major}), lasting="${var.failed_requests_timer}") and when(signal <= ${var.failed_requests_threshold_critical})).publish('MAJOR')
     EOF
 
   rule {
@@ -90,11 +90,11 @@ resource "signalfx_detector" "failed_requests" {
   }
 
   rule {
-    description           = "is too high > ${var.failed_requests_threshold_warning}%"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.failed_requests_disabled_warning, var.failed_requests_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.failed_requests_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.failed_requests_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.failed_requests_disabled_major, var.failed_requests_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.failed_requests_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -108,7 +108,7 @@ resource "signalfx_detector" "unhealthy_host_ratio" {
         B = data('HealthyHostCount', filter=base_filter and ${module.filter-tags.filter_custom})${var.unhealthy_host_ratio_aggregation_function}
         signal = (A/(A+B)).scale(100).publish('signal')
         detect(when(signal >= threshold(${var.unhealthy_host_ratio_threshold_critical}), lasting="${var.unhealthy_host_ratio_timer}")).publish('CRIT')
-        detect(when(signal >= threshold(${var.unhealthy_host_ratio_threshold_warning}), lasting="${var.unhealthy_host_ratio_timer}") and when(signal < ${var.unhealthy_host_ratio_threshold_critical})).publish('WARN')
+        detect(when(signal >= threshold(${var.unhealthy_host_ratio_threshold_major}), lasting="${var.unhealthy_host_ratio_timer}") and when(signal < ${var.unhealthy_host_ratio_threshold_critical})).publish('MAJOR')
     EOF
 
   rule {
@@ -121,11 +121,11 @@ resource "signalfx_detector" "unhealthy_host_ratio" {
   }
 
   rule {
-    description           = "is too high >= ${var.unhealthy_host_ratio_threshold_warning}%"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.unhealthy_host_ratio_disabled_warning, var.unhealthy_host_ratio_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.unhealthy_host_ratio_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high >= ${var.unhealthy_host_ratio_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.unhealthy_host_ratio_disabled_major, var.unhealthy_host_ratio_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.unhealthy_host_ratio_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -139,7 +139,7 @@ resource "signalfx_detector" "http_4xx_errors" {
         B = data('ResponseStatus', extrapolation='zero', filter=base_filter and ${module.filter-tags.filter_custom})${var.http_4xx_errors_aggregation_function}
         signal = (A/B).scale(100).fill(0).publish('signal')
         detect(when(signal > threshold(${var.http_4xx_errors_threshold_critical}), lasting="${var.http_4xx_errors_timer}")).publish('CRIT')
-        detect(when(signal > threshold(${var.http_4xx_errors_threshold_warning}), lasting="${var.http_4xx_errors_timer}") and when(signal <= ${var.http_4xx_errors_threshold_critical})).publish('WARN')
+        detect(when(signal > threshold(${var.http_4xx_errors_threshold_major}), lasting="${var.http_4xx_errors_timer}") and when(signal <= ${var.http_4xx_errors_threshold_critical})).publish('MAJOR')
     EOF
 
   rule {
@@ -152,11 +152,11 @@ resource "signalfx_detector" "http_4xx_errors" {
   }
 
   rule {
-    description           = "is too high > ${var.http_4xx_errors_threshold_warning}%"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.http_4xx_errors_disabled_warning, var.http_4xx_errors_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.http_4xx_errors_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.http_4xx_errors_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.http_4xx_errors_disabled_major, var.http_4xx_errors_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.http_4xx_errors_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -170,7 +170,7 @@ resource "signalfx_detector" "http_5xx_errors" {
         B = data('ResponseStatus', extrapolation='zero', filter=base_filter and ${module.filter-tags.filter_custom})${var.http_5xx_errors_aggregation_function}
         signal = (A/B).scale(100).fill(0).publish('signal')
         detect(when(signal > threshold(${var.http_5xx_errors_threshold_critical}), lasting="${var.http_5xx_errors_timer}")).publish('CRIT')
-        detect(when(signal > threshold(${var.http_5xx_errors_threshold_warning}), lasting="${var.http_5xx_errors_timer}") and when(signal <= ${var.http_5xx_errors_threshold_critical})).publish('WARN')
+        detect(when(signal > threshold(${var.http_5xx_errors_threshold_major}), lasting="${var.http_5xx_errors_timer}") and when(signal <= ${var.http_5xx_errors_threshold_critical})).publish('MAJOR')
     EOF
 
   rule {
@@ -183,11 +183,11 @@ resource "signalfx_detector" "http_5xx_errors" {
   }
 
   rule {
-    description           = "is too high > ${var.http_5xx_errors_threshold_warning}%"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.http_5xx_errors_disabled_warning, var.http_5xx_errors_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.http_5xx_errors_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.http_5xx_errors_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.http_5xx_errors_disabled_major, var.http_5xx_errors_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.http_5xx_errors_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -201,7 +201,7 @@ resource "signalfx_detector" "backend_http_4xx_errors" {
         B = data('BackendResponseStatus', extrapolation='zero', filter=base_filter and ${module.filter-tags.filter_custom})${var.backend_http_4xx_errors_aggregation_function}
         signal = (A/B).scale(100).fill(0).publish('signal')
         detect(when(signal > threshold(${var.backend_http_4xx_errors_threshold_critical}), lasting="${var.backend_http_4xx_errors_timer}")).publish('CRIT')
-        detect(when(signal > threshold(${var.backend_http_4xx_errors_threshold_warning}), lasting="${var.backend_http_4xx_errors_timer}") and when(signal <= ${var.backend_http_4xx_errors_threshold_critical})).publish('WARN')
+        detect(when(signal > threshold(${var.backend_http_4xx_errors_threshold_major}), lasting="${var.backend_http_4xx_errors_timer}") and when(signal <= ${var.backend_http_4xx_errors_threshold_critical})).publish('MAJOR')
     EOF
 
   rule {
@@ -214,11 +214,11 @@ resource "signalfx_detector" "backend_http_4xx_errors" {
   }
 
   rule {
-    description           = "is too high > ${var.backend_http_4xx_errors_threshold_warning}%"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.backend_http_4xx_errors_disabled_warning, var.backend_http_4xx_errors_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.backend_http_4xx_errors_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.backend_http_4xx_errors_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.backend_http_4xx_errors_disabled_major, var.backend_http_4xx_errors_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.backend_http_4xx_errors_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -232,7 +232,7 @@ resource "signalfx_detector" "backend_http_5xx_errors" {
         B = data('BackendResponseStatus', extrapolation='zero', filter=base_filter and ${module.filter-tags.filter_custom})${var.backend_http_5xx_errors_aggregation_function}
         signal = (A/B).scale(100).fill(0).publish('signal')
         detect(when(signal > threshold(${var.backend_http_5xx_errors_threshold_critical}), lasting="${var.backend_http_5xx_errors_timer}")).publish('CRIT')
-        detect(when(signal > threshold(${var.backend_http_5xx_errors_threshold_warning}), lasting="${var.backend_http_5xx_errors_timer}") and when(signal <= ${var.backend_http_5xx_errors_threshold_critical})).publish('WARN')
+        detect(when(signal > threshold(${var.backend_http_5xx_errors_threshold_major}), lasting="${var.backend_http_5xx_errors_timer}") and when(signal <= ${var.backend_http_5xx_errors_threshold_critical})).publish('MAJOR')
     EOF
 
   rule {
@@ -245,11 +245,11 @@ resource "signalfx_detector" "backend_http_5xx_errors" {
   }
 
   rule {
-    description           = "is too high > ${var.backend_http_5xx_errors_threshold_warning}%"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.backend_http_5xx_errors_disabled_warning, var.backend_http_5xx_errors_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.backend_http_5xx_errors_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.backend_http_5xx_errors_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.backend_http_5xx_errors_disabled_major, var.backend_http_5xx_errors_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.backend_http_5xx_errors_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/azure/application-gateway/variables.tf
+++ b/cloud/azure/application-gateway/variables.tf
@@ -108,8 +108,8 @@ variable "backend_connect_time_disabled_critical" {
   default     = null
 }
 
-variable "backend_connect_time_disabled_warning" {
-  description = "Disable warning alerting rule for backend_connect_time detector"
+variable "backend_connect_time_disabled_major" {
+  description = "Disable major alerting rule for backend_connect_time detector"
   type        = bool
   default     = null
 }
@@ -138,8 +138,8 @@ variable "backend_connect_time_threshold_critical" {
   default     = 50
 }
 
-variable "backend_connect_time_threshold_warning" {
-  description = "Warning threshold for backend_connect_time detector"
+variable "backend_connect_time_threshold_major" {
+  description = "Major threshold for backend_connect_time detector"
   type        = number
   default     = 40
 }
@@ -158,8 +158,8 @@ variable "failed_requests_disabled_critical" {
   default     = null
 }
 
-variable "failed_requests_disabled_warning" {
-  description = "Disable warning alerting rule for failed_requests detector"
+variable "failed_requests_disabled_major" {
+  description = "Disable major alerting rule for failed_requests detector"
   type        = bool
   default     = null
 }
@@ -188,8 +188,8 @@ variable "failed_requests_threshold_critical" {
   default     = 95
 }
 
-variable "failed_requests_threshold_warning" {
-  description = "Warning threshold for failed_requests detector"
+variable "failed_requests_threshold_major" {
+  description = "Major threshold for failed_requests detector"
   type        = number
   default     = 80
 }
@@ -208,8 +208,8 @@ variable "unhealthy_host_ratio_disabled_critical" {
   default     = null
 }
 
-variable "unhealthy_host_ratio_disabled_warning" {
-  description = "Disable warning alerting rule for unhealthy_host_ratio detector"
+variable "unhealthy_host_ratio_disabled_major" {
+  description = "Disable major alerting rule for unhealthy_host_ratio detector"
   type        = bool
   default     = null
 }
@@ -238,8 +238,8 @@ variable "unhealthy_host_ratio_threshold_critical" {
   default     = 75
 }
 
-variable "unhealthy_host_ratio_threshold_warning" {
-  description = "Warning threshold for unhealthy_host_ratio detector"
+variable "unhealthy_host_ratio_threshold_major" {
+  description = "Major threshold for unhealthy_host_ratio detector"
   type        = number
   default     = 50
 }
@@ -258,8 +258,8 @@ variable "http_4xx_errors_disabled_critical" {
   default     = null
 }
 
-variable "http_4xx_errors_disabled_warning" {
-  description = "Disable warning alerting rule for http_4xx_errors detector"
+variable "http_4xx_errors_disabled_major" {
+  description = "Disable major alerting rule for http_4xx_errors detector"
   type        = bool
   default     = null
 }
@@ -288,8 +288,8 @@ variable "http_4xx_errors_threshold_critical" {
   default     = 95
 }
 
-variable "http_4xx_errors_threshold_warning" {
-  description = "Warning threshold for http_4xx_errors detector"
+variable "http_4xx_errors_threshold_major" {
+  description = "Major threshold for http_4xx_errors detector"
   type        = number
   default     = 80
 }
@@ -308,8 +308,8 @@ variable "http_5xx_errors_disabled_critical" {
   default     = null
 }
 
-variable "http_5xx_errors_disabled_warning" {
-  description = "Disable warning alerting rule for http_5xx_errors detector"
+variable "http_5xx_errors_disabled_major" {
+  description = "Disable major alerting rule for http_5xx_errors detector"
   type        = bool
   default     = null
 }
@@ -338,8 +338,8 @@ variable "http_5xx_errors_threshold_critical" {
   default     = 95
 }
 
-variable "http_5xx_errors_threshold_warning" {
-  description = "Warning threshold for http_5xx_errors detector"
+variable "http_5xx_errors_threshold_major" {
+  description = "Major threshold for http_5xx_errors detector"
   type        = number
   default     = 80
 }
@@ -358,8 +358,8 @@ variable "backend_http_4xx_errors_disabled_critical" {
   default     = null
 }
 
-variable "backend_http_4xx_errors_disabled_warning" {
-  description = "Disable warning alerting rule for backend_http_4xx_errors detector"
+variable "backend_http_4xx_errors_disabled_major" {
+  description = "Disable major alerting rule for backend_http_4xx_errors detector"
   type        = bool
   default     = null
 }
@@ -388,8 +388,8 @@ variable "backend_http_4xx_errors_threshold_critical" {
   default     = 95
 }
 
-variable "backend_http_4xx_errors_threshold_warning" {
-  description = "Warning threshold for backend_http_4xx_errors detector"
+variable "backend_http_4xx_errors_threshold_major" {
+  description = "Major threshold for backend_http_4xx_errors detector"
   type        = number
   default     = 80
 }
@@ -408,8 +408,8 @@ variable "backend_http_5xx_errors_disabled_critical" {
   default     = null
 }
 
-variable "backend_http_5xx_errors_disabled_warning" {
-  description = "Disable warning alerting rule for backend_http_5xx_errors detector"
+variable "backend_http_5xx_errors_disabled_major" {
+  description = "Disable major alerting rule for backend_http_5xx_errors detector"
   type        = bool
   default     = null
 }
@@ -438,8 +438,8 @@ variable "backend_http_5xx_errors_threshold_critical" {
   default     = 95
 }
 
-variable "backend_http_5xx_errors_threshold_warning" {
-  description = "Warning threshold for backend_http_5xx_errors detector"
+variable "backend_http_5xx_errors_threshold_major" {
+  description = "Major threshold for backend_http_5xx_errors detector"
   type        = number
   default     = 80
 }

--- a/cloud/azure/azure-search/detectors-azure-search.tf
+++ b/cloud/azure/azure-search/detectors-azure-search.tf
@@ -5,7 +5,7 @@ resource "signalfx_detector" "search_latency" {
         base_filter = filter('resource_type', 'Microsoft.Search/searchServices') and filter('primary_aggregation_type', 'true')
         signal = data('SearchLatency', filter=base_filter and ${module.filter-tags.filter_custom})${var.search_latency_aggregation_function}.publish('signal')
         detect(when(signal > threshold(${var.search_latency_threshold_critical}), lasting="${var.search_latency_timer}")).publish('CRIT')
-        detect(when(signal > threshold(${var.search_latency_threshold_warning}), lasting="${var.search_latency_timer}") and when(signal <= ${var.search_latency_threshold_critical})).publish('WARN')
+        detect(when(signal > threshold(${var.search_latency_threshold_major}), lasting="${var.search_latency_timer}") and when(signal <= ${var.search_latency_threshold_critical})).publish('MAJOR')
     EOF
 
   rule {
@@ -18,11 +18,11 @@ resource "signalfx_detector" "search_latency" {
   }
 
   rule {
-    description           = "is too high > ${var.search_latency_threshold_warning}ms"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.search_latency_disabled_warning, var.search_latency_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.search_latency_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.search_latency_threshold_major}ms"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.search_latency_disabled_major, var.search_latency_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.search_latency_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -34,7 +34,7 @@ resource "signalfx_detector" "search_throttled_queries_rate" {
         base_filter = filter('resource_type', 'Microsoft.Search/searchServices') and filter('primary_aggregation_type', 'true')
         signal = data('ThrottledSearchQueriesPercentage', filter=base_filter and ${module.filter-tags.filter_custom})${var.search_throttled_queries_rate_aggregation_function}.publish('signal')
         detect(when(signal > threshold(${var.search_throttled_queries_rate_threshold_critical}), lasting="${var.search_throttled_queries_rate_timer}")).publish('CRIT')
-        detect(when(signal > threshold(${var.search_throttled_queries_rate_threshold_warning}), lasting="${var.search_throttled_queries_rate_timer}") and when(signal <= ${var.search_throttled_queries_rate_threshold_critical})).publish('WARN')
+        detect(when(signal > threshold(${var.search_throttled_queries_rate_threshold_major}), lasting="${var.search_throttled_queries_rate_timer}") and when(signal <= ${var.search_throttled_queries_rate_threshold_critical})).publish('MAJOR')
     EOF
 
   rule {
@@ -47,11 +47,11 @@ resource "signalfx_detector" "search_throttled_queries_rate" {
   }
 
   rule {
-    description           = "is too high > ${var.search_throttled_queries_rate_threshold_warning}%"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.search_throttled_queries_rate_disabled_warning, var.search_throttled_queries_rate_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.search_throttled_queries_rate_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.search_throttled_queries_rate_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.search_throttled_queries_rate_disabled_major, var.search_throttled_queries_rate_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.search_throttled_queries_rate_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 

--- a/cloud/azure/azure-search/variables.tf
+++ b/cloud/azure/azure-search/variables.tf
@@ -58,8 +58,8 @@ variable "search_latency_disabled_critical" {
   default     = null
 }
 
-variable "search_latency_disabled_warning" {
-  description = "Disable warning alerting rule for search_latency detector"
+variable "search_latency_disabled_major" {
+  description = "Disable major alerting rule for search_latency detector"
   type        = bool
   default     = null
 }
@@ -88,8 +88,8 @@ variable "search_latency_threshold_critical" {
   default     = 4
 }
 
-variable "search_latency_threshold_warning" {
-  description = "Warning threshold for search_latency detector"
+variable "search_latency_threshold_major" {
+  description = "Major threshold for search_latency detector"
   type        = number
   default     = 2
 }
@@ -108,8 +108,8 @@ variable "search_throttled_queries_rate_disabled_critical" {
   default     = null
 }
 
-variable "search_throttled_queries_rate_disabled_warning" {
-  description = "Disable warning alerting rule for search_throttled_queries_rate detector"
+variable "search_throttled_queries_rate_disabled_major" {
+  description = "Disable major alerting rule for search_throttled_queries_rate detector"
   type        = bool
   default     = null
 }
@@ -138,8 +138,8 @@ variable "search_throttled_queries_rate_threshold_critical" {
   default     = 50
 }
 
-variable "search_throttled_queries_rate_threshold_warning" {
-  description = "Warning threshold for search_throttled_queries_rate detector"
+variable "search_throttled_queries_rate_threshold_major" {
+  description = "Major threshold for search_throttled_queries_rate detector"
   type        = number
   default     = 20
 }

--- a/cloud/azure/cosmos-db/detectors-cosmosdb.tf
+++ b/cloud/azure/cosmos-db/detectors-cosmosdb.tf
@@ -28,7 +28,7 @@ resource "signalfx_detector" "db_4xx_requests" {
         B = data('TotalRequests', extrapolation='zero', filter=base_filter and ${module.filter-tags.filter_custom})${var.db_4xx_requests_aggregation_function}
         signal = (A/B).scale(100).fill(0).publish('signal')
         detect(when(signal > threshold(${var.db_4xx_requests_threshold_critical}), lasting="${var.db_4xx_requests_timer}")).publish('CRIT')
-        detect(when(signal > threshold(${var.db_4xx_requests_threshold_warning}), lasting="${var.db_4xx_requests_timer}") and when(signal <= ${var.db_4xx_requests_threshold_critical})).publish('WARN')
+        detect(when(signal > threshold(${var.db_4xx_requests_threshold_major}), lasting="${var.db_4xx_requests_timer}") and when(signal <= ${var.db_4xx_requests_threshold_critical})).publish('MAJOR')
     EOF
 
   rule {
@@ -41,11 +41,11 @@ resource "signalfx_detector" "db_4xx_requests" {
   }
 
   rule {
-    description           = "is too high > ${var.db_4xx_requests_threshold_warning}%"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.db_4xx_requests_disabled_warning, var.db_4xx_requests_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.db_4xx_requests_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.db_4xx_requests_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.db_4xx_requests_disabled_major, var.db_4xx_requests_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.db_4xx_requests_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -60,7 +60,7 @@ resource "signalfx_detector" "db_5xx_requests" {
         B = data('TotalRequests', extrapolation='zero', filter=base_filter and ${module.filter-tags.filter_custom})${var.db_5xx_requests_aggregation_function}
         signal = (A/B).scale(100).fill(0).publish('signal')
         detect(when(signal > threshold(${var.db_5xx_requests_threshold_critical}), lasting="${var.db_5xx_requests_timer}")).publish('CRIT')
-        detect(when(signal > threshold(${var.db_5xx_requests_threshold_warning}), lasting="${var.db_5xx_requests_timer}") and when(signal <= ${var.db_5xx_requests_threshold_critical})).publish('WARN')
+        detect(when(signal > threshold(${var.db_5xx_requests_threshold_major}), lasting="${var.db_5xx_requests_timer}") and when(signal <= ${var.db_5xx_requests_threshold_critical})).publish('MAJOR')
     EOF
 
   rule {
@@ -73,11 +73,11 @@ resource "signalfx_detector" "db_5xx_requests" {
   }
 
   rule {
-    description           = "is too high > ${var.db_5xx_requests_threshold_warning}%"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.db_5xx_requests_disabled_warning, var.db_5xx_requests_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.db_5xx_requests_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.db_5xx_requests_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.db_5xx_requests_disabled_major, var.db_5xx_requests_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.db_5xx_requests_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -92,7 +92,7 @@ resource "signalfx_detector" "scaling" {
         B = data('TotalRequests', extrapolation='zero', filter=base_filter and ${module.filter-tags.filter_custom})${var.scaling_aggregation_function}
         signal = (A/B).scale(100).fill(0).publish('signal')
         detect(when(signal > threshold(${var.scaling_threshold_critical}), lasting="${var.scaling_timer}")).publish('CRIT')
-        detect(when(signal > threshold(${var.scaling_threshold_warning}), lasting="${var.scaling_timer}") and when(signal <= ${var.scaling_threshold_critical})).publish('WARN')
+        detect(when(signal > threshold(${var.scaling_threshold_major}), lasting="${var.scaling_timer}") and when(signal <= ${var.scaling_threshold_critical})).publish('MAJOR')
     EOF
 
   rule {
@@ -105,11 +105,11 @@ resource "signalfx_detector" "scaling" {
   }
 
   rule {
-    description           = "is too high > ${var.scaling_threshold_warning}%"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.scaling_disabled_warning, var.scaling_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.scaling_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.scaling_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.scaling_disabled_major, var.scaling_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.scaling_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/azure/cosmos-db/variables.tf
+++ b/cloud/azure/cosmos-db/variables.tf
@@ -76,8 +76,8 @@ variable "db_4xx_requests_disabled_critical" {
   default     = null
 }
 
-variable "db_4xx_requests_disabled_warning" {
-  description = "Disable warning alerting rule for db_4xx_requests detector"
+variable "db_4xx_requests_disabled_major" {
+  description = "Disable major alerting rule for db_4xx_requests detector"
   type        = bool
   default     = null
 }
@@ -106,8 +106,8 @@ variable "db_4xx_requests_threshold_critical" {
   default     = 80
 }
 
-variable "db_4xx_requests_threshold_warning" {
-  description = "Warning threshold for db_4xx_requests detector"
+variable "db_4xx_requests_threshold_major" {
+  description = "Major threshold for db_4xx_requests detector"
   type        = number
   default     = 50
 }
@@ -126,8 +126,8 @@ variable "db_5xx_requests_disabled_critical" {
   default     = null
 }
 
-variable "db_5xx_requests_disabled_warning" {
-  description = "Disable warning alerting rule for db_5xx_requests detector"
+variable "db_5xx_requests_disabled_major" {
+  description = "Disable major alerting rule for db_5xx_requests detector"
   type        = bool
   default     = null
 }
@@ -156,8 +156,8 @@ variable "db_5xx_requests_threshold_critical" {
   default     = 80
 }
 
-variable "db_5xx_requests_threshold_warning" {
-  description = "Warning threshold for db_5xx_requests detector"
+variable "db_5xx_requests_threshold_major" {
+  description = "Major threshold for db_5xx_requests detector"
   type        = number
   default     = 50
 }
@@ -176,8 +176,8 @@ variable "scaling_disabled_critical" {
   default     = null
 }
 
-variable "scaling_disabled_warning" {
-  description = "Disable warning alerting rule for scaling detector"
+variable "scaling_disabled_major" {
+  description = "Disable major alerting rule for scaling detector"
   type        = bool
   default     = null
 }
@@ -206,8 +206,8 @@ variable "scaling_threshold_critical" {
   default     = 10
 }
 
-variable "scaling_threshold_warning" {
-  description = "Warning threshold for scaling detector"
+variable "scaling_threshold_major" {
+  description = "Major threshold for scaling detector"
   type        = number
   default     = 5
 }

--- a/cloud/azure/functions/detectors-functions.tf
+++ b/cloud/azure/functions/detectors-functions.tf
@@ -27,7 +27,7 @@ resource "signalfx_detector" "http_5xx_errors_rate" {
         B = data('FunctionExecutionCount', extrapolation="zero", filter=base_filter and ${module.filter-tags.filter_custom})${var.http_5xx_errors_rate_aggregation_function}
         signal = (A/B).scale(100).fill(0).publish('signal')
         detect(when(signal > threshold(${var.http_5xx_errors_rate_threshold_critical}), lasting="${var.http_5xx_errors_rate_timer}")).publish('CRIT')
-        detect(when(signal > threshold(${var.http_5xx_errors_rate_threshold_warning}), lasting="${var.http_5xx_errors_rate_timer}") and when(signal <= ${var.http_5xx_errors_rate_threshold_critical})).publish('WARN')
+        detect(when(signal > threshold(${var.http_5xx_errors_rate_threshold_major}), lasting="${var.http_5xx_errors_rate_timer}") and when(signal <= ${var.http_5xx_errors_rate_threshold_critical})).publish('MAJOR')
     EOF
 
   rule {
@@ -40,11 +40,11 @@ resource "signalfx_detector" "http_5xx_errors_rate" {
   }
 
   rule {
-    description           = "is too high > ${var.http_5xx_errors_rate_threshold_warning}%"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.http_5xx_errors_rate_disabled_warning, var.http_5xx_errors_rate_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.http_5xx_errors_rate_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.http_5xx_errors_rate_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.http_5xx_errors_rate_disabled_major, var.http_5xx_errors_rate_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.http_5xx_errors_rate_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -56,7 +56,7 @@ resource "signalfx_detector" "high_connections_count" {
         base_filter = filter('resource_type', 'Microsoft.Web/sites') and filter('is_Azure_Function', 'true') and filter('primary_aggregation_type', 'true')
         signal = data('AppConnections', extrapolation="last_value", filter=base_filter and ${module.filter-tags.filter_custom})${var.high_connections_count_aggregation_function}.publish('signal')
         detect(when(signal > threshold(${var.high_connections_count_threshold_critical}), lasting="${var.high_connections_count_timer}")).publish('CRIT')
-        detect(when(signal > threshold(${var.high_connections_count_threshold_warning}), lasting="${var.high_connections_count_timer}") and when(signal <= ${var.high_connections_count_threshold_critical})).publish('WARN')
+        detect(when(signal > threshold(${var.high_connections_count_threshold_major}), lasting="${var.high_connections_count_timer}") and when(signal <= ${var.high_connections_count_threshold_critical})).publish('MAJOR')
     EOF
 
   rule {
@@ -69,11 +69,11 @@ resource "signalfx_detector" "high_connections_count" {
   }
 
   rule {
-    description           = "is too high > ${var.high_connections_count_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.high_connections_count_disabled_warning, var.high_connections_count_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.high_connections_count_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.high_connections_count_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.high_connections_count_disabled_major, var.high_connections_count_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.high_connections_count_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -85,7 +85,7 @@ resource "signalfx_detector" "high_threads_count" {
         base_filter = filter('resource_type', 'Microsoft.Web/sites') and filter('is_Azure_Function', 'true') and filter('primary_aggregation_type', 'true')
         signal = data('Threads', extrapolation='last_value', filter=base_filter and ${module.filter-tags.filter_custom})${var.high_threads_count_aggregation_function}.publish('signal')
         detect(when(signal > threshold(${var.high_threads_count_threshold_critical}), lasting="${var.high_threads_count_timer}")).publish('CRIT')
-        detect(when(signal > threshold(${var.high_threads_count_threshold_warning}), lasting="${var.high_threads_count_timer}") and when(signal <= ${var.high_threads_count_threshold_critical})).publish('WARN')
+        detect(when(signal > threshold(${var.high_threads_count_threshold_major}), lasting="${var.high_threads_count_timer}") and when(signal <= ${var.high_threads_count_threshold_critical})).publish('MAJOR')
     EOF
 
   rule {
@@ -98,11 +98,11 @@ resource "signalfx_detector" "high_threads_count" {
   }
 
   rule {
-    description           = "is too high > ${var.high_threads_count_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.high_threads_count_disabled_warning, var.high_threads_count_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.high_threads_count_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.high_threads_count_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.high_threads_count_disabled_major, var.high_threads_count_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.high_threads_count_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/azure/functions/variables.tf
+++ b/cloud/azure/functions/variables.tf
@@ -76,8 +76,8 @@ variable "http_5xx_errors_rate_disabled_critical" {
   default     = null
 }
 
-variable "http_5xx_errors_rate_disabled_warning" {
-  description = "Disable warning alerting rule for http_5xx_errors_rate detector"
+variable "http_5xx_errors_rate_disabled_major" {
+  description = "Disable major alerting rule for http_5xx_errors_rate detector"
   type        = bool
   default     = null
 }
@@ -106,8 +106,8 @@ variable "http_5xx_errors_rate_threshold_critical" {
   default     = 20
 }
 
-variable "http_5xx_errors_rate_threshold_warning" {
-  description = "Warning threshold for http_5xx_errors_rate detector"
+variable "http_5xx_errors_rate_threshold_major" {
+  description = "Major threshold for http_5xx_errors_rate detector"
   type        = number
   default     = 10
 }
@@ -126,8 +126,8 @@ variable "high_connections_count_disabled_critical" {
   default     = null
 }
 
-variable "high_connections_count_disabled_warning" {
-  description = "Disable warning alerting rule for high_connections_count detector"
+variable "high_connections_count_disabled_major" {
+  description = "Disable major alerting rule for high_connections_count detector"
   type        = bool
   default     = null
 }
@@ -156,8 +156,8 @@ variable "high_connections_count_threshold_critical" {
   default     = 590
 }
 
-variable "high_connections_count_threshold_warning" {
-  description = "Warning threshold for high_connections_count detector"
+variable "high_connections_count_threshold_major" {
+  description = "Major threshold for high_connections_count detector"
   type        = number
   default     = 550
 }
@@ -176,8 +176,8 @@ variable "high_threads_count_disabled_critical" {
   default     = null
 }
 
-variable "high_threads_count_disabled_warning" {
-  description = "Disable warning alerting rule for high_threads_count detector"
+variable "high_threads_count_disabled_major" {
+  description = "Disable major alerting rule for high_threads_count detector"
   type        = bool
   default     = null
 }
@@ -206,8 +206,8 @@ variable "high_threads_count_threshold_critical" {
   default     = 510
 }
 
-variable "high_threads_count_threshold_warning" {
-  description = "Warning threshold for high_threads_count detector"
+variable "high_threads_count_threshold_major" {
+  description = "Major threshold for high_threads_count detector"
   type        = number
   default     = 490
 }

--- a/cloud/azure/key-vault/detectors-keyvault.tf
+++ b/cloud/azure/key-vault/detectors-keyvault.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "api_result" {
         B = data('ServiceApiResult', extrapolation="zero", filter=base_filter and ${module.filter-tags.filter_custom})${var.api_result_aggregation_function}
         signal = (A/B).scale(100).fill(100).publish('signal')
         detect(when(signal < threshold(${var.api_result_threshold_critical}), lasting="${var.api_result_timer}")).publish('CRIT')
-        detect(when(signal < threshold(${var.api_result_threshold_warning}), lasting="${var.api_result_timer}") and when(signal >= ${var.api_result_threshold_critical})).publish('WARN')
+        detect(when(signal < threshold(${var.api_result_threshold_major}), lasting="${var.api_result_timer}") and when(signal >= ${var.api_result_threshold_critical})).publish('MAJOR')
     EOF
 
   rule {
@@ -20,11 +20,11 @@ resource "signalfx_detector" "api_result" {
   }
 
   rule {
-    description           = "is too low < ${var.api_result_threshold_warning}%"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.api_result_disabled_warning, var.api_result_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.api_result_notifications, "warning", []), var.notifications.warning)
+    description           = "is too low < ${var.api_result_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.api_result_disabled_major, var.api_result_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.api_result_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -36,7 +36,7 @@ resource "signalfx_detector" "api_latency" {
         base_filter = filter('resource_type', 'Microsoft.KeyVault/vaults') and filter('primary_aggregation_type', 'true')
         signal = data('ServiceApiLatency', extrapolation="zero", filter=base_filter and not filter('activityname', 'secretlist') and ${module.filter-tags.filter_custom})${var.api_latency_aggregation_function}.publish('signal')
         detect(when(signal > threshold(${var.api_latency_threshold_critical}), lasting="${var.api_latency_timer}")).publish('CRIT')
-        detect(when(signal > threshold(${var.api_latency_threshold_warning}), lasting="${var.api_latency_timer}") and when(signal <= ${var.api_latency_threshold_critical})).publish('WARN')
+        detect(when(signal > threshold(${var.api_latency_threshold_major}), lasting="${var.api_latency_timer}") and when(signal <= ${var.api_latency_threshold_critical})).publish('MAJOR')
     EOF
 
   rule {
@@ -49,11 +49,11 @@ resource "signalfx_detector" "api_latency" {
   }
 
   rule {
-    description           = "is too high > ${var.api_latency_threshold_warning}ms"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.api_latency_disabled_warning, var.api_latency_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.api_latency_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.api_latency_threshold_major}ms"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.api_latency_disabled_major, var.api_latency_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.api_latency_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/azure/key-vault/variables.tf
+++ b/cloud/azure/key-vault/variables.tf
@@ -56,8 +56,8 @@ variable "api_result_disabled_critical" {
   default     = null
 }
 
-variable "api_result_disabled_warning" {
-  description = "Disable warning alerting rule for api_result detector"
+variable "api_result_disabled_major" {
+  description = "Disable major alerting rule for api_result detector"
   type        = bool
   default     = null
 }
@@ -86,8 +86,8 @@ variable "api_result_threshold_critical" {
   default     = 10
 }
 
-variable "api_result_threshold_warning" {
-  description = "Warning threshold for api_result detector"
+variable "api_result_threshold_major" {
+  description = "Major threshold for api_result detector"
   type        = number
   default     = 30
 }
@@ -106,8 +106,8 @@ variable "api_latency_disabled_critical" {
   default     = null
 }
 
-variable "api_latency_disabled_warning" {
-  description = "Disable warning alerting rule for api_latency detector"
+variable "api_latency_disabled_major" {
+  description = "Disable major alerting rule for api_latency detector"
   type        = bool
   default     = null
 }
@@ -136,8 +136,8 @@ variable "api_latency_threshold_critical" {
   default     = 100
 }
 
-variable "api_latency_threshold_warning" {
-  description = "Warning threshold for api_latency detector"
+variable "api_latency_threshold_major" {
+  description = "Major threshold for api_latency detector"
   type        = number
   default     = 80
 }

--- a/cloud/azure/mysql/detectors-mysql.tf
+++ b/cloud/azure/mysql/detectors-mysql.tf
@@ -25,7 +25,7 @@ resource "signalfx_detector" "cpu_usage" {
         base_filter = filter('resource_type', 'Microsoft.DBforMySQL/servers') and filter('primary_aggregation_type', 'true')
         signal = data('cpu_percent', filter=base_filter and ${module.filter-tags.filter_custom})${var.cpu_usage_aggregation_function}.publish('signal')
         detect(when(signal > threshold(${var.cpu_usage_threshold_critical}), lasting="${var.cpu_usage_timer}")).publish('CRIT')
-        detect(when(signal > threshold(${var.cpu_usage_threshold_warning}), lasting="${var.cpu_usage_timer}") and when(signal <= ${var.cpu_usage_threshold_critical})).publish('WARN')
+        detect(when(signal > threshold(${var.cpu_usage_threshold_major}), lasting="${var.cpu_usage_timer}") and when(signal <= ${var.cpu_usage_threshold_critical})).publish('MAJOR')
     EOF
 
   rule {
@@ -38,11 +38,11 @@ resource "signalfx_detector" "cpu_usage" {
   }
 
   rule {
-    description           = "is too high > ${var.cpu_usage_threshold_warning}%"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.cpu_usage_disabled_warning, var.cpu_usage_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.cpu_usage_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.cpu_usage_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.cpu_usage_disabled_major, var.cpu_usage_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.cpu_usage_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -55,7 +55,7 @@ resource "signalfx_detector" "free_storage" {
         A = data('storage_percent', filter=base_filter and ${module.filter-tags.filter_custom})${var.free_storage_aggregation_function}
         signal = (100-A).publish('signal')
         detect(when(signal < threshold(${var.free_storage_threshold_critical}), lasting="${var.free_storage_timer}")).publish('CRIT')
-        detect(when(signal < threshold(${var.free_storage_threshold_warning}), lasting="${var.free_storage_timer}") and when(signal >= ${var.free_storage_threshold_critical})).publish('WARN')
+        detect(when(signal < threshold(${var.free_storage_threshold_major}), lasting="${var.free_storage_timer}") and when(signal >= ${var.free_storage_threshold_critical})).publish('MAJOR')
     EOF
 
   rule {
@@ -68,11 +68,11 @@ resource "signalfx_detector" "free_storage" {
   }
 
   rule {
-    description           = "is too low < ${var.free_storage_threshold_warning}%"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.free_storage_disabled_warning, var.free_storage_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.free_storage_notifications, "warning", []), var.notifications.warning)
+    description           = "is too low < ${var.free_storage_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.free_storage_disabled_major, var.free_storage_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.free_storage_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -84,7 +84,7 @@ resource "signalfx_detector" "io_consumption" {
         base_filter = filter('resource_type', 'Microsoft.DBforMySQL/servers') and filter('primary_aggregation_type', 'true')
         signal = data('io_consumption_percent', filter=base_filter and ${module.filter-tags.filter_custom})${var.io_consumption_aggregation_function}.publish('signal')
         detect(when(signal > threshold(${var.io_consumption_threshold_critical}), lasting="${var.io_consumption_timer}")).publish('CRIT')
-        detect(when(signal > threshold(${var.io_consumption_threshold_warning}), lasting="${var.io_consumption_timer}") and when(signal <= ${var.io_consumption_threshold_critical})).publish('WARN')
+        detect(when(signal > threshold(${var.io_consumption_threshold_major}), lasting="${var.io_consumption_timer}") and when(signal <= ${var.io_consumption_threshold_critical})).publish('MAJOR')
     EOF
 
   rule {
@@ -97,11 +97,11 @@ resource "signalfx_detector" "io_consumption" {
   }
 
   rule {
-    description           = "is too high > ${var.io_consumption_threshold_warning}%"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.io_consumption_disabled_warning, var.io_consumption_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.io_consumption_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.io_consumption_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.io_consumption_disabled_major, var.io_consumption_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.io_consumption_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -113,7 +113,7 @@ resource "signalfx_detector" "memory_usage" {
         base_filter = filter('resource_type', 'Microsoft.DBforMySQL/servers') and filter('primary_aggregation_type', 'true')
         signal = data('memory_percent', filter=base_filter and ${module.filter-tags.filter_custom})${var.memory_usage_aggregation_function}.publish('signal')
         detect(when(signal > threshold(${var.memory_usage_threshold_critical}), lasting="${var.memory_usage_timer}")).publish('CRIT')
-        detect(when(signal > threshold(${var.memory_usage_threshold_warning}), lasting="${var.memory_usage_timer}") and when(signal <= ${var.memory_usage_threshold_critical})).publish('WARN')
+        detect(when(signal > threshold(${var.memory_usage_threshold_major}), lasting="${var.memory_usage_timer}") and when(signal <= ${var.memory_usage_threshold_critical})).publish('MAJOR')
     EOF
 
   rule {
@@ -126,11 +126,11 @@ resource "signalfx_detector" "memory_usage" {
   }
 
   rule {
-    description           = "is too high > ${var.memory_usage_threshold_warning}%"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.memory_usage_disabled_warning, var.memory_usage_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.memory_usage_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.memory_usage_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.memory_usage_disabled_major, var.memory_usage_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.memory_usage_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -142,7 +142,7 @@ resource "signalfx_detector" "replication_lag" {
         base_filter = filter('resource_type', 'Microsoft.DBforMySQL/servers') and filter('primary_aggregation_type', 'true')
         signal = data('seconds_behind_master', filter=base_filter and ${module.filter-tags.filter_custom})${var.replication_lag_aggregation_function}.publish('signal')
         detect(when(signal > threshold(${var.replication_lag_threshold_critical}), lasting="${var.replication_lag_timer}")).publish('CRIT')
-        detect(when(signal > threshold(${var.replication_lag_threshold_warning}), lasting="${var.replication_lag_timer}") and when(signal <= ${var.replication_lag_threshold_critical})).publish('WARN')
+        detect(when(signal > threshold(${var.replication_lag_threshold_major}), lasting="${var.replication_lag_timer}") and when(signal <= ${var.replication_lag_threshold_critical})).publish('MAJOR')
     EOF
 
   rule {
@@ -155,11 +155,11 @@ resource "signalfx_detector" "replication_lag" {
   }
 
   rule {
-    description           = "is too high > ${var.replication_lag_threshold_warning}s"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.replication_lag_disabled_warning, var.replication_lag_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.replication_lag_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.replication_lag_threshold_major}s"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.replication_lag_disabled_major, var.replication_lag_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.replication_lag_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/azure/mysql/variables.tf
+++ b/cloud/azure/mysql/variables.tf
@@ -76,8 +76,8 @@ variable "cpu_usage_disabled_critical" {
   default     = null
 }
 
-variable "cpu_usage_disabled_warning" {
-  description = "Disable warning alerting rule for cpu_usage detector"
+variable "cpu_usage_disabled_major" {
+  description = "Disable major alerting rule for cpu_usage detector"
   type        = bool
   default     = null
 }
@@ -106,8 +106,8 @@ variable "cpu_usage_threshold_critical" {
   default     = 90
 }
 
-variable "cpu_usage_threshold_warning" {
-  description = "Warning threshold for cpu_usage detector"
+variable "cpu_usage_threshold_major" {
+  description = "Major threshold for cpu_usage detector"
   type        = number
   default     = 80
 }
@@ -126,8 +126,8 @@ variable "free_storage_disabled_critical" {
   default     = null
 }
 
-variable "free_storage_disabled_warning" {
-  description = "Disable warning alerting rule for free_storage detector"
+variable "free_storage_disabled_major" {
+  description = "Disable major alerting rule for free_storage detector"
   type        = bool
   default     = null
 }
@@ -156,8 +156,8 @@ variable "free_storage_threshold_critical" {
   default     = 10
 }
 
-variable "free_storage_threshold_warning" {
-  description = "Warning threshold for free_storage detector"
+variable "free_storage_threshold_major" {
+  description = "Major threshold for free_storage detector"
   type        = number
   default     = 20
 }
@@ -176,8 +176,8 @@ variable "io_consumption_disabled_critical" {
   default     = null
 }
 
-variable "io_consumption_disabled_warning" {
-  description = "Disable warning alerting rule for io_consumption detector"
+variable "io_consumption_disabled_major" {
+  description = "Disable major alerting rule for io_consumption detector"
   type        = bool
   default     = null
 }
@@ -206,8 +206,8 @@ variable "io_consumption_threshold_critical" {
   default     = 90
 }
 
-variable "io_consumption_threshold_warning" {
-  description = "Warning threshold for io_consumption detector"
+variable "io_consumption_threshold_major" {
+  description = "Major threshold for io_consumption detector"
   type        = number
   default     = 80
 }
@@ -226,8 +226,8 @@ variable "memory_usage_disabled_critical" {
   default     = null
 }
 
-variable "memory_usage_disabled_warning" {
-  description = "Disable warning alerting rule for memory_usage detector"
+variable "memory_usage_disabled_major" {
+  description = "Disable major alerting rule for memory_usage detector"
   type        = bool
   default     = null
 }
@@ -256,8 +256,8 @@ variable "memory_usage_threshold_critical" {
   default     = 90
 }
 
-variable "memory_usage_threshold_warning" {
-  description = "Warning threshold for memory_usage detector"
+variable "memory_usage_threshold_major" {
+  description = "Major threshold for memory_usage detector"
   type        = number
   default     = 80
 }
@@ -276,8 +276,8 @@ variable "replication_lag_disabled_critical" {
   default     = null
 }
 
-variable "replication_lag_disabled_warning" {
-  description = "Disable warning alerting rule for replication_lag detector"
+variable "replication_lag_disabled_major" {
+  description = "Disable major alerting rule for replication_lag detector"
   type        = bool
   default     = null
 }
@@ -306,8 +306,8 @@ variable "replication_lag_threshold_critical" {
   default     = 200
 }
 
-variable "replication_lag_threshold_warning" {
-  description = "Warning threshold in seconds for replication_lag detector"
+variable "replication_lag_threshold_major" {
+  description = "Major threshold in seconds for replication_lag detector"
   type        = number
   default     = 100
 }

--- a/cloud/azure/postgresql/detectors-postgresql.tf
+++ b/cloud/azure/postgresql/detectors-postgresql.tf
@@ -25,7 +25,7 @@ resource "signalfx_detector" "cpu_usage" {
         base_filter = filter('resource_type', 'Microsoft.DBforPostgreSQL/servers') and filter('primary_aggregation_type', 'true')
         signal = data('cpu_percent', filter=base_filter and ${module.filter-tags.filter_custom})${var.cpu_usage_aggregation_function}.publish('signal')
         detect(when(signal > threshold(${var.cpu_usage_threshold_critical}), lasting="${var.cpu_usage_timer}")).publish('CRIT')
-        detect(when(signal > threshold(${var.cpu_usage_threshold_warning}), lasting="${var.cpu_usage_timer}") and when(signal <= ${var.cpu_usage_threshold_critical})).publish('WARN')
+        detect(when(signal > threshold(${var.cpu_usage_threshold_major}), lasting="${var.cpu_usage_timer}") and when(signal <= ${var.cpu_usage_threshold_critical})).publish('MAJOR')
     EOF
 
   rule {
@@ -38,11 +38,11 @@ resource "signalfx_detector" "cpu_usage" {
   }
 
   rule {
-    description           = "is too high > ${var.cpu_usage_threshold_warning}%"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.cpu_usage_disabled_warning, var.cpu_usage_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.cpu_usage_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.cpu_usage_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.cpu_usage_disabled_major, var.cpu_usage_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.cpu_usage_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -73,7 +73,7 @@ resource "signalfx_detector" "free_storage" {
         A = data('storage_percent', filter=base_filter and ${module.filter-tags.filter_custom})${var.free_storage_aggregation_function}
         signal = (100-A).publish('signal')
         detect(when(signal < threshold(${var.free_storage_threshold_critical}), lasting="${var.free_storage_timer}")).publish('CRIT')
-        detect(when(signal < threshold(${var.free_storage_threshold_warning}), lasting="${var.free_storage_timer}") and when(signal >= ${var.free_storage_threshold_critical})).publish('WARN')
+        detect(when(signal < threshold(${var.free_storage_threshold_major}), lasting="${var.free_storage_timer}") and when(signal >= ${var.free_storage_threshold_critical})).publish('MAJOR')
     EOF
 
   rule {
@@ -86,11 +86,11 @@ resource "signalfx_detector" "free_storage" {
   }
 
   rule {
-    description           = "is too low < ${var.free_storage_threshold_warning}%"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.free_storage_disabled_warning, var.free_storage_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.free_storage_notifications, "warning", []), var.notifications.warning)
+    description           = "is too low < ${var.free_storage_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.free_storage_disabled_major, var.free_storage_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.free_storage_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -102,7 +102,7 @@ resource "signalfx_detector" "io_consumption" {
         base_filter = filter('resource_type', 'Microsoft.DBforPostgreSQL/servers') and filter('primary_aggregation_type', 'true')
         signal = data('io_consumption_percent', filter=base_filter and ${module.filter-tags.filter_custom})${var.io_consumption_aggregation_function}.publish('signal')
         detect(when(signal > threshold(${var.io_consumption_threshold_critical}), lasting="${var.io_consumption_timer}")).publish('CRIT')
-        detect(when(signal > threshold(${var.io_consumption_threshold_warning}), lasting="${var.io_consumption_timer}") and when(signal <= ${var.io_consumption_threshold_critical})).publish('WARN')
+        detect(when(signal > threshold(${var.io_consumption_threshold_major}), lasting="${var.io_consumption_timer}") and when(signal <= ${var.io_consumption_threshold_critical})).publish('MAJOR')
     EOF
 
   rule {
@@ -115,11 +115,11 @@ resource "signalfx_detector" "io_consumption" {
   }
 
   rule {
-    description           = "is too high > ${var.io_consumption_threshold_warning}%"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.io_consumption_disabled_warning, var.io_consumption_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.io_consumption_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.io_consumption_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.io_consumption_disabled_major, var.io_consumption_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.io_consumption_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -131,7 +131,7 @@ resource "signalfx_detector" "memory_usage" {
         base_filter = filter('resource_type', 'Microsoft.DBforPostgreSQL/servers') and filter('primary_aggregation_type', 'true')
         signal = data('memory_percent', filter=base_filter and ${module.filter-tags.filter_custom})${var.memory_usage_aggregation_function}.publish('signal')
         detect(when(signal > threshold(${var.memory_usage_threshold_critical}), lasting="${var.memory_usage_timer}")).publish('CRIT')
-        detect(when(signal > threshold(${var.memory_usage_threshold_warning}), lasting="${var.memory_usage_timer}") and when(signal <= ${var.memory_usage_threshold_critical})).publish('WARN')
+        detect(when(signal > threshold(${var.memory_usage_threshold_major}), lasting="${var.memory_usage_timer}") and when(signal <= ${var.memory_usage_threshold_critical})).publish('MAJOR')
     EOF
 
   rule {
@@ -144,11 +144,11 @@ resource "signalfx_detector" "memory_usage" {
   }
 
   rule {
-    description           = "is too high > ${var.memory_usage_threshold_warning}%"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.memory_usage_disabled_warning, var.memory_usage_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.memory_usage_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.memory_usage_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.memory_usage_disabled_major, var.memory_usage_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.memory_usage_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/azure/postgresql/variables.tf
+++ b/cloud/azure/postgresql/variables.tf
@@ -76,8 +76,8 @@ variable "cpu_usage_disabled_critical" {
   default     = null
 }
 
-variable "cpu_usage_disabled_warning" {
-  description = "Disable warning alerting rule for cpu_usage detector"
+variable "cpu_usage_disabled_major" {
+  description = "Disable major alerting rule for cpu_usage detector"
   type        = bool
   default     = null
 }
@@ -106,8 +106,8 @@ variable "cpu_usage_threshold_critical" {
   default     = 90
 }
 
-variable "cpu_usage_threshold_warning" {
-  description = "Warning threshold for cpu_usage detector"
+variable "cpu_usage_threshold_major" {
+  description = "Major threshold for cpu_usage detector"
   type        = number
   default     = 80
 }
@@ -158,8 +158,8 @@ variable "free_storage_disabled_critical" {
   default     = null
 }
 
-variable "free_storage_disabled_warning" {
-  description = "Disable warning alerting rule for free_storage detector"
+variable "free_storage_disabled_major" {
+  description = "Disable major alerting rule for free_storage detector"
   type        = bool
   default     = null
 }
@@ -188,8 +188,8 @@ variable "free_storage_threshold_critical" {
   default     = 10
 }
 
-variable "free_storage_threshold_warning" {
-  description = "Warning threshold for free_storage detector"
+variable "free_storage_threshold_major" {
+  description = "Major threshold for free_storage detector"
   type        = number
   default     = 20
 }
@@ -208,8 +208,8 @@ variable "io_consumption_disabled_critical" {
   default     = null
 }
 
-variable "io_consumption_disabled_warning" {
-  description = "Disable warning alerting rule for io_consumption detector"
+variable "io_consumption_disabled_major" {
+  description = "Disable major alerting rule for io_consumption detector"
   type        = bool
   default     = null
 }
@@ -238,8 +238,8 @@ variable "io_consumption_threshold_critical" {
   default     = 90
 }
 
-variable "io_consumption_threshold_warning" {
-  description = "Warning threshold for io_consumption detector"
+variable "io_consumption_threshold_major" {
+  description = "Major threshold for io_consumption detector"
   type        = number
   default     = 80
 }
@@ -258,8 +258,8 @@ variable "memory_usage_disabled_critical" {
   default     = null
 }
 
-variable "memory_usage_disabled_warning" {
-  description = "Disable warning alerting rule for memory_usage detector"
+variable "memory_usage_disabled_major" {
+  description = "Disable major alerting rule for memory_usage detector"
   type        = bool
   default     = null
 }
@@ -288,8 +288,8 @@ variable "memory_usage_threshold_critical" {
   default     = 90
 }
 
-variable "memory_usage_threshold_warning" {
-  description = "Warning threshold for memory_usage detector"
+variable "memory_usage_threshold_major" {
+  description = "Major threshold for memory_usage detector"
   type        = number
   default     = 80
 }

--- a/cloud/azure/redis/detectors-azure-redis.tf
+++ b/cloud/azure/redis/detectors-azure-redis.tf
@@ -25,7 +25,7 @@ resource "signalfx_detector" "evictedkeys" {
         base_filter = filter('resource_type', 'Microsoft.Cache/Redis') and filter('primary_aggregation_type', 'true')
         signal = data('evictedkeys', filter=base_filter and ${module.filter-tags.filter_custom})${var.evictedkeys_aggregation_function}.publish('signal')
         detect(when(signal > threshold(${var.evictedkeys_threshold_critical}), lasting="${var.evictedkeys_timer}")).publish('CRIT')
-        detect(when(signal > threshold(${var.evictedkeys_threshold_warning}), lasting="${var.evictedkeys_timer}") and when(signal <= ${var.evictedkeys_threshold_critical})).publish('WARN')
+        detect(when(signal > threshold(${var.evictedkeys_threshold_major}), lasting="${var.evictedkeys_timer}") and when(signal <= ${var.evictedkeys_threshold_critical})).publish('MAJOR')
     EOF
 
   rule {
@@ -38,11 +38,11 @@ resource "signalfx_detector" "evictedkeys" {
   }
 
   rule {
-    description           = "are too high > ${var.evictedkeys_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.evictedkeys_disabled_warning, var.evictedkeys_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.evictedkeys_notifications, "warning", []), var.notifications.warning)
+    description           = "are too high > ${var.evictedkeys_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.evictedkeys_disabled_major, var.evictedkeys_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.evictedkeys_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -54,7 +54,7 @@ resource "signalfx_detector" "percent_processor_time" {
         base_filter = filter('resource_type', 'Microsoft.Cache/Redis') and filter('primary_aggregation_type', 'true')
         signal = data('percentProcessorTime', filter=base_filter and ${module.filter-tags.filter_custom})${var.percent_processor_time_aggregation_function}.publish('signal')
         detect(when(signal > threshold(${var.percent_processor_time_threshold_critical}), lasting="${var.percent_processor_time_timer}")).publish('CRIT')
-        detect(when(signal > threshold(${var.percent_processor_time_threshold_warning}), lasting="${var.percent_processor_time_timer}") and when(signal <= ${var.percent_processor_time_threshold_critical})).publish('WARN')
+        detect(when(signal > threshold(${var.percent_processor_time_threshold_major}), lasting="${var.percent_processor_time_timer}") and when(signal <= ${var.percent_processor_time_threshold_critical})).publish('MAJOR')
     EOF
 
   rule {
@@ -67,11 +67,11 @@ resource "signalfx_detector" "percent_processor_time" {
   }
 
   rule {
-    description           = "is too high > ${var.percent_processor_time_threshold_warning}%"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.percent_processor_time_disabled_warning, var.percent_processor_time_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.percent_processor_time_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.percent_processor_time_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.percent_processor_time_disabled_major, var.percent_processor_time_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.percent_processor_time_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -83,7 +83,7 @@ resource "signalfx_detector" "load" {
         base_filter = filter('resource_type', 'Microsoft.Cache/Redis') and filter('primary_aggregation_type', 'true')
         signal = data('serverLoad', filter=base_filter and ${module.filter-tags.filter_custom})${var.load_aggregation_function}.publish('signal')
         detect(when(signal > threshold(${var.load_threshold_critical}), lasting="${var.load_timer}")).publish('CRIT')
-        detect(when(signal > threshold(${var.load_threshold_warning}), lasting="${var.load_timer}") and when(signal <= ${var.load_threshold_critical})).publish('WARN')
+        detect(when(signal > threshold(${var.load_threshold_major}), lasting="${var.load_timer}") and when(signal <= ${var.load_threshold_critical})).publish('MAJOR')
     EOF
 
   rule {
@@ -96,11 +96,11 @@ resource "signalfx_detector" "load" {
   }
 
   rule {
-    description           = "is too high > ${var.load_threshold_warning}%"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.load_disabled_warning, var.load_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.load_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.load_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.load_disabled_major, var.load_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.load_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/azure/redis/variables.tf
+++ b/cloud/azure/redis/variables.tf
@@ -76,8 +76,8 @@ variable "evictedkeys_disabled_critical" {
   default     = null
 }
 
-variable "evictedkeys_disabled_warning" {
-  description = "Disable warning alerting rule for evictedkeys detector"
+variable "evictedkeys_disabled_major" {
+  description = "Disable major alerting rule for evictedkeys detector"
   type        = bool
   default     = null
 }
@@ -106,8 +106,8 @@ variable "evictedkeys_threshold_critical" {
   default     = 100
 }
 
-variable "evictedkeys_threshold_warning" {
-  description = "Warning threshold for evictedkeys detector"
+variable "evictedkeys_threshold_major" {
+  description = "Major threshold for evictedkeys detector"
   type        = number
   default     = 0
 }
@@ -126,8 +126,8 @@ variable "percent_processor_time_disabled_critical" {
   default     = null
 }
 
-variable "percent_processor_time_disabled_warning" {
-  description = "Disable warning alerting rule for percent_processor_time detector"
+variable "percent_processor_time_disabled_major" {
+  description = "Disable major alerting rule for percent_processor_time detector"
   type        = bool
   default     = null
 }
@@ -156,8 +156,8 @@ variable "percent_processor_time_threshold_critical" {
   default     = 80
 }
 
-variable "percent_processor_time_threshold_warning" {
-  description = "Warning threshold for percent_processor_time detector"
+variable "percent_processor_time_threshold_major" {
+  description = "Major threshold for percent_processor_time detector"
   type        = number
   default     = 60
 }
@@ -176,8 +176,8 @@ variable "load_disabled_critical" {
   default     = null
 }
 
-variable "load_disabled_warning" {
-  description = "Disable warning alerting rule for load detector"
+variable "load_disabled_major" {
+  description = "Disable major alerting rule for load detector"
   type        = bool
   default     = null
 }
@@ -206,8 +206,8 @@ variable "load_threshold_critical" {
   default     = 90
 }
 
-variable "load_threshold_warning" {
-  description = "Warning threshold for load detector"
+variable "load_threshold_major" {
+  description = "Major threshold for load detector"
   type        = number
   default     = 70
 }

--- a/cloud/azure/service-bus/detectors-service-bus.tf
+++ b/cloud/azure/service-bus/detectors-service-bus.tf
@@ -47,7 +47,7 @@ resource "signalfx_detector" "user_errors" {
         B = data('IncomingRequests', extrapolation='zero', filter=base_filter)${var.user_errors_aggregation_function}
         signal = (A/B).scale(100).fill(0).publish('signal')
         detect(when(signal > threshold(${var.user_errors_threshold_critical}), lasting="${var.user_errors_timer}")).publish('CRIT')
-        detect(when(signal > threshold(${var.user_errors_threshold_warning}), lasting="${var.user_errors_timer}") and when(signal <= ${var.user_errors_threshold_critical})).publish('WARN')
+        detect(when(signal > threshold(${var.user_errors_threshold_major}), lasting="${var.user_errors_timer}") and when(signal <= ${var.user_errors_threshold_critical})).publish('MAJOR')
     EOF
 
   rule {
@@ -60,11 +60,11 @@ resource "signalfx_detector" "user_errors" {
   }
 
   rule {
-    description           = "is too high > ${var.user_errors_threshold_warning}%"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.user_errors_disabled_warning, var.user_errors_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.user_errors_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.user_errors_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.user_errors_disabled_major, var.user_errors_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.user_errors_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -78,7 +78,7 @@ resource "signalfx_detector" "server_errors" {
         B = data('IncomingRequests', extrapolation='zero', filter=base_filter)${var.server_errors_aggregation_function}
         signal = (A/B).scale(100).fill(0).publish('signal')
         detect(when(signal > threshold(${var.server_errors_threshold_critical}), lasting="${var.server_errors_timer}")).publish('CRIT')
-        detect(when(signal > threshold(${var.server_errors_threshold_warning}), lasting="${var.server_errors_timer}") and when(signal <= ${var.server_errors_threshold_critical})).publish('WARN')
+        detect(when(signal > threshold(${var.server_errors_threshold_major}), lasting="${var.server_errors_timer}") and when(signal <= ${var.server_errors_threshold_critical})).publish('MAJOR')
     EOF
 
   rule {
@@ -91,11 +91,11 @@ resource "signalfx_detector" "server_errors" {
   }
 
   rule {
-    description           = "is too high > ${var.server_errors_threshold_warning}%"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.server_errors_disabled_warning, var.server_errors_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.server_errors_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.server_errors_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.server_errors_disabled_major, var.server_errors_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.server_errors_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/azure/service-bus/variables.tf
+++ b/cloud/azure/service-bus/variables.tf
@@ -114,8 +114,8 @@ variable "user_errors_disabled_critical" {
   default     = null
 }
 
-variable "user_errors_disabled_warning" {
-  description = "Disable warning alerting rule for user_errors detector"
+variable "user_errors_disabled_major" {
+  description = "Disable major alerting rule for user_errors detector"
   type        = bool
   default     = null
 }
@@ -144,8 +144,8 @@ variable "user_errors_threshold_critical" {
   default     = 90
 }
 
-variable "user_errors_threshold_warning" {
-  description = "Warning threshold for user_errors detector"
+variable "user_errors_threshold_major" {
+  description = "Major threshold for user_errors detector"
   type        = number
   default     = 50
 }
@@ -164,8 +164,8 @@ variable "server_errors_disabled_critical" {
   default     = null
 }
 
-variable "server_errors_disabled_warning" {
-  description = "Disable warning alerting rule for server_errors detector"
+variable "server_errors_disabled_major" {
+  description = "Disable major alerting rule for server_errors detector"
   type        = bool
   default     = null
 }
@@ -194,8 +194,8 @@ variable "server_errors_threshold_critical" {
   default     = 90
 }
 
-variable "server_errors_threshold_warning" {
-  description = "Warning threshold for server_errors detector"
+variable "server_errors_threshold_major" {
+  description = "Major threshold for server_errors detector"
   type        = number
   default     = 50
 }

--- a/cloud/azure/sql-database/detectors-sql-database.tf
+++ b/cloud/azure/sql-database/detectors-sql-database.tf
@@ -25,7 +25,7 @@ resource "signalfx_detector" "cpu" {
         base_filter = filter('resource_type', 'Microsoft.Sql/servers/databases') and filter('primary_aggregation_type', 'true')
         signal = data('cpu_percent', filter=base_filter and ${module.filter-tags.filter_custom})${var.cpu_aggregation_function}.publish('signal')
         detect(when(signal > threshold(${var.cpu_threshold_critical}), lasting="${var.cpu_timer}")).publish('CRIT')
-        detect(when(signal > threshold(${var.cpu_threshold_warning}), lasting="${var.cpu_timer}") and when(signal <= ${var.cpu_threshold_critical})).publish('WARN')
+        detect(when(signal > threshold(${var.cpu_threshold_major}), lasting="${var.cpu_timer}") and when(signal <= ${var.cpu_threshold_critical})).publish('MAJOR')
     EOF
 
   rule {
@@ -38,11 +38,11 @@ resource "signalfx_detector" "cpu" {
   }
 
   rule {
-    description           = "is too high > ${var.cpu_threshold_warning}%"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.cpu_disabled_warning, var.cpu_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.cpu_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.cpu_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.cpu_disabled_major, var.cpu_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.cpu_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -54,7 +54,7 @@ resource "signalfx_detector" "free_space" {
         base_filter = filter('resource_type', 'Microsoft.Sql/servers/databases') and filter('primary_aggregation_type', 'true')
         signal = data('storage_percent', filter=base_filter and ${module.filter-tags.filter_custom})${var.free_space_aggregation_function}.publish('signal')
         detect(when(signal > threshold(${var.free_space_threshold_critical}), lasting="${var.free_space_timer}")).publish('CRIT')
-        detect(when(signal > threshold(${var.free_space_threshold_warning}), lasting="${var.free_space_timer}") and when(signal <= ${var.free_space_threshold_critical})).publish('WARN')
+        detect(when(signal > threshold(${var.free_space_threshold_major}), lasting="${var.free_space_timer}") and when(signal <= ${var.free_space_threshold_critical})).publish('MAJOR')
     EOF
 
   rule {
@@ -67,11 +67,11 @@ resource "signalfx_detector" "free_space" {
   }
 
   rule {
-    description           = "is too high > ${var.free_space_threshold_warning}%"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.free_space_disabled_warning, var.free_space_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.free_space_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.free_space_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.free_space_disabled_major, var.free_space_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.free_space_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -83,7 +83,7 @@ resource "signalfx_detector" "dtu_consumption" {
         base_filter = filter('resource_type', 'Microsoft.Sql/servers/databases') and filter('primary_aggregation_type', 'true')
         signal = data('dtu_consumption_percent', filter=base_filter and ${module.filter-tags.filter_custom})${var.dtu_consumption_aggregation_function}.publish('signal')
         detect(when(signal > threshold(${var.dtu_consumption_threshold_critical}), lasting="${var.dtu_consumption_timer}")).publish('CRIT')
-        detect(when(signal > threshold(${var.dtu_consumption_threshold_warning}), lasting="${var.dtu_consumption_timer}") and when(signal <= ${var.dtu_consumption_threshold_critical})).publish('WARN')
+        detect(when(signal > threshold(${var.dtu_consumption_threshold_major}), lasting="${var.dtu_consumption_timer}") and when(signal <= ${var.dtu_consumption_threshold_critical})).publish('MAJOR')
     EOF
 
   rule {
@@ -96,11 +96,11 @@ resource "signalfx_detector" "dtu_consumption" {
   }
 
   rule {
-    description           = "is too high > ${var.dtu_consumption_threshold_warning}%"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.dtu_consumption_disabled_warning, var.dtu_consumption_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.dtu_consumption_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.dtu_consumption_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.dtu_consumption_disabled_major, var.dtu_consumption_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.dtu_consumption_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/azure/sql-database/variables.tf
+++ b/cloud/azure/sql-database/variables.tf
@@ -76,8 +76,8 @@ variable "cpu_disabled_critical" {
   default     = null
 }
 
-variable "cpu_disabled_warning" {
-  description = "Disable warning alerting rule for cpu detector"
+variable "cpu_disabled_major" {
+  description = "Disable major alerting rule for cpu detector"
   type        = bool
   default     = null
 }
@@ -106,8 +106,8 @@ variable "cpu_threshold_critical" {
   default     = 90
 }
 
-variable "cpu_threshold_warning" {
-  description = "Warning threshold for cpu detector"
+variable "cpu_threshold_major" {
+  description = "Major threshold for cpu detector"
   type        = number
   default     = 80
 }
@@ -126,8 +126,8 @@ variable "free_space_disabled_critical" {
   default     = null
 }
 
-variable "free_space_disabled_warning" {
-  description = "Disable warning alerting rule for free_space detector"
+variable "free_space_disabled_major" {
+  description = "Disable major alerting rule for free_space detector"
   type        = bool
   default     = null
 }
@@ -156,8 +156,8 @@ variable "free_space_threshold_critical" {
   default     = 90
 }
 
-variable "free_space_threshold_warning" {
-  description = "Warning threshold for free_space detector"
+variable "free_space_threshold_major" {
+  description = "Major threshold for free_space detector"
   type        = number
   default     = 80
 }
@@ -176,8 +176,8 @@ variable "dtu_consumption_disabled_critical" {
   default     = null
 }
 
-variable "dtu_consumption_disabled_warning" {
-  description = "Disable warning alerting rule for dtu_consumption detector"
+variable "dtu_consumption_disabled_major" {
+  description = "Disable major alerting rule for dtu_consumption detector"
   type        = bool
   default     = null
 }
@@ -206,8 +206,8 @@ variable "dtu_consumption_threshold_critical" {
   default     = 90
 }
 
-variable "dtu_consumption_threshold_warning" {
-  description = "Warning threshold for dtu_consumption detector"
+variable "dtu_consumption_threshold_major" {
+  description = "Major threshold for dtu_consumption detector"
   type        = number
   default     = 85
 }

--- a/cloud/azure/sql-elastic-pool/detectors-sql-elasticpool.tf
+++ b/cloud/azure/sql-elastic-pool/detectors-sql-elasticpool.tf
@@ -25,7 +25,7 @@ resource "signalfx_detector" "cpu" {
         base_filter = filter('resource_type', 'Microsoft.Sql/servers/elasticpools') and filter('primary_aggregation_type', 'true')
         signal = data('cpu_percent', filter=base_filter and ${module.filter-tags.filter_custom})${var.cpu_aggregation_function}.publish('signal')
         detect(when(signal > threshold(${var.cpu_threshold_critical}), lasting="${var.cpu_timer}")).publish('CRIT')
-        detect(when(signal > threshold(${var.cpu_threshold_warning}), lasting="${var.cpu_timer}") and when(signal <= ${var.cpu_threshold_critical})).publish('WARN')
+        detect(when(signal > threshold(${var.cpu_threshold_major}), lasting="${var.cpu_timer}") and when(signal <= ${var.cpu_threshold_critical})).publish('MAJOR')
     EOF
 
   rule {
@@ -38,11 +38,11 @@ resource "signalfx_detector" "cpu" {
   }
 
   rule {
-    description           = "is too high > ${var.cpu_threshold_warning}%"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.cpu_disabled_warning, var.cpu_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.cpu_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.cpu_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.cpu_disabled_major, var.cpu_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.cpu_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -54,7 +54,7 @@ resource "signalfx_detector" "free_space" {
         base_filter = filter('resource_type', 'Microsoft.Sql/servers/elasticpools') and filter('primary_aggregation_type', 'true')
         signal = data('storage_percent', filter=base_filter and ${module.filter-tags.filter_custom})${var.free_space_aggregation_function}.publish('signal')
         detect(when(signal > threshold(${var.free_space_threshold_critical}), lasting="${var.free_space_timer}")).publish('CRIT')
-        detect(when(signal > threshold(${var.free_space_threshold_warning}), lasting="${var.free_space_timer}") and when(signal <= ${var.free_space_threshold_critical})).publish('WARN')
+        detect(when(signal > threshold(${var.free_space_threshold_major}), lasting="${var.free_space_timer}") and when(signal <= ${var.free_space_threshold_critical})).publish('MAJOR')
     EOF
 
   rule {
@@ -67,11 +67,11 @@ resource "signalfx_detector" "free_space" {
   }
 
   rule {
-    description           = "is too high > ${var.free_space_threshold_warning}%"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.free_space_disabled_warning, var.free_space_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.free_space_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.free_space_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.free_space_disabled_major, var.free_space_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.free_space_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -83,7 +83,7 @@ resource "signalfx_detector" "dtu_consumption" {
         base_filter = filter('resource_type', 'Microsoft.Sql/servers/elasticpools') and filter('primary_aggregation_type', 'true')
         signal = data('dtu_consumption_percent', filter=base_filter and ${module.filter-tags.filter_custom})${var.dtu_consumption_aggregation_function}.publish('signal')
         detect(when(signal > threshold(${var.dtu_consumption_threshold_critical}), lasting="${var.dtu_consumption_timer}")).publish('CRIT')
-        detect(when(signal > threshold(${var.dtu_consumption_threshold_warning}), lasting="${var.dtu_consumption_timer}") and when(signal <= ${var.dtu_consumption_threshold_critical})).publish('WARN')
+        detect(when(signal > threshold(${var.dtu_consumption_threshold_major}), lasting="${var.dtu_consumption_timer}") and when(signal <= ${var.dtu_consumption_threshold_critical})).publish('MAJOR')
     EOF
 
   rule {
@@ -96,11 +96,11 @@ resource "signalfx_detector" "dtu_consumption" {
   }
 
   rule {
-    description           = "is too high > ${var.dtu_consumption_threshold_warning}%"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.dtu_consumption_disabled_warning, var.dtu_consumption_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.dtu_consumption_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.dtu_consumption_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.dtu_consumption_disabled_major, var.dtu_consumption_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.dtu_consumption_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/azure/sql-elastic-pool/variables.tf
+++ b/cloud/azure/sql-elastic-pool/variables.tf
@@ -76,8 +76,8 @@ variable "cpu_disabled_critical" {
   default     = null
 }
 
-variable "cpu_disabled_warning" {
-  description = "Disable warning alerting rule for cpu detector"
+variable "cpu_disabled_major" {
+  description = "Disable major alerting rule for cpu detector"
   type        = bool
   default     = null
 }
@@ -106,8 +106,8 @@ variable "cpu_threshold_critical" {
   default     = 90
 }
 
-variable "cpu_threshold_warning" {
-  description = "Warning threshold for cpu detector"
+variable "cpu_threshold_major" {
+  description = "Major threshold for cpu detector"
   type        = number
   default     = 80
 }
@@ -126,8 +126,8 @@ variable "free_space_disabled_critical" {
   default     = null
 }
 
-variable "free_space_disabled_warning" {
-  description = "Disable warning alerting rule for free_space detector"
+variable "free_space_disabled_major" {
+  description = "Disable major alerting rule for free_space detector"
   type        = bool
   default     = null
 }
@@ -156,8 +156,8 @@ variable "free_space_threshold_critical" {
   default     = 90
 }
 
-variable "free_space_threshold_warning" {
-  description = "Warning threshold for free_space detector"
+variable "free_space_threshold_major" {
+  description = "Major threshold for free_space detector"
   type        = number
   default     = 80
 }
@@ -176,8 +176,8 @@ variable "dtu_consumption_disabled_critical" {
   default     = null
 }
 
-variable "dtu_consumption_disabled_warning" {
-  description = "Disable warning alerting rule for dtu_consumption detector"
+variable "dtu_consumption_disabled_major" {
+  description = "Disable major alerting rule for dtu_consumption detector"
   type        = bool
   default     = null
 }
@@ -206,8 +206,8 @@ variable "dtu_consumption_threshold_critical" {
   default     = 90
 }
 
-variable "dtu_consumption_threshold_warning" {
-  description = "Warning threshold for dtu_consumption detector"
+variable "dtu_consumption_threshold_major" {
+  description = "Major threshold for dtu_consumption detector"
   type        = number
   default     = 85
 }

--- a/cloud/azure/stream-analytics/detectors-stream-analytics.tf
+++ b/cloud/azure/stream-analytics/detectors-stream-analytics.tf
@@ -25,7 +25,7 @@ resource "signalfx_detector" "su_utilization" {
         base_filter = filter('resource_type', 'Microsoft.StreamAnalytics/streamingjobs') and filter('primary_aggregation_type', 'true') and ${module.filter-tags.filter_custom}
         signal = data('ResourceUtilization', filter=base_filter)${var.su_utilization_aggregation_function}.publish('signal')
         detect(when(signal > threshold(${var.su_utilization_threshold_critical}), lasting="${var.su_utilization_timer}")).publish('CRIT')
-        detect(when(signal > threshold(${var.su_utilization_threshold_warning}), lasting="${var.su_utilization_timer}") and when(signal <= ${var.su_utilization_threshold_critical})).publish('WARN')
+        detect(when(signal > threshold(${var.su_utilization_threshold_major}), lasting="${var.su_utilization_timer}") and when(signal <= ${var.su_utilization_threshold_critical})).publish('MAJOR')
     EOF
 
   rule {
@@ -38,11 +38,11 @@ resource "signalfx_detector" "su_utilization" {
   }
 
   rule {
-    description           = "is too high > ${var.su_utilization_threshold_warning}%"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.su_utilization_disabled_warning, var.su_utilization_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.su_utilization_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.su_utilization_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.su_utilization_disabled_major, var.su_utilization_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.su_utilization_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -56,7 +56,7 @@ resource "signalfx_detector" "failed_function_requests" {
         B = data('AMLCalloutRequests', extrapolation='zero', filter=base_filter)${var.failed_function_requests_aggregation_function}
         signal = (A/B).scale(100).fill(0).publish('signal')
         detect(when(signal > threshold(${var.failed_function_requests_threshold_critical}), lasting="${var.failed_function_requests_timer}")).publish('CRIT')
-        detect(when(signal > threshold(${var.failed_function_requests_threshold_warning}), lasting="${var.failed_function_requests_timer}") and when(signal <= ${var.failed_function_requests_threshold_critical})).publish('WARN')
+        detect(when(signal > threshold(${var.failed_function_requests_threshold_major}), lasting="${var.failed_function_requests_timer}") and when(signal <= ${var.failed_function_requests_threshold_critical})).publish('MAJOR')
     EOF
 
   rule {
@@ -69,11 +69,11 @@ resource "signalfx_detector" "failed_function_requests" {
   }
 
   rule {
-    description           = "is too high > ${var.failed_function_requests_threshold_warning}%"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.failed_function_requests_disabled_warning, var.failed_function_requests_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.failed_function_requests_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.failed_function_requests_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.failed_function_requests_disabled_major, var.failed_function_requests_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.failed_function_requests_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -85,7 +85,7 @@ resource "signalfx_detector" "conversion_errors" {
         base_filter = filter('resource_type', 'Microsoft.StreamAnalytics/streamingjobs') and filter('primary_aggregation_type', 'true') and ${module.filter-tags.filter_custom}
         signal = data('ConversionErrors', filter=base_filter)${var.conversion_errors_aggregation_function}. publish('signal')
         detect(when(signal > threshold(${var.conversion_errors_threshold_critical}), lasting="${var.conversion_errors_timer}")).publish('CRIT')
-        detect(when(signal > threshold(${var.conversion_errors_threshold_warning}), lasting="${var.conversion_errors_timer}") and when(signal <= ${var.conversion_errors_threshold_critical})).publish('WARN')
+        detect(when(signal > threshold(${var.conversion_errors_threshold_major}), lasting="${var.conversion_errors_timer}") and when(signal <= ${var.conversion_errors_threshold_critical})).publish('MAJOR')
     EOF
 
   rule {
@@ -98,11 +98,11 @@ resource "signalfx_detector" "conversion_errors" {
   }
 
   rule {
-    description           = "is too high > ${var.conversion_errors_threshold_warning}%"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.conversion_errors_disabled_warning, var.conversion_errors_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.conversion_errors_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.conversion_errors_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.conversion_errors_disabled_major, var.conversion_errors_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.conversion_errors_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -114,7 +114,7 @@ resource "signalfx_detector" "runtime_errors" {
         base_filter = filter('resource_type', 'Microsoft.StreamAnalytics/streamingjobs') and filter('primary_aggregation_type', 'true') and ${module.filter-tags.filter_custom}
         signal = data('Errors', filter=base_filter)${var.runtime_errors_aggregation_function}.publish('signal')
         detect(when(signal > threshold(${var.runtime_errors_threshold_critical}), lasting="${var.runtime_errors_timer}")).publish('CRIT')
-        detect(when(signal > threshold(${var.runtime_errors_threshold_warning}), lasting="${var.runtime_errors_timer}") and when(signal <= ${var.runtime_errors_threshold_critical})).publish('WARN')
+        detect(when(signal > threshold(${var.runtime_errors_threshold_major}), lasting="${var.runtime_errors_timer}") and when(signal <= ${var.runtime_errors_threshold_critical})).publish('MAJOR')
     EOF
 
   rule {
@@ -127,11 +127,11 @@ resource "signalfx_detector" "runtime_errors" {
   }
 
   rule {
-    description           = "is too high > ${var.runtime_errors_threshold_warning}%"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.runtime_errors_disabled_warning, var.runtime_errors_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.runtime_errors_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.runtime_errors_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.runtime_errors_disabled_major, var.runtime_errors_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.runtime_errors_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/azure/stream-analytics/variables.tf
+++ b/cloud/azure/stream-analytics/variables.tf
@@ -76,8 +76,8 @@ variable "su_utilization_disabled_critical" {
   default     = null
 }
 
-variable "su_utilization_disabled_warning" {
-  description = "Disable warning alerting rule for su_utilization detector"
+variable "su_utilization_disabled_major" {
+  description = "Disable major alerting rule for su_utilization detector"
   type        = bool
   default     = null
 }
@@ -106,8 +106,8 @@ variable "su_utilization_threshold_critical" {
   default     = 95
 }
 
-variable "su_utilization_threshold_warning" {
-  description = "Warning threshold for su_utilization detector"
+variable "su_utilization_threshold_major" {
+  description = "Major threshold for su_utilization detector"
   type        = number
   default     = 80
 }
@@ -126,8 +126,8 @@ variable "failed_function_requests_disabled_critical" {
   default     = null
 }
 
-variable "failed_function_requests_disabled_warning" {
-  description = "Disable warning alerting rule for failed_function_requests detector"
+variable "failed_function_requests_disabled_major" {
+  description = "Disable major alerting rule for failed_function_requests detector"
   type        = bool
   default     = null
 }
@@ -156,8 +156,8 @@ variable "failed_function_requests_threshold_critical" {
   default     = 10
 }
 
-variable "failed_function_requests_threshold_warning" {
-  description = "Warning threshold for failed_function_requests detector"
+variable "failed_function_requests_threshold_major" {
+  description = "Major threshold for failed_function_requests detector"
   type        = number
   default     = 0
 }
@@ -176,8 +176,8 @@ variable "conversion_errors_disabled_critical" {
   default     = null
 }
 
-variable "conversion_errors_disabled_warning" {
-  description = "Disable warning alerting rule for conversion_errors detector"
+variable "conversion_errors_disabled_major" {
+  description = "Disable major alerting rule for conversion_errors detector"
   type        = bool
   default     = null
 }
@@ -206,8 +206,8 @@ variable "conversion_errors_threshold_critical" {
   default     = 10
 }
 
-variable "conversion_errors_threshold_warning" {
-  description = "Warning threshold for conversion_errors detector"
+variable "conversion_errors_threshold_major" {
+  description = "Major threshold for conversion_errors detector"
   type        = number
   default     = 0
 }
@@ -226,8 +226,8 @@ variable "runtime_errors_disabled_critical" {
   default     = null
 }
 
-variable "runtime_errors_disabled_warning" {
-  description = "Disable warning alerting rule for runtime_errors detector"
+variable "runtime_errors_disabled_major" {
+  description = "Disable major alerting rule for runtime_errors detector"
   type        = bool
   default     = null
 }
@@ -256,8 +256,8 @@ variable "runtime_errors_threshold_critical" {
   default     = 10
 }
 
-variable "runtime_errors_threshold_warning" {
-  description = "Warning threshold for runtime_errors detector"
+variable "runtime_errors_threshold_major" {
+  description = "Major threshold for runtime_errors detector"
   type        = number
   default     = 0
 }

--- a/cloud/azure/virtual-machine/detectors-virtual-machine.tf
+++ b/cloud/azure/virtual-machine/detectors-virtual-machine.tf
@@ -25,7 +25,7 @@ resource "signalfx_detector" "cpu_usage" {
         base_filter = filter('resource_type', 'Microsoft.Compute/virtualMachines') and filter('primary_aggregation_type', 'true') and (not filter('azure_power_state', 'PowerState/stopping', 'PowerState/stopped', 'PowerState/deallocating', 'PowerState/deallocated'))
         signal = data('Percentage CPU', filter=base_filter and ${module.filter-tags.filter_custom})${var.cpu_usage_aggregation_function}.publish('signal')
         detect(when(signal > threshold(${var.cpu_usage_threshold_critical}), lasting="${var.cpu_usage_timer}")).publish('CRIT')
-        detect(when(signal > threshold(${var.cpu_usage_threshold_warning}), lasting="${var.cpu_usage_timer}") and when(signal <= ${var.cpu_usage_threshold_critical})).publish('WARN')
+        detect(when(signal > threshold(${var.cpu_usage_threshold_major}), lasting="${var.cpu_usage_timer}") and when(signal <= ${var.cpu_usage_threshold_critical})).publish('MAJOR')
     EOF
 
   rule {
@@ -38,11 +38,11 @@ resource "signalfx_detector" "cpu_usage" {
   }
 
   rule {
-    description           = "is too high > ${var.cpu_usage_threshold_warning}%"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.cpu_usage_disabled_warning, var.cpu_usage_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.cpu_usage_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.cpu_usage_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.cpu_usage_disabled_major, var.cpu_usage_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.cpu_usage_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -56,7 +56,7 @@ resource "signalfx_detector" "credit_cpu" {
         B = data('CPU Credits Consumed', filter=base_filter and ${module.filter-tags.filter_custom})${var.credit_cpu_aggregation_function}
         signal = ((A/(A+B))*100).fill(100).${var.credit_cpu_transformation_function}(over='${var.credit_cpu_timer}').publish('signal')
         detect(when(signal < threshold(${var.credit_cpu_threshold_critical}), lasting="${var.credit_cpu_timer}")).publish('CRIT')
-        detect(when(signal < threshold(${var.credit_cpu_threshold_warning}), lasting="${var.credit_cpu_timer}") and when(signal >= ${var.credit_cpu_threshold_critical})).publish('WARN')
+        detect(when(signal < threshold(${var.credit_cpu_threshold_major}), lasting="${var.credit_cpu_timer}") and when(signal >= ${var.credit_cpu_threshold_critical})).publish('MAJOR')
     EOF
 
   rule {
@@ -69,11 +69,11 @@ resource "signalfx_detector" "credit_cpu" {
   }
 
   rule {
-    description           = "is too low < ${var.credit_cpu_threshold_warning}%"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.credit_cpu_disabled_warning, var.credit_cpu_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.credit_cpu_notifications, "warning", []), var.notifications.warning)
+    description           = "is too low < ${var.credit_cpu_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.credit_cpu_disabled_major, var.credit_cpu_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.credit_cpu_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/azure/virtual-machine/variables.tf
+++ b/cloud/azure/virtual-machine/variables.tf
@@ -76,8 +76,8 @@ variable "cpu_usage_disabled_critical" {
   default     = null
 }
 
-variable "cpu_usage_disabled_warning" {
-  description = "Disable warning alerting rule for cpu_usage detector"
+variable "cpu_usage_disabled_major" {
+  description = "Disable major alerting rule for cpu_usage detector"
   type        = bool
   default     = null
 }
@@ -106,8 +106,8 @@ variable "cpu_usage_threshold_critical" {
   default     = 90
 }
 
-variable "cpu_usage_threshold_warning" {
-  description = "Warning threshold for cpu_usage detector"
+variable "cpu_usage_threshold_major" {
+  description = "Major threshold for cpu_usage detector"
   type        = number
   default     = 80
 }
@@ -126,8 +126,8 @@ variable "credit_cpu_disabled_critical" {
   default     = null
 }
 
-variable "credit_cpu_disabled_warning" {
-  description = "Disable warning alerting rule for credit_cpu detector"
+variable "credit_cpu_disabled_major" {
+  description = "Disable major alerting rule for credit_cpu detector"
   type        = bool
   default     = null
 }
@@ -162,8 +162,8 @@ variable "credit_cpu_threshold_critical" {
   default     = 15
 }
 
-variable "credit_cpu_threshold_warning" {
-  description = "Warning threshold for credit_cpu detector"
+variable "credit_cpu_threshold_major" {
+  description = "Major threshold for credit_cpu detector"
   type        = number
   default     = 30
 }

--- a/cloud/gcp/big-query/detectors-big-query.tf
+++ b/cloud/gcp/big-query/detectors-big-query.tf
@@ -5,9 +5,9 @@ resource "signalfx_detector" "concurrent_queries" {
     from signalfx.detectors.aperiodic import conditions
     signal = data('query/count', ${module.filter-tags.filter_custom})${var.concurrent_queries_aggregation_function}${var.concurrent_queries_transformation_function}.publish('signal')
     ON_Condition_CRIT = conditions.generic_condition(signal, ${var.concurrent_queries_threshold_critical}, ${var.concurrent_queries_threshold_critical}, 'above', lasting('${var.concurrent_queries_aperiodic_duration}', ${var.concurrent_queries_aperiodic_percentage}), 'observed')
-    ON_Condition_WARN = conditions.generic_condition(signal, ${var.concurrent_queries_threshold_warning}, ${var.concurrent_queries_threshold_critical}, 'within_range', lasting('${var.concurrent_queries_aperiodic_duration}', ${var.concurrent_queries_aperiodic_percentage}), 'observed', strict_2=False)
+    ON_Condition_MAJOR = conditions.generic_condition(signal, ${var.concurrent_queries_threshold_major}, ${var.concurrent_queries_threshold_critical}, 'within_range', lasting('${var.concurrent_queries_aperiodic_duration}', ${var.concurrent_queries_aperiodic_percentage}), 'observed', strict_2=False)
     detect(ON_Condition_CRIT, off=when(signal is None, '${var.concurrent_queries_clear_duration}')).publish('CRIT')
-    detect(ON_Condition_WARN, off=when(signal is None, '${var.concurrent_queries_clear_duration}')).publish('WARN')
+    detect(ON_Condition_MAJOR, off=when(signal is None, '${var.concurrent_queries_clear_duration}')).publish('MAJOR')
 EOF
 
   rule {
@@ -20,11 +20,11 @@ EOF
   }
 
   rule {
-    description           = "are too high > ${var.concurrent_queries_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.concurrent_queries_disabled_warning, var.concurrent_queries_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.concurrent_queries_notifications, "warning", []), var.notifications.warning)
+    description           = "are too high > ${var.concurrent_queries_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.concurrent_queries_disabled_major, var.concurrent_queries_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.concurrent_queries_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -37,9 +37,9 @@ resource "signalfx_detector" "execution_time" {
     from signalfx.detectors.aperiodic import conditions
     signal = data('query/execution_times', ${module.filter-tags.filter_custom})${var.execution_time_aggregation_function}${var.execution_time_transformation_function}.publish('signal')
     ON_Condition_CRIT = conditions.generic_condition(signal, ${var.execution_time_threshold_critical}, ${var.execution_time_threshold_critical}, 'above', lasting('${var.execution_time_aperiodic_duration}', ${var.execution_time_aperiodic_percentage}), 'observed')
-    ON_Condition_WARN = conditions.generic_condition(signal, ${var.execution_time_threshold_warning}, ${var.execution_time_threshold_critical}, 'within_range', lasting('${var.execution_time_aperiodic_duration}', ${var.execution_time_aperiodic_percentage}), 'observed', strict_2=False)
+    ON_Condition_MAJOR = conditions.generic_condition(signal, ${var.execution_time_threshold_major}, ${var.execution_time_threshold_critical}, 'within_range', lasting('${var.execution_time_aperiodic_duration}', ${var.execution_time_aperiodic_percentage}), 'observed', strict_2=False)
     detect(ON_Condition_CRIT, off=when(signal is None, '${var.execution_time_clear_duration}')).publish('CRIT')
-    detect(ON_Condition_WARN, off=when(signal is None, '${var.execution_time_clear_duration}')).publish('WARN')
+    detect(ON_Condition_MAJOR, off=when(signal is None, '${var.execution_time_clear_duration}')).publish('MAJOR')
 EOF
 
   rule {
@@ -52,11 +52,11 @@ EOF
   }
 
   rule {
-    description           = "are too high > ${var.execution_time_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.execution_time_disabled_warning, var.execution_time_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.execution_time_notifications, "warning", []), var.notifications.warning)
+    description           = "are too high > ${var.execution_time_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.execution_time_disabled_major, var.execution_time_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.execution_time_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -69,9 +69,9 @@ resource "signalfx_detector" "scanned_bytes" {
     from signalfx.detectors.aperiodic import conditions
     signal = data('query/scanned_bytes', ${module.filter-tags.filter_custom})${var.scanned_bytes_aggregation_function}${var.scanned_bytes_transformation_function}.publish('signal')
     ON_Condition_CRIT = conditions.generic_condition(signal, ${var.scanned_bytes_threshold_critical}, ${var.scanned_bytes_threshold_critical}, 'above', lasting('${var.scanned_bytes_aperiodic_duration}', ${var.scanned_bytes_aperiodic_percentage}), 'observed')
-    ON_Condition_WARN = conditions.generic_condition(signal, ${var.scanned_bytes_threshold_warning}, ${var.scanned_bytes_threshold_critical}, 'within_range', lasting('${var.scanned_bytes_aperiodic_duration}', ${var.scanned_bytes_aperiodic_percentage}), 'observed', strict_2=False)
+    ON_Condition_MAJOR = conditions.generic_condition(signal, ${var.scanned_bytes_threshold_major}, ${var.scanned_bytes_threshold_critical}, 'within_range', lasting('${var.scanned_bytes_aperiodic_duration}', ${var.scanned_bytes_aperiodic_percentage}), 'observed', strict_2=False)
     detect(ON_Condition_CRIT, off=when(signal is None, '${var.scanned_bytes_clear_duration}')).publish('CRIT')
-    detect(ON_Condition_WARN, off=when(signal is None, '${var.scanned_bytes_clear_duration}')).publish('WARN')
+    detect(ON_Condition_MAJOR, off=when(signal is None, '${var.scanned_bytes_clear_duration}')).publish('MAJOR')
 EOF
 
   rule {
@@ -84,11 +84,11 @@ EOF
   }
 
   rule {
-    description           = "are too high > ${var.scanned_bytes_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.scanned_bytes_disabled_warning, var.scanned_bytes_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.scanned_bytes_notifications, "warning", []), var.notifications.warning)
+    description           = "are too high > ${var.scanned_bytes_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.scanned_bytes_disabled_major, var.scanned_bytes_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.scanned_bytes_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -101,9 +101,9 @@ resource "signalfx_detector" "scanned_bytes_billed" {
     from signalfx.detectors.aperiodic import conditions
     signal = data('query/scanned_bytes_billed', ${module.filter-tags.filter_custom})${var.scanned_bytes_billed_aggregation_function}${var.scanned_bytes_billed_transformation_function}.publish('signal')
     ON_Condition_CRIT = conditions.generic_condition(signal, ${var.scanned_bytes_billed_threshold_critical}, ${var.scanned_bytes_billed_threshold_critical}, 'above', lasting('${var.scanned_bytes_billed_aperiodic_duration}', ${var.scanned_bytes_billed_aperiodic_percentage}), 'observed')
-    ON_Condition_WARN = conditions.generic_condition(signal, ${var.scanned_bytes_billed_threshold_warning}, ${var.scanned_bytes_billed_threshold_critical}, 'within_range', lasting('${var.scanned_bytes_billed_aperiodic_duration}', ${var.scanned_bytes_billed_aperiodic_percentage}), 'observed', strict_2=False)
+    ON_Condition_MAJOR = conditions.generic_condition(signal, ${var.scanned_bytes_billed_threshold_major}, ${var.scanned_bytes_billed_threshold_critical}, 'within_range', lasting('${var.scanned_bytes_billed_aperiodic_duration}', ${var.scanned_bytes_billed_aperiodic_percentage}), 'observed', strict_2=False)
     detect(ON_Condition_CRIT, off=when(signal is None, '${var.scanned_bytes_billed_clear_duration}')).publish('CRIT')
-    detect(ON_Condition_WARN, off=when(signal is None, '${var.scanned_bytes_billed_clear_duration}')).publish('WARN')
+    detect(ON_Condition_MAJOR, off=when(signal is None, '${var.scanned_bytes_billed_clear_duration}')).publish('MAJOR')
 EOF
 
   rule {
@@ -116,11 +116,11 @@ EOF
   }
 
   rule {
-    description           = "are too high > ${var.scanned_bytes_billed_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.scanned_bytes_billed_disabled_warning, var.scanned_bytes_billed_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.scanned_bytes_billed_notifications, "warning", []), var.notifications.warning)
+    description           = "are too high > ${var.scanned_bytes_billed_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.scanned_bytes_billed_disabled_major, var.scanned_bytes_billed_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.scanned_bytes_billed_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -133,9 +133,9 @@ resource "signalfx_detector" "available_slots" {
     from signalfx.detectors.aperiodic import conditions
     signal = data('slots/total_available', ${module.filter-tags.filter_custom})${var.available_slots_aggregation_function}${var.available_slots_transformation_function}.publish('signal')
     ON_Condition_CRIT = conditions.generic_condition(signal, ${var.available_slots_threshold_critical}, ${var.available_slots_threshold_critical}, 'above', lasting('${var.available_slots_aperiodic_duration}', ${var.available_slots_aperiodic_percentage}), 'observed')
-    ON_Condition_WARN = conditions.generic_condition(signal, ${var.available_slots_threshold_warning}, ${var.available_slots_threshold_critical}, 'within_range', lasting('${var.available_slots_aperiodic_duration}', ${var.available_slots_aperiodic_percentage}), 'observed', strict_2=False)
+    ON_Condition_MAJOR = conditions.generic_condition(signal, ${var.available_slots_threshold_major}, ${var.available_slots_threshold_critical}, 'within_range', lasting('${var.available_slots_aperiodic_duration}', ${var.available_slots_aperiodic_percentage}), 'observed', strict_2=False)
     detect(ON_Condition_CRIT, off=when(signal is None, '${var.available_slots_clear_duration}')).publish('CRIT')
-    detect(ON_Condition_WARN, off=when(signal is None, '${var.available_slots_clear_duration}')).publish('WARN')
+    detect(ON_Condition_MAJOR, off=when(signal is None, '${var.available_slots_clear_duration}')).publish('MAJOR')
 EOF
 
   rule {
@@ -148,11 +148,11 @@ EOF
   }
 
   rule {
-    description           = "are too low < ${var.available_slots_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.available_slots_disabled_warning, var.available_slots_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.available_slots_notifications, "warning", []), var.notifications.warning)
+    description           = "are too low < ${var.available_slots_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.available_slots_disabled_major, var.available_slots_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.available_slots_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -165,9 +165,9 @@ resource "signalfx_detector" "stored_bytes" {
     from signalfx.detectors.aperiodic import conditions
     signal = data('storage/stored_bytes', ${module.filter-tags.filter_custom})${var.stored_bytes_aggregation_function}${var.stored_bytes_transformation_function}.publish('signal')
     ON_Condition_CRIT = conditions.generic_condition(signal, ${var.stored_bytes_threshold_critical}, ${var.stored_bytes_threshold_critical}, 'above', lasting('${var.stored_bytes_aperiodic_duration}', ${var.stored_bytes_aperiodic_percentage}), 'observed')
-    ON_Condition_WARN = conditions.generic_condition(signal, ${var.stored_bytes_threshold_warning}, ${var.stored_bytes_threshold_critical}, 'within_range', lasting('${var.stored_bytes_aperiodic_duration}', ${var.stored_bytes_aperiodic_percentage}), 'observed', strict_2=False)
+    ON_Condition_MAJOR = conditions.generic_condition(signal, ${var.stored_bytes_threshold_major}, ${var.stored_bytes_threshold_critical}, 'within_range', lasting('${var.stored_bytes_aperiodic_duration}', ${var.stored_bytes_aperiodic_percentage}), 'observed', strict_2=False)
     detect(ON_Condition_CRIT, off=when(signal is None, '${var.stored_bytes_clear_duration}')).publish('CRIT')
-    detect(ON_Condition_WARN, off=when(signal is None, '${var.stored_bytes_clear_duration}')).publish('WARN')
+    detect(ON_Condition_MAJOR, off=when(signal is None, '${var.stored_bytes_clear_duration}')).publish('MAJOR')
 EOF
 
   rule {
@@ -180,11 +180,11 @@ EOF
   }
 
   rule {
-    description           = "are too high > ${var.stored_bytes_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.stored_bytes_disabled_warning, var.stored_bytes_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.stored_bytes_notifications, "warning", []), var.notifications.warning)
+    description           = "are too high > ${var.stored_bytes_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.stored_bytes_disabled_major, var.stored_bytes_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.stored_bytes_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -197,9 +197,9 @@ resource "signalfx_detector" "table_count" {
     from signalfx.detectors.aperiodic import conditions
     signal = data('storage/table_count', ${module.filter-tags.filter_custom})${var.table_count_aggregation_function}${var.table_count_transformation_function}.publish('signal')
     ON_Condition_CRIT = conditions.generic_condition(signal, ${var.table_count_threshold_critical}, ${var.table_count_threshold_critical}, 'above', lasting('${var.table_count_aperiodic_duration}', ${var.table_count_aperiodic_percentage}), 'observed')
-    ON_Condition_WARN = conditions.generic_condition(signal, ${var.table_count_threshold_warning}, ${var.table_count_threshold_critical}, 'within_range', lasting('${var.table_count_aperiodic_duration}', ${var.table_count_aperiodic_percentage}), 'observed', strict_2=False)
+    ON_Condition_MAJOR = conditions.generic_condition(signal, ${var.table_count_threshold_major}, ${var.table_count_threshold_critical}, 'within_range', lasting('${var.table_count_aperiodic_duration}', ${var.table_count_aperiodic_percentage}), 'observed', strict_2=False)
     detect(ON_Condition_CRIT, off=when(signal is None, '${var.table_count_clear_duration}')).publish('CRIT')
-    detect(ON_Condition_WARN, off=when(signal is None, '${var.table_count_clear_duration}')).publish('WARN')
+    detect(ON_Condition_MAJOR, off=when(signal is None, '${var.table_count_clear_duration}')).publish('MAJOR')
 EOF
 
   rule {
@@ -212,11 +212,11 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.table_count_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.table_count_disabled_warning, var.table_count_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.table_count_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.table_count_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.table_count_disabled_major, var.table_count_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.table_count_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -229,9 +229,9 @@ resource "signalfx_detector" "uploaded_bytes" {
     from signalfx.detectors.aperiodic import conditions
     signal = data('storage/uploaded_bytes', ${module.filter-tags.filter_custom})${var.uploaded_bytes_aggregation_function}${var.uploaded_bytes_transformation_function}.publish('signal')
     ON_Condition_CRIT = conditions.generic_condition(signal, ${var.uploaded_bytes_threshold_critical}, ${var.uploaded_bytes_threshold_critical}, 'above', lasting('${var.uploaded_bytes_aperiodic_duration}', ${var.uploaded_bytes_aperiodic_percentage}), 'observed')
-    ON_Condition_WARN = conditions.generic_condition(signal, ${var.uploaded_bytes_threshold_warning}, ${var.uploaded_bytes_threshold_critical}, 'within_range', lasting('${var.uploaded_bytes_aperiodic_duration}', ${var.uploaded_bytes_aperiodic_percentage}), 'observed', strict_2=False)
+    ON_Condition_MAJOR = conditions.generic_condition(signal, ${var.uploaded_bytes_threshold_major}, ${var.uploaded_bytes_threshold_critical}, 'within_range', lasting('${var.uploaded_bytes_aperiodic_duration}', ${var.uploaded_bytes_aperiodic_percentage}), 'observed', strict_2=False)
     detect(ON_Condition_CRIT, off=when(signal is None, '${var.uploaded_bytes_clear_duration}')).publish('CRIT')
-    detect(ON_Condition_WARN, off=when(signal is None, '${var.uploaded_bytes_clear_duration}')).publish('WARN')
+    detect(ON_Condition_MAJOR, off=when(signal is None, '${var.uploaded_bytes_clear_duration}')).publish('MAJOR')
 EOF
 
   rule {
@@ -244,11 +244,11 @@ EOF
   }
 
   rule {
-    description           = "are too high > ${var.uploaded_bytes_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.uploaded_bytes_disabled_warning, var.uploaded_bytes_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.uploaded_bytes_notifications, "warning", []), var.notifications.warning)
+    description           = "are too high > ${var.uploaded_bytes_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.uploaded_bytes_disabled_major, var.uploaded_bytes_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.uploaded_bytes_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -261,9 +261,9 @@ resource "signalfx_detector" "uploaded_bytes_billed" {
     from signalfx.detectors.aperiodic import conditions
     signal = data('storage/uploaded_bytes_billed', ${module.filter-tags.filter_custom})${var.uploaded_bytes_billed_aggregation_function}${var.uploaded_bytes_billed_transformation_function}.publish('signal')
     ON_Condition_CRIT = conditions.generic_condition(signal, ${var.uploaded_bytes_billed_threshold_critical}, ${var.uploaded_bytes_billed_threshold_critical}, 'above', lasting('${var.uploaded_bytes_billed_aperiodic_duration}', ${var.uploaded_bytes_billed_aperiodic_percentage}), 'observed')
-    ON_Condition_WARN = conditions.generic_condition(signal, ${var.uploaded_bytes_billed_threshold_warning}, ${var.uploaded_bytes_billed_threshold_critical}, 'within_range', lasting('${var.uploaded_bytes_billed_aperiodic_duration}', ${var.uploaded_bytes_billed_aperiodic_percentage}), 'observed', strict_2=False)
+    ON_Condition_MAJOR = conditions.generic_condition(signal, ${var.uploaded_bytes_billed_threshold_major}, ${var.uploaded_bytes_billed_threshold_critical}, 'within_range', lasting('${var.uploaded_bytes_billed_aperiodic_duration}', ${var.uploaded_bytes_billed_aperiodic_percentage}), 'observed', strict_2=False)
     detect(ON_Condition_CRIT, off=when(signal is None, '${var.uploaded_bytes_billed_clear_duration}')).publish('CRIT')
-    detect(ON_Condition_WARN, off=when(signal is None, '${var.uploaded_bytes_billed_clear_duration}')).publish('WARN')
+    detect(ON_Condition_MAJOR, off=when(signal is None, '${var.uploaded_bytes_billed_clear_duration}')).publish('MAJOR')
 EOF
 
   rule {
@@ -276,11 +276,11 @@ EOF
   }
 
   rule {
-    description           = "are too high > ${var.uploaded_bytes_billed_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.uploaded_bytes_billed_disabled_warning, var.uploaded_bytes_billed_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.uploaded_bytes_billed_notifications, "warning", []), var.notifications.warning)
+    description           = "are too high > ${var.uploaded_bytes_billed_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.uploaded_bytes_billed_disabled_major, var.uploaded_bytes_billed_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.uploaded_bytes_billed_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 

--- a/cloud/gcp/big-query/variables.tf
+++ b/cloud/gcp/big-query/variables.tf
@@ -63,8 +63,8 @@ variable "concurrent_queries_disabled_critical" {
   default     = null
 }
 
-variable "concurrent_queries_disabled_warning" {
-  description = "Disable warning alerting rule for concurrent_queries detector"
+variable "concurrent_queries_disabled_major" {
+  description = "Disable major alerting rule for concurrent_queries detector"
   type        = bool
   default     = null
 }
@@ -93,8 +93,8 @@ variable "concurrent_queries_threshold_critical" {
   default     = 45
 }
 
-variable "concurrent_queries_threshold_warning" {
-  description = "Warning threshold for concurrent_queries detector"
+variable "concurrent_queries_threshold_major" {
+  description = "Major threshold for concurrent_queries detector"
   type        = number
   default     = 40
 }
@@ -131,8 +131,8 @@ variable "execution_time_disabled_critical" {
   default     = null
 }
 
-variable "execution_time_disabled_warning" {
-  description = "Disable warning alerting rule for execution_time detector"
+variable "execution_time_disabled_major" {
+  description = "Disable major alerting rule for execution_time detector"
   type        = bool
   default     = null
 }
@@ -161,8 +161,8 @@ variable "execution_time_threshold_critical" {
   default     = 150
 }
 
-variable "execution_time_threshold_warning" {
-  description = "Warning threshold for execution_time detector"
+variable "execution_time_threshold_major" {
+  description = "Major threshold for execution_time detector"
   type        = number
   default     = 100
 }
@@ -199,8 +199,8 @@ variable "scanned_bytes_disabled_critical" {
   default     = null
 }
 
-variable "scanned_bytes_disabled_warning" {
-  description = "Disable warning alerting rule for scanned_bytes detector"
+variable "scanned_bytes_disabled_major" {
+  description = "Disable major alerting rule for scanned_bytes detector"
   type        = bool
   default     = null
 }
@@ -229,8 +229,8 @@ variable "scanned_bytes_threshold_critical" {
   default     = 1
 }
 
-variable "scanned_bytes_threshold_warning" {
-  description = "Warning threshold for scanned_bytes detector"
+variable "scanned_bytes_threshold_major" {
+  description = "Major threshold for scanned_bytes detector"
   type        = number
   default     = 0
 }
@@ -267,8 +267,8 @@ variable "scanned_bytes_billed_disabled_critical" {
   default     = null
 }
 
-variable "scanned_bytes_billed_disabled_warning" {
-  description = "Disable warning alerting rule for scanned_bytes_billed detector"
+variable "scanned_bytes_billed_disabled_major" {
+  description = "Disable major alerting rule for scanned_bytes_billed detector"
   type        = bool
   default     = null
 }
@@ -297,8 +297,8 @@ variable "scanned_bytes_billed_threshold_critical" {
   default     = 1
 }
 
-variable "scanned_bytes_billed_threshold_warning" {
-  description = "Warning threshold for scanned_bytes_billed detector"
+variable "scanned_bytes_billed_threshold_major" {
+  description = "Major threshold for scanned_bytes_billed detector"
   type        = number
   default     = 0
 }
@@ -335,8 +335,8 @@ variable "available_slots_disabled_critical" {
   default     = null
 }
 
-variable "available_slots_disabled_warning" {
-  description = "Disable warning alerting rule for available_slots detector"
+variable "available_slots_disabled_major" {
+  description = "Disable major alerting rule for available_slots detector"
   type        = bool
   default     = null
 }
@@ -365,8 +365,8 @@ variable "available_slots_threshold_critical" {
   default     = 200
 }
 
-variable "available_slots_threshold_warning" {
-  description = "Warning threshold for available_slots detector"
+variable "available_slots_threshold_major" {
+  description = "Major threshold for available_slots detector"
   type        = number
   default     = 300
 }
@@ -403,8 +403,8 @@ variable "stored_bytes_disabled_critical" {
   default     = null
 }
 
-variable "stored_bytes_disabled_warning" {
-  description = "Disable warning alerting rule for stored_bytes detector"
+variable "stored_bytes_disabled_major" {
+  description = "Disable major alerting rule for stored_bytes detector"
   type        = bool
   default     = null
 }
@@ -433,8 +433,8 @@ variable "stored_bytes_threshold_critical" {
   default     = 1
 }
 
-variable "stored_bytes_threshold_warning" {
-  description = "Warning threshold for stored_bytes detector"
+variable "stored_bytes_threshold_major" {
+  description = "Major threshold for stored_bytes detector"
   type        = number
   default     = 0
 }
@@ -471,8 +471,8 @@ variable "table_count_disabled_critical" {
   default     = null
 }
 
-variable "table_count_disabled_warning" {
-  description = "Disable warning alerting rule for table_count detector"
+variable "table_count_disabled_major" {
+  description = "Disable major alerting rule for table_count detector"
   type        = bool
   default     = null
 }
@@ -501,8 +501,8 @@ variable "table_count_threshold_critical" {
   default     = 1
 }
 
-variable "table_count_threshold_warning" {
-  description = "Warning threshold for table_count detector"
+variable "table_count_threshold_major" {
+  description = "Major threshold for table_count detector"
   type        = number
   default     = 0
 }
@@ -539,8 +539,8 @@ variable "uploaded_bytes_disabled_critical" {
   default     = null
 }
 
-variable "uploaded_bytes_disabled_warning" {
-  description = "Disable warning alerting rule for uploaded_bytes detector"
+variable "uploaded_bytes_disabled_major" {
+  description = "Disable major alerting rule for uploaded_bytes detector"
   type        = bool
   default     = null
 }
@@ -569,8 +569,8 @@ variable "uploaded_bytes_threshold_critical" {
   default     = 1
 }
 
-variable "uploaded_bytes_threshold_warning" {
-  description = "Warning threshold for uploaded_bytes detector"
+variable "uploaded_bytes_threshold_major" {
+  description = "Major threshold for uploaded_bytes detector"
   type        = number
   default     = 0
 }
@@ -607,8 +607,8 @@ variable "uploaded_bytes_billed_disabled_critical" {
   default     = null
 }
 
-variable "uploaded_bytes_billed_disabled_warning" {
-  description = "Disable warning alerting rule for uploaded_bytes_billed detector"
+variable "uploaded_bytes_billed_disabled_major" {
+  description = "Disable major alerting rule for uploaded_bytes_billed detector"
   type        = bool
   default     = null
 }
@@ -637,8 +637,8 @@ variable "uploaded_bytes_billed_threshold_critical" {
   default     = 1
 }
 
-variable "uploaded_bytes_billed_threshold_warning" {
-  description = "Warning threshold for uploaded_bytes_billed detector"
+variable "uploaded_bytes_billed_threshold_major" {
+  description = "Major threshold for uploaded_bytes_billed detector"
   type        = number
   default     = 0
 }

--- a/cloud/gcp/cloud-sql/common/detectors-cloud-sql-common.tf
+++ b/cloud/gcp/cloud-sql/common/detectors-cloud-sql-common.tf
@@ -23,7 +23,7 @@ resource "signalfx_detector" "cpu_utilization" {
   program_text = <<-EOF
     signal = data('database/cpu/utilization', ${module.filter-tags.filter_custom})${var.cpu_utilization_aggregation_function}${var.cpu_utilization_transformation_function}.scale(100).publish('signal')
     detect(when(signal > ${var.cpu_utilization_threshold_critical})).publish('CRIT')
-    detect(when(signal > ${var.cpu_utilization_threshold_warning}) and when(signal <= ${var.cpu_utilization_threshold_critical})).publish('WARN')
+    detect(when(signal > ${var.cpu_utilization_threshold_major}) and when(signal <= ${var.cpu_utilization_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -36,11 +36,11 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.cpu_utilization_threshold_warning}%"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.cpu_utilization_disabled_warning, var.cpu_utilization_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.cpu_utilization_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.cpu_utilization_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.cpu_utilization_disabled_major, var.cpu_utilization_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.cpu_utilization_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -51,7 +51,7 @@ resource "signalfx_detector" "disk_utilization" {
   program_text = <<-EOF
     signal = data('database/disk/utilization', ${module.filter-tags.filter_custom})${var.disk_utilization_aggregation_function}${var.disk_utilization_transformation_function}.scale(100).publish('signal')
     detect(when(signal > ${var.disk_utilization_threshold_critical})).publish('CRIT')
-    detect(when(signal > ${var.disk_utilization_threshold_warning}) and when(signal <= ${var.disk_utilization_threshold_critical})).publish('WARN')
+    detect(when(signal > ${var.disk_utilization_threshold_major}) and when(signal <= ${var.disk_utilization_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -64,11 +64,11 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.disk_utilization_threshold_warning}%"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.disk_utilization_disabled_warning, var.disk_utilization_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.disk_utilization_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.disk_utilization_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.disk_utilization_disabled_major, var.disk_utilization_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.disk_utilization_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -98,7 +98,7 @@ resource "signalfx_detector" "memory_utilization" {
   program_text = <<-EOF
     signal = data('database/memory/utilization', ${module.filter-tags.filter_custom})${var.memory_utilization_aggregation_function}${var.memory_utilization_transformation_function}.scale(100).publish('signal')
     detect(when(signal > ${var.memory_utilization_threshold_critical})).publish('CRIT')
-    detect(when(signal > ${var.memory_utilization_threshold_warning}) and when(signal <= ${var.memory_utilization_threshold_critical})).publish('WARN')
+    detect(when(signal > ${var.memory_utilization_threshold_major}) and when(signal <= ${var.memory_utilization_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -111,11 +111,11 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.memory_utilization_threshold_warning}%"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.memory_utilization_disabled_warning, var.memory_utilization_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.memory_utilization_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.memory_utilization_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.memory_utilization_disabled_major, var.memory_utilization_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.memory_utilization_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/gcp/cloud-sql/common/failover/detectors-cloud-sql-failover.tf
+++ b/cloud/gcp/cloud-sql/common/failover/detectors-cloud-sql-failover.tf
@@ -3,15 +3,15 @@ resource "signalfx_detector" "failover_unavailable" {
 
   program_text = <<-EOF
     signal = data('database/available_for_failover', ${module.filter-tags.filter_custom})${var.failover_unavailable_aggregation_function}${var.failover_unavailable_transformation_function}.publish('signal')
-    detect(when(signal < 1)).publish('WARN')
+    detect(when(signal < 1)).publish('MAJOR')
 EOF
 
   rule {
     description           = "is unavailable"
-    severity              = "Warning"
-    detect_label          = "WARN"
+    severity              = "Major"
+    detect_label          = "MAJOR"
     disabled              = coalesce(var.failover_unavailable_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.failover_unavailable_notifications, "warning", []), var.notifications.warning)
+    notifications         = coalescelist(lookup(var.failover_unavailable_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/gcp/cloud-sql/common/variables.tf
+++ b/cloud/gcp/cloud-sql/common/variables.tf
@@ -81,8 +81,8 @@ variable "cpu_utilization_disabled_critical" {
   default     = null
 }
 
-variable "cpu_utilization_disabled_warning" {
-  description = "Disable warning alerting rule for cpu_utilization detector"
+variable "cpu_utilization_disabled_major" {
+  description = "Disable major alerting rule for cpu_utilization detector"
   type        = bool
   default     = null
 }
@@ -111,8 +111,8 @@ variable "cpu_utilization_threshold_critical" {
   default     = 95
 }
 
-variable "cpu_utilization_threshold_warning" {
-  description = "Warning threshold for cpu_utilization detector"
+variable "cpu_utilization_threshold_major" {
+  description = "Major threshold for cpu_utilization detector"
   type        = number
   default     = 80
 }
@@ -131,8 +131,8 @@ variable "disk_utilization_disabled_critical" {
   default     = null
 }
 
-variable "disk_utilization_disabled_warning" {
-  description = "Disable warning alerting rule for disk_utilization detector"
+variable "disk_utilization_disabled_major" {
+  description = "Disable major alerting rule for disk_utilization detector"
   type        = bool
   default     = null
 }
@@ -161,8 +161,8 @@ variable "disk_utilization_threshold_critical" {
   default     = 95
 }
 
-variable "disk_utilization_threshold_warning" {
-  description = "Warning threshold for disk_utilization detector"
+variable "disk_utilization_threshold_major" {
+  description = "Major threshold for disk_utilization detector"
   type        = number
   default     = 86
 }
@@ -243,8 +243,8 @@ variable "memory_utilization_disabled_critical" {
   default     = null
 }
 
-variable "memory_utilization_disabled_warning" {
-  description = "Disable warning alerting rule for memory_utilization detector"
+variable "memory_utilization_disabled_major" {
+  description = "Disable major alerting rule for memory_utilization detector"
   type        = bool
   default     = null
 }
@@ -273,8 +273,8 @@ variable "memory_utilization_threshold_critical" {
   default     = 95
 }
 
-variable "memory_utilization_threshold_warning" {
-  description = "Warning threshold for memory_utilization detector"
+variable "memory_utilization_threshold_major" {
+  description = "Major threshold for memory_utilization detector"
   type        = number
   default     = 90
 }

--- a/cloud/gcp/cloud-sql/mysql/detectors-cloudsql-mysql.tf
+++ b/cloud/gcp/cloud-sql/mysql/detectors-cloudsql-mysql.tf
@@ -4,7 +4,7 @@ resource "signalfx_detector" "replication_lag" {
   program_text = <<-EOF
     signal = data('database/mysql/replication/seconds_behind_master', ${module.filter-tags.filter_custom})${var.replication_lag_aggregation_function}${var.replication_lag_transformation_function}.publish('signal')
     detect(when(signal > ${var.replication_lag_threshold_critical})).publish('CRIT')
-    detect(when(signal > ${var.replication_lag_threshold_warning}) and when(signal <= ${var.replication_lag_threshold_critical})).publish('WARN')
+    detect(when(signal > ${var.replication_lag_threshold_major}) and when(signal <= ${var.replication_lag_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -17,11 +17,11 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.replication_lag_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.replication_lag_disabled_warning, var.replication_lag_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.replication_lag_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.replication_lag_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.replication_lag_disabled_major, var.replication_lag_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.replication_lag_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/gcp/cloud-sql/mysql/variables.tf
+++ b/cloud/gcp/cloud-sql/mysql/variables.tf
@@ -63,8 +63,8 @@ variable "replication_lag_disabled_critical" {
   default     = null
 }
 
-variable "replication_lag_disabled_warning" {
-  description = "Disable warning alerting rule for replication_lag detector"
+variable "replication_lag_disabled_major" {
+  description = "Disable major alerting rule for replication_lag detector"
   type        = bool
   default     = null
 }
@@ -93,8 +93,8 @@ variable "replication_lag_threshold_critical" {
   default     = 180
 }
 
-variable "replication_lag_threshold_warning" {
-  description = "Warning threshold for replication_lag detector"
+variable "replication_lag_threshold_major" {
+  description = "Major threshold for replication_lag detector"
   type        = number
   default     = 90
 }

--- a/cloud/gcp/gce/instance/detectors-gce-instance.tf
+++ b/cloud/gcp/gce/instance/detectors-gce-instance.tf
@@ -23,7 +23,7 @@ resource "signalfx_detector" "cpu_utilization" {
   program_text = <<-EOF
     signal = data('instance/cpu/utilization', ${module.filter-tags.filter_custom})${var.cpu_utilization_aggregation_function}${var.cpu_utilization_transformation_function}.scale(100).publish('signal')
     detect(when(signal > ${var.cpu_utilization_threshold_critical})).publish('CRIT')
-    detect(when(signal > ${var.cpu_utilization_threshold_warning}) and when(signal <= ${var.cpu_utilization_threshold_critical})).publish('WARN')
+    detect(when(signal > ${var.cpu_utilization_threshold_major}) and when(signal <= ${var.cpu_utilization_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -36,11 +36,11 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.cpu_utilization_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.cpu_utilization_disabled_warning, var.cpu_utilization_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.cpu_utilization_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.cpu_utilization_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.cpu_utilization_disabled_major, var.cpu_utilization_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.cpu_utilization_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -55,7 +55,7 @@ resource "signalfx_detector" "disk_throttled_bps" {
     D = data('instance/disk/write_bytes_count', ${module.filter-tags.filter_custom})${var.disk_throttled_bps_aggregation_function}${var.disk_throttled_bps_transformation_function}
     signal = ((A+B) / (C+D)).scale(100).publish('signal')
     detect(when(signal > ${var.disk_throttled_bps_threshold_critical})).publish('CRIT')
-    detect(when(signal > ${var.disk_throttled_bps_threshold_warning}) and when(signal <= ${var.disk_throttled_bps_threshold_critical})).publish('WARN')
+    detect(when(signal > ${var.disk_throttled_bps_threshold_major}) and when(signal <= ${var.disk_throttled_bps_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -68,11 +68,11 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.disk_throttled_bps_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.disk_throttled_bps_disabled_warning, var.disk_throttled_bps_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.disk_throttled_bps_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.disk_throttled_bps_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.disk_throttled_bps_disabled_major, var.disk_throttled_bps_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.disk_throttled_bps_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -87,7 +87,7 @@ resource "signalfx_detector" "disk_throttled_ops" {
     D = data('instance/disk/write_ops_count', ${module.filter-tags.filter_custom})${var.disk_throttled_ops_aggregation_function}${var.disk_throttled_ops_transformation_function}
     signal = ((A+B) / (C+D)).scale(100).publish('signal')
     detect(when(signal > ${var.disk_throttled_ops_threshold_critical})).publish('CRIT')
-    detect(when(signal > ${var.disk_throttled_ops_threshold_warning}) and when(signal <= ${var.disk_throttled_ops_threshold_critical})).publish('WARN')
+    detect(when(signal > ${var.disk_throttled_ops_threshold_major}) and when(signal <= ${var.disk_throttled_ops_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -100,11 +100,11 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.disk_throttled_ops_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.disk_throttled_ops_disabled_warning, var.disk_throttled_ops_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.disk_throttled_ops_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.disk_throttled_ops_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.disk_throttled_ops_disabled_major, var.disk_throttled_ops_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.disk_throttled_ops_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/gcp/gce/instance/variables.tf
+++ b/cloud/gcp/gce/instance/variables.tf
@@ -76,8 +76,8 @@ variable "cpu_utilization_disabled_critical" {
   default     = null
 }
 
-variable "cpu_utilization_disabled_warning" {
-  description = "Disable warning alerting rule for cpu_utilization detector"
+variable "cpu_utilization_disabled_major" {
+  description = "Disable major alerting rule for cpu_utilization detector"
   type        = bool
   default     = null
 }
@@ -106,8 +106,8 @@ variable "cpu_utilization_threshold_critical" {
   default     = 90
 }
 
-variable "cpu_utilization_threshold_warning" {
-  description = "Warning threshold for cpu_utilization detector"
+variable "cpu_utilization_threshold_major" {
+  description = "Major threshold for cpu_utilization detector"
   type        = number
   default     = 85
 }
@@ -126,8 +126,8 @@ variable "disk_throttled_bps_disabled_critical" {
   default     = null
 }
 
-variable "disk_throttled_bps_disabled_warning" {
-  description = "Disable warning alerting rule for disk_throttled_bps detector"
+variable "disk_throttled_bps_disabled_major" {
+  description = "Disable major alerting rule for disk_throttled_bps detector"
   type        = bool
   default     = null
 }
@@ -156,8 +156,8 @@ variable "disk_throttled_bps_threshold_critical" {
   default     = 50
 }
 
-variable "disk_throttled_bps_threshold_warning" {
-  description = "Warning threshold for disk_throttled_bps detector"
+variable "disk_throttled_bps_threshold_major" {
+  description = "Major threshold for disk_throttled_bps detector"
   type        = number
   default     = 30
 }
@@ -176,8 +176,8 @@ variable "disk_throttled_ops_disabled_critical" {
   default     = null
 }
 
-variable "disk_throttled_ops_disabled_warning" {
-  description = "Disable warning alerting rule for disk_throttled_ops detector"
+variable "disk_throttled_ops_disabled_major" {
+  description = "Disable major alerting rule for disk_throttled_ops detector"
   type        = bool
   default     = null
 }
@@ -206,8 +206,8 @@ variable "disk_throttled_ops_threshold_critical" {
   default     = 50
 }
 
-variable "disk_throttled_ops_threshold_warning" {
-  description = "Warning threshold for disk_throttled_ops detector"
+variable "disk_throttled_ops_threshold_major" {
+  description = "Major threshold for disk_throttled_ops detector"
   type        = number
   default     = 30
 }

--- a/cloud/gcp/lb/detectors-lb.tf
+++ b/cloud/gcp/lb/detectors-lb.tf
@@ -6,7 +6,7 @@ resource "signalfx_detector" "error_rate_4xx" {
     B = data('https/request_count', filter=filter('service', 'loadbalancing') and ${module.filter-tags.filter_custom}, extrapolation='zero', rollup='sum')${var.error_rate_4xx_aggregation_function}${var.error_rate_4xx_transformation_function}
     signal = (A/B).scale(100).fill(value=0).publish('signal')
     detect(when(signal > threshold(${var.error_rate_4xx_threshold_critical}), lasting='${var.error_rate_4xx_lasting_duration_seconds}s', at_least=${var.error_rate_4xx_at_least_percentage}) and when(B > ${var.minimum_traffic})).publish('CRIT')
-    detect((when(signal > threshold(${var.error_rate_4xx_threshold_warning}), lasting='${var.error_rate_4xx_lasting_duration_seconds}s', at_least=${var.error_rate_4xx_at_least_percentage}) and when(signal <= ${var.error_rate_4xx_threshold_critical}) and when(B > ${var.minimum_traffic})), off=(when(signal <= ${var.error_rate_4xx_threshold_warning}, lasting='${var.error_rate_4xx_lasting_duration_seconds / 2}s') or when(signal >= ${var.error_rate_4xx_threshold_critical}, lasting='${var.error_rate_4xx_lasting_duration_seconds}s', at_least=${var.error_rate_4xx_at_least_percentage})), mode='paired').publish('WARN')
+    detect((when(signal > threshold(${var.error_rate_4xx_threshold_major}), lasting='${var.error_rate_4xx_lasting_duration_seconds}s', at_least=${var.error_rate_4xx_at_least_percentage}) and when(signal <= ${var.error_rate_4xx_threshold_critical}) and when(B > ${var.minimum_traffic})), off=(when(signal <= ${var.error_rate_4xx_threshold_major}, lasting='${var.error_rate_4xx_lasting_duration_seconds / 2}s') or when(signal >= ${var.error_rate_4xx_threshold_critical}, lasting='${var.error_rate_4xx_lasting_duration_seconds}s', at_least=${var.error_rate_4xx_at_least_percentage})), mode='paired').publish('MAJOR')
 EOF
 
   rule {
@@ -19,11 +19,11 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.error_rate_4xx_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.error_rate_4xx_disabled_warning, var.error_rate_4xx_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.error_rate_4xx_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.error_rate_4xx_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.error_rate_4xx_disabled_major, var.error_rate_4xx_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.error_rate_4xx_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -36,7 +36,7 @@ resource "signalfx_detector" "error_rate_5xx" {
     B = data('https/request_count', filter=filter('service', 'loadbalancing') and ${module.filter-tags.filter_custom}, extrapolation='zero', rollup='sum')${var.error_rate_5xx_aggregation_function}${var.error_rate_5xx_transformation_function}
     signal = (A/B).scale(100).fill(value=0).publish('signal')
     detect(when(signal > threshold(${var.error_rate_5xx_threshold_critical}), lasting='${var.error_rate_5xx_lasting_duration_seconds}s', at_least=${var.error_rate_5xx_at_least_percentage}) and when(B > ${var.minimum_traffic})).publish('CRIT')
-    detect((when(signal > threshold(${var.error_rate_5xx_threshold_warning}), lasting='${var.error_rate_5xx_lasting_duration_seconds}s', at_least=${var.error_rate_5xx_at_least_percentage}) and when(signal <= ${var.error_rate_5xx_threshold_critical}) and when(B > ${var.minimum_traffic})), off=(when(signal <= ${var.error_rate_5xx_threshold_warning}, lasting='${var.error_rate_5xx_lasting_duration_seconds / 2}s') or when(signal >= ${var.error_rate_5xx_threshold_critical}, lasting='${var.error_rate_5xx_lasting_duration_seconds}s', at_least=${var.error_rate_5xx_at_least_percentage})), mode='paired').publish('WARN')
+    detect((when(signal > threshold(${var.error_rate_5xx_threshold_major}), lasting='${var.error_rate_5xx_lasting_duration_seconds}s', at_least=${var.error_rate_5xx_at_least_percentage}) and when(signal <= ${var.error_rate_5xx_threshold_critical}) and when(B > ${var.minimum_traffic})), off=(when(signal <= ${var.error_rate_5xx_threshold_major}, lasting='${var.error_rate_5xx_lasting_duration_seconds / 2}s') or when(signal >= ${var.error_rate_5xx_threshold_critical}, lasting='${var.error_rate_5xx_lasting_duration_seconds}s', at_least=${var.error_rate_5xx_at_least_percentage})), mode='paired').publish('MAJOR')
 EOF
 
   rule {
@@ -49,11 +49,11 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.error_rate_5xx_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.error_rate_5xx_disabled_warning, var.error_rate_5xx_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.error_rate_5xx_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.error_rate_5xx_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.error_rate_5xx_disabled_major, var.error_rate_5xx_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.error_rate_5xx_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -64,7 +64,7 @@ resource "signalfx_detector" "backend_latency_service" {
   program_text = <<-EOF
     signal = data('https/backend_latencies', filter=filter('service', 'loadbalancing') and filter('backend_target_type', 'BACKEND_SERVICE') and ${module.filter-tags.filter_custom}, extrapolation='zero', rollup='average')${var.backend_latency_service_aggregation_function}${var.backend_latency_service_transformation_function}.publish('signal')
     detect(when(signal > threshold(${var.backend_latency_service_threshold_critical}), lasting='${var.backend_latency_service_lasting_duration_seconds}s', at_least=${var.backend_latency_service_at_least_percentage})).publish('CRIT')
-    detect((when(signal > threshold(${var.backend_latency_service_threshold_warning}), lasting='${var.backend_latency_service_lasting_duration_seconds}s', at_least=${var.backend_latency_service_at_least_percentage}) and when(signal <= ${var.backend_latency_service_threshold_critical})), off=(when(signal <= ${var.backend_latency_service_threshold_warning}, lasting='${var.backend_latency_service_lasting_duration_seconds / 2}s') or when(signal >= ${var.backend_latency_service_threshold_critical}, lasting='${var.backend_latency_service_lasting_duration_seconds}s', at_least=${var.backend_latency_service_at_least_percentage})), mode='paired').publish('WARN')
+    detect((when(signal > threshold(${var.backend_latency_service_threshold_major}), lasting='${var.backend_latency_service_lasting_duration_seconds}s', at_least=${var.backend_latency_service_at_least_percentage}) and when(signal <= ${var.backend_latency_service_threshold_critical})), off=(when(signal <= ${var.backend_latency_service_threshold_major}, lasting='${var.backend_latency_service_lasting_duration_seconds / 2}s') or when(signal >= ${var.backend_latency_service_threshold_critical}, lasting='${var.backend_latency_service_lasting_duration_seconds}s', at_least=${var.backend_latency_service_at_least_percentage})), mode='paired').publish('MAJOR')
 EOF
 
   rule {
@@ -77,11 +77,11 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.backend_latency_service_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.backend_latency_service_disabled_warning, var.backend_latency_service_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.backend_latency_service_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.backend_latency_service_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.backend_latency_service_disabled_major, var.backend_latency_service_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.backend_latency_service_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -92,7 +92,7 @@ resource "signalfx_detector" "backend_latency_bucket" {
   program_text = <<-EOF
     signal = data('https/backend_latencies', filter=filter('service', 'loadbalancing') and filter('backend_target_type', 'BACKEND_BUCKET') and ${module.filter-tags.filter_custom}, extrapolation='zero', rollup='average')${var.backend_latency_bucket_aggregation_function}${var.backend_latency_bucket_transformation_function}.publish('signal')
     detect(when(signal > threshold(${var.backend_latency_bucket_threshold_critical}), lasting='${var.backend_latency_bucket_lasting_duration_seconds}s', at_least=${var.backend_latency_bucket_at_least_percentage})).publish('CRIT')
-    detect((when(signal > threshold(${var.backend_latency_bucket_threshold_warning}), lasting='${var.backend_latency_bucket_lasting_duration_seconds}s', at_least=${var.backend_latency_bucket_at_least_percentage}) and when(signal <= ${var.backend_latency_bucket_threshold_critical})), off=(when(signal <= ${var.backend_latency_bucket_threshold_warning}, lasting='${var.backend_latency_bucket_lasting_duration_seconds / 2}s') or when(signal >= ${var.backend_latency_bucket_threshold_critical}, lasting='${var.backend_latency_bucket_lasting_duration_seconds}s', at_least=${var.backend_latency_bucket_at_least_percentage})), mode='paired').publish('WARN')
+    detect((when(signal > threshold(${var.backend_latency_bucket_threshold_major}), lasting='${var.backend_latency_bucket_lasting_duration_seconds}s', at_least=${var.backend_latency_bucket_at_least_percentage}) and when(signal <= ${var.backend_latency_bucket_threshold_critical})), off=(when(signal <= ${var.backend_latency_bucket_threshold_major}, lasting='${var.backend_latency_bucket_lasting_duration_seconds / 2}s') or when(signal >= ${var.backend_latency_bucket_threshold_critical}, lasting='${var.backend_latency_bucket_lasting_duration_seconds}s', at_least=${var.backend_latency_bucket_at_least_percentage})), mode='paired').publish('MAJOR')
 EOF
 
   rule {
@@ -105,11 +105,11 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.backend_latency_bucket_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.backend_latency_bucket_disabled_warning, var.backend_latency_bucket_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.backend_latency_bucket_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.backend_latency_bucket_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.backend_latency_bucket_disabled_major, var.backend_latency_bucket_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.backend_latency_bucket_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -119,15 +119,15 @@ resource "signalfx_detector" "request_count" {
 
   program_text = <<-EOF
     signal = data('https/request_count', filter=filter('service', 'loadbalancing') and ${module.filter-tags.filter_custom}, extrapolation='last_value', rollup='sum')${var.request_count_aggregation_function}${var.request_count_transformation_function}.rateofchange().publish('signal')
-    detect(when(signal > threshold(${var.request_count_threshold_warning}))).publish('WARN')
+    detect(when(signal > threshold(${var.request_count_threshold_major}))).publish('MAJOR')
 EOF
 
   rule {
-    description           = "is too high > ${var.request_count_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
+    description           = "is too high > ${var.request_count_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
     disabled              = coalesce(var.request_count_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.request_count_notifications, "warning", []), var.notifications.warning)
+    notifications         = coalescelist(lookup(var.request_count_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/gcp/lb/variables.tf
+++ b/cloud/gcp/lb/variables.tf
@@ -69,8 +69,8 @@ variable "error_rate_4xx_disabled_critical" {
   default     = null
 }
 
-variable "error_rate_4xx_disabled_warning" {
-  description = "Disable warning alerting rule for error_rate_4xx detector"
+variable "error_rate_4xx_disabled_major" {
+  description = "Disable major alerting rule for error_rate_4xx detector"
   type        = bool
   default     = null
 }
@@ -111,8 +111,8 @@ variable "error_rate_4xx_threshold_critical" {
   default     = 40
 }
 
-variable "error_rate_4xx_threshold_warning" {
-  description = "Warning threshold for error_rate_4xx detector"
+variable "error_rate_4xx_threshold_major" {
+  description = "Major threshold for error_rate_4xx detector"
   type        = number
   default     = 20
 }
@@ -131,8 +131,8 @@ variable "error_rate_5xx_disabled_critical" {
   default     = null
 }
 
-variable "error_rate_5xx_disabled_warning" {
-  description = "Disable warning alerting rule for error_rate_5xx detector"
+variable "error_rate_5xx_disabled_major" {
+  description = "Disable major alerting rule for error_rate_5xx detector"
   type        = bool
   default     = null
 }
@@ -173,8 +173,8 @@ variable "error_rate_5xx_threshold_critical" {
   default     = 10
 }
 
-variable "error_rate_5xx_threshold_warning" {
-  description = "Warning threshold for error_rate_5xx detector"
+variable "error_rate_5xx_threshold_major" {
+  description = "Major threshold for error_rate_5xx detector"
   type        = number
   default     = 5
 }
@@ -193,8 +193,8 @@ variable "backend_latency_service_disabled_critical" {
   default     = null
 }
 
-variable "backend_latency_service_disabled_warning" {
-  description = "Disable warning alerting rule for backend_latency_service detector"
+variable "backend_latency_service_disabled_major" {
+  description = "Disable major alerting rule for backend_latency_service detector"
   type        = bool
   default     = null
 }
@@ -235,8 +235,8 @@ variable "backend_latency_service_threshold_critical" {
   default     = 3000
 }
 
-variable "backend_latency_service_threshold_warning" {
-  description = "Warning threshold for backend_latency_service detector"
+variable "backend_latency_service_threshold_major" {
+  description = "Major threshold for backend_latency_service detector"
   type        = number
   default     = 1000
 }
@@ -255,8 +255,8 @@ variable "backend_latency_bucket_disabled_critical" {
   default     = null
 }
 
-variable "backend_latency_bucket_disabled_warning" {
-  description = "Disable warning alerting rule for backend_latency_bucket detector"
+variable "backend_latency_bucket_disabled_major" {
+  description = "Disable major alerting rule for backend_latency_bucket detector"
   type        = bool
   default     = null
 }
@@ -297,8 +297,8 @@ variable "backend_latency_bucket_threshold_critical" {
   default     = 8000
 }
 
-variable "backend_latency_bucket_threshold_warning" {
-  description = "Warning threshold for backend_latency_bucket detector"
+variable "backend_latency_bucket_threshold_major" {
+  description = "Major threshold for backend_latency_bucket detector"
   type        = number
   default     = 5000
 }
@@ -329,8 +329,8 @@ variable "request_count_transformation_function" {
   default     = ""
 }
 
-variable "request_count_threshold_warning" {
-  description = "Warning threshold for request_count detector"
+variable "request_count_threshold_major" {
+  description = "Major threshold for request_count detector"
   type        = number
   default     = 250
 }

--- a/cloud/gcp/pubsub/subscription/detectors-subscription.tf
+++ b/cloud/gcp/pubsub/subscription/detectors-subscription.tf
@@ -23,7 +23,7 @@ resource "signalfx_detector" "oldest_unacked_message" {
   program_text = <<-EOF
     signal = data('subscription/oldest_unacked_message_age', filter=filter('monitored_resource', 'pubsub_subscription') and ${module.filter-tags.filter_custom})${var.oldest_unacked_message_aggregation_function}${var.oldest_unacked_message_transformation_function}.publish('signal')
     detect(when(signal >= ${var.oldest_unacked_message_threshold_critical})).publish('CRIT')
-    detect(when(signal >= ${var.oldest_unacked_message_threshold_warning}) and when(signal < ${var.oldest_unacked_message_threshold_critical})).publish('WARN')
+    detect(when(signal >= ${var.oldest_unacked_message_threshold_major}) and when(signal < ${var.oldest_unacked_message_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -36,11 +36,11 @@ EOF
   }
 
   rule {
-    description           = "is too old >= ${var.oldest_unacked_message_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.oldest_unacked_message_disabled_warning, var.oldest_unacked_message_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.oldest_unacked_message_notifications, "warning", []), var.notifications.warning)
+    description           = "is too old >= ${var.oldest_unacked_message_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.oldest_unacked_message_disabled_major, var.oldest_unacked_message_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.oldest_unacked_message_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -51,7 +51,7 @@ resource "signalfx_detector" "push_latency" {
   program_text = <<-EOF
     signal = data('subscription/push_request_latencies', filter=filter('monitored_resource', 'pubsub_subscription') and ${module.filter-tags.filter_custom}, extrapolation='zero', rollup='average')${var.push_latency_aggregation_function}${var.push_latency_transformation_function}.publish('signal')
     detect(when(signal >= ${var.push_latency_threshold_critical})).publish('CRIT')
-    detect(when(signal >= ${var.push_latency_threshold_warning}) and when(signal < ${var.push_latency_threshold_critical})).publish('WARN')
+    detect(when(signal >= ${var.push_latency_threshold_major}) and when(signal < ${var.push_latency_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -64,11 +64,11 @@ EOF
   }
 
   rule {
-    description           = "is too high >= ${var.push_latency_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.push_latency_disabled_warning, var.push_latency_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.push_latency_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high >= ${var.push_latency_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.push_latency_disabled_major, var.push_latency_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.push_latency_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/gcp/pubsub/subscription/variables.tf
+++ b/cloud/gcp/pubsub/subscription/variables.tf
@@ -81,8 +81,8 @@ variable "oldest_unacked_message_disabled_critical" {
   default     = null
 }
 
-variable "oldest_unacked_message_disabled_warning" {
-  description = "Disable warning alerting rule for oldest_unacked_message detector"
+variable "oldest_unacked_message_disabled_major" {
+  description = "Disable major alerting rule for oldest_unacked_message detector"
   type        = bool
   default     = null
 }
@@ -111,8 +111,8 @@ variable "oldest_unacked_message_threshold_critical" {
   default     = 120
 }
 
-variable "oldest_unacked_message_threshold_warning" {
-  description = "Warning threshold for oldest_unacked_message detector"
+variable "oldest_unacked_message_threshold_major" {
+  description = "Major threshold for oldest_unacked_message detector"
   type        = number
   default     = 30
 }
@@ -131,8 +131,8 @@ variable "push_latency_disabled_critical" {
   default     = null
 }
 
-variable "push_latency_disabled_warning" {
-  description = "Disable warning alerting rule for push_latency detector"
+variable "push_latency_disabled_major" {
+  description = "Disable major alerting rule for push_latency detector"
   type        = bool
   default     = null
 }
@@ -161,8 +161,8 @@ variable "push_latency_threshold_critical" {
   default     = 5000000
 }
 
-variable "push_latency_threshold_warning" {
-  description = "Warning threshold for push_latency detector"
+variable "push_latency_threshold_major" {
+  description = "Major threshold for push_latency detector"
   type        = number
   default     = 1000000
 }

--- a/cloud/gcp/pubsub/topic/detectors-topics.tf
+++ b/cloud/gcp/pubsub/topic/detectors-topics.tf
@@ -4,15 +4,15 @@ resource "signalfx_detector" "sending_operations" {
   program_text = <<-EOF
     reserved_topics = (not filter('topic_id', 'container-analysis-occurrences*', 'container-analysis-notes*', 'cloud-builds', 'gcr'))
     signal = data('topic/send_message_operation_count', filter=filter('monitored_resource', 'pubsub_topic') and reserved_topics and ${module.filter-tags.filter_custom}, extrapolation='zero', rollup='sum')${var.sending_operations_aggregation_function}${var.sending_operations_transformation_function}.publish('signal')
-    detect(when(signal < ${var.sending_operations_threshold_warning})).publish('WARN')
+    detect(when(signal < ${var.sending_operations_threshold_major})).publish('MAJOR')
 EOF
 
   rule {
-    description           = "are too low < ${var.sending_operations_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
+    description           = "are too low < ${var.sending_operations_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
     disabled              = coalesce(var.sending_operations_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.sending_operations_notifications, "warning", []), var.notifications.warning)
+    notifications         = coalescelist(lookup(var.sending_operations_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -24,7 +24,7 @@ resource "signalfx_detector" "unavailable_sending_operations" {
     reserved_topics = (not filter('topic_id', 'container-analysis-occurrences*', 'container-analysis-notes*', 'cloud-builds', 'gcr'))
     signal = data('topic/send_message_operation_count', filter=filter('monitored_resource', 'pubsub_topic') and reserved_topics and ${module.filter-tags.filter_custom}, extrapolation='zero', rollup='sum')${var.unavailable_sending_operations_aggregation_function}${var.unavailable_sending_operations_transformation_function}.publish('signal')
     detect(when(signal > ${var.unavailable_sending_operations_threshold_critical})).publish('CRIT')
-    detect(when(signal > ${var.unavailable_sending_operations_threshold_warning}) and when(signal <= ${var.unavailable_sending_operations_threshold_critical})).publish('WARN')
+    detect(when(signal > ${var.unavailable_sending_operations_threshold_major}) and when(signal <= ${var.unavailable_sending_operations_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -37,11 +37,11 @@ EOF
   }
 
   rule {
-    description           = "are too high > ${var.unavailable_sending_operations_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.unavailable_sending_operations_disabled_warning, var.unavailable_sending_operations_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.unavailable_sending_operations_notifications, "warning", []), var.notifications.warning)
+    description           = "are too high > ${var.unavailable_sending_operations_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.unavailable_sending_operations_disabled_major, var.unavailable_sending_operations_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.unavailable_sending_operations_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -55,7 +55,7 @@ resource "signalfx_detector" "unavailable_sending_operations_ratio" {
     B = data('topic/send_message_operation_count', filter=filter('monitored_resource', 'pubsub_topic') and ${module.filter-tags.filter_custom}, extrapolation='zero', rollup='sum')${var.unavailable_sending_operations_ratio_aggregation_function}${var.unavailable_sending_operations_ratio_transformation_function}
     signal = (A/B).scale(100).fill(value=0).publish('signal')
     detect(when(signal > ${var.unavailable_sending_operations_ratio_threshold_critical})).publish('CRIT')
-    detect(when(signal > ${var.unavailable_sending_operations_ratio_threshold_warning}) and when(signal <= ${var.unavailable_sending_operations_ratio_threshold_critical})).publish('WARN')
+    detect(when(signal > ${var.unavailable_sending_operations_ratio_threshold_major}) and when(signal <= ${var.unavailable_sending_operations_ratio_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -68,11 +68,11 @@ EOF
   }
 
   rule {
-    description           = "is too high >= ${var.unavailable_sending_operations_ratio_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.unavailable_sending_operations_ratio_disabled_warning, var.unavailable_sending_operations_ratio_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.unavailable_sending_operations_ratio_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high >= ${var.unavailable_sending_operations_ratio_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.unavailable_sending_operations_ratio_disabled_major, var.unavailable_sending_operations_ratio_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.unavailable_sending_operations_ratio_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/cloud/gcp/pubsub/topic/variables.tf
+++ b/cloud/gcp/pubsub/topic/variables.tf
@@ -75,8 +75,8 @@ variable "sending_operations_transformation_function" {
   default     = ".sum(over='30m')"
 }
 
-variable "sending_operations_threshold_warning" {
-  description = "Warning threshold for sending_operations detector"
+variable "sending_operations_threshold_major" {
+  description = "Major threshold for sending_operations detector"
   type        = number
   default     = 1
 }
@@ -95,8 +95,8 @@ variable "unavailable_sending_operations_disabled_critical" {
   default     = null
 }
 
-variable "unavailable_sending_operations_disabled_warning" {
-  description = "Disable warning alerting rule for unavailable_sending_operations detector"
+variable "unavailable_sending_operations_disabled_major" {
+  description = "Disable major alerting rule for unavailable_sending_operations detector"
   type        = bool
   default     = null
 }
@@ -125,8 +125,8 @@ variable "unavailable_sending_operations_threshold_critical" {
   default     = 5
 }
 
-variable "unavailable_sending_operations_threshold_warning" {
-  description = "Warning threshold for unavailable_sending_operations detector"
+variable "unavailable_sending_operations_threshold_major" {
+  description = "Major threshold for unavailable_sending_operations detector"
   type        = number
   default     = 0
 }
@@ -145,8 +145,8 @@ variable "unavailable_sending_operations_ratio_disabled_critical" {
   default     = null
 }
 
-variable "unavailable_sending_operations_ratio_disabled_warning" {
-  description = "Disable warning alerting rule for unavailable_sending_operations_ratio detector"
+variable "unavailable_sending_operations_ratio_disabled_major" {
+  description = "Disable major alerting rule for unavailable_sending_operations_ratio detector"
   type        = bool
   default     = null
 }
@@ -175,8 +175,8 @@ variable "unavailable_sending_operations_ratio_threshold_critical" {
   default     = 20
 }
 
-variable "unavailable_sending_operations_ratio_threshold_warning" {
-  description = "Warning threshold for unavailable_sending_operations_ratio detector"
+variable "unavailable_sending_operations_ratio_threshold_major" {
+  description = "Major threshold for unavailable_sending_operations_ratio detector"
   type        = number
   default     = 0
 }

--- a/container/docker/detectors-docker.tf
+++ b/container/docker/detectors-docker.tf
@@ -23,18 +23,9 @@ resource "signalfx_detector" "cpu" {
 
   program_text = <<-EOF
 		signal = data('cpu.percent', filter=filter('plugin', 'docker') and ${module.filter-tags.filter_custom})${var.cpu_aggregation_function}${var.cpu_transformation_function}.publish('signal')
-		detect(when(signal > ${var.cpu_threshold_warning})).publish('WARN')
-		detect(when(signal > ${var.cpu_threshold_major}) and when(signal <= ${var.cpu_threshold_warning})).publish('MAJOR')
+		detect(when(signal > ${var.cpu_threshold_major})).publish('MAJOR')
+		detect(when(signal > ${var.cpu_threshold_minor}) and when(signal <= ${var.cpu_threshold_major})).publish('MINOR')
 EOF
-
-  rule {
-    description           = "is too high > ${var.cpu_threshold_warning}%"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.cpu_disabled_warning, var.cpu_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.cpu_notifications, "warning", []), var.notifications.warning)
-    parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
-  }
 
   rule {
     description           = "is too high > ${var.cpu_threshold_major}%"
@@ -42,6 +33,15 @@ EOF
     detect_label          = "MAJOR"
     disabled              = coalesce(var.cpu_disabled_major, var.cpu_disabled, var.detectors_disabled)
     notifications         = coalescelist(lookup(var.cpu_notifications, "major", []), var.notifications.major)
+    parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
+  }
+
+  rule {
+    description           = "is too high > ${var.cpu_threshold_minor}%"
+    severity              = "Minor"
+    detect_label          = "MINOR"
+    disabled              = coalesce(var.cpu_disabled_minor, var.cpu_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.cpu_notifications, "minor", []), var.notifications.minor)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -53,18 +53,9 @@ resource "signalfx_detector" "throttling" {
 		A = data('cpu.throttling_data.throttled_time', filter=filter('plugin', 'docker') and ${module.filter-tags.filter_custom}, rollup='delta')${var.throttling_aggregation_function}${var.throttling_transformation_function}
 		B = data('cpu.throttling_data.throttled_time', filter=filter('plugin', 'docker') and ${module.filter-tags.filter_custom}, rollup='delta')${var.throttling_aggregation_function}${var.throttling_transformation_function}
 		signal = (A/B).scale(100).publish('signal')
-		detect(when(signal > ${var.throttling_threshold_warning})).publish('WARN')
-		detect(when(signal > ${var.throttling_threshold_major}) and when(signal <= ${var.throttling_threshold_warning})).publish('MAJOR')
+		detect(when(signal > ${var.throttling_threshold_major})).publish('MAJOR')
+		detect(when(signal > ${var.throttling_threshold_minor}) and when(signal <= ${var.throttling_threshold_major})).publish('MINOR')
 EOF
-
-  rule {
-    description           = "is too high > ${var.throttling_threshold_warning}ns"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.throttling_disabled_warning, var.throttling_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.throttling_notifications, "warning", []), var.notifications.warning)
-    parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
-  }
 
   rule {
     description           = "is too high > ${var.throttling_threshold_major}ns"
@@ -72,6 +63,15 @@ EOF
     detect_label          = "MAJOR"
     disabled              = coalesce(var.throttling_disabled_major, var.throttling_disabled, var.detectors_disabled)
     notifications         = coalescelist(lookup(var.throttling_notifications, "major", []), var.notifications.major)
+    parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
+  }
+
+  rule {
+    description           = "is too high > ${var.throttling_threshold_minor}ns"
+    severity              = "Minor"
+    detect_label          = "MINOR"
+    disabled              = coalesce(var.throttling_disabled_minor, var.throttling_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.throttling_notifications, "minor", []), var.notifications.minor)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -83,18 +83,9 @@ resource "signalfx_detector" "memory" {
 		A = data('memory.usage.total', filter=filter('plugin', 'docker') and ${module.filter-tags.filter_custom})${var.memory_aggregation_function}${var.memory_transformation_function}
 		B = data('memory.usage.limit', filter=filter('plugin', 'docker') and ${module.filter-tags.filter_custom})${var.memory_aggregation_function}${var.memory_transformation_function}
 		signal = (A/B).scale(100).publish('signal')
-		detect(when(signal > ${var.memory_threshold_warning})).publish('WARN')
-		detect(when(signal > ${var.memory_threshold_major}) and when(signal <= ${var.memory_threshold_warning})).publish('MAJOR')
+		detect(when(signal > ${var.memory_threshold_major})).publish('MAJOR')
+		detect(when(signal > ${var.memory_threshold_minor}) and when(signal <= ${var.memory_threshold_major})).publish('MINOR')
 EOF
-
-  rule {
-    description           = "is too high > ${var.memory_threshold_warning}%"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.memory_disabled_warning, var.memory_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.memory_notifications, "warning", []), var.notifications.warning)
-    parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
-  }
 
   rule {
     description           = "is too high > ${var.memory_threshold_major}%"
@@ -102,6 +93,15 @@ EOF
     detect_label          = "MAJOR"
     disabled              = coalesce(var.memory_disabled_major, var.memory_disabled, var.detectors_disabled)
     notifications         = coalescelist(lookup(var.memory_notifications, "major", []), var.notifications.major)
+    parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
+  }
+
+  rule {
+    description           = "is too high > ${var.memory_threshold_minor}%"
+    severity              = "Minor"
+    detect_label          = "MINOR"
+    disabled              = coalesce(var.memory_disabled_minor, var.memory_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.memory_notifications, "minor", []), var.notifications.minor)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/container/docker/variables.tf
+++ b/container/docker/variables.tf
@@ -70,14 +70,14 @@ variable "cpu_disabled" {
   default     = false
 }
 
-variable "cpu_disabled_major" {
-  description = "Disable major alerting rule for cpu detector"
+variable "cpu_disabled_minor" {
+  description = "Disable minor alerting rule for cpu detector"
   type        = bool
   default     = null
 }
 
-variable "cpu_disabled_warning" {
-  description = "Disable warning alerting rule for cpu detector"
+variable "cpu_disabled_major" {
+  description = "Disable major alerting rule for cpu detector"
   type        = bool
   default     = null
 }
@@ -100,14 +100,14 @@ variable "cpu_transformation_function" {
   default     = ".min(over='1h')"
 }
 
-variable "cpu_threshold_major" {
-  description = "major threshold for cpu detector"
+variable "cpu_threshold_minor" {
+  description = "minor threshold for cpu detector"
   type        = number
   default     = 50
 }
 
-variable "cpu_threshold_warning" {
-  description = "Warning threshold for cpu detector"
+variable "cpu_threshold_major" {
+  description = "Major threshold for cpu detector"
   type        = number
   default     = 75
 }
@@ -120,14 +120,14 @@ variable "throttling_disabled" {
   default     = false
 }
 
-variable "throttling_disabled_major" {
-  description = "Disable major alerting rule for throttling detector"
+variable "throttling_disabled_minor" {
+  description = "Disable minor alerting rule for throttling detector"
   type        = bool
   default     = null
 }
 
-variable "throttling_disabled_warning" {
-  description = "Disable warning alerting rule for throttling detector"
+variable "throttling_disabled_major" {
+  description = "Disable major alerting rule for throttling detector"
   type        = bool
   default     = null
 }
@@ -150,14 +150,14 @@ variable "throttling_transformation_function" {
   default     = ".max(over='5m')"
 }
 
-variable "throttling_threshold_major" {
-  description = "major threshold for throttling detector"
+variable "throttling_threshold_minor" {
+  description = "minor threshold for throttling detector"
   type        = number
   default     = 1000 # = 1 millisecond in nanoseconds
 }
 
-variable "throttling_threshold_warning" {
-  description = "Warning threshold for throttling detector"
+variable "throttling_threshold_major" {
+  description = "Major threshold for throttling detector"
   type        = number
   default     = 1000000000 # = 1 second in nanoseconds
 }
@@ -170,14 +170,14 @@ variable "memory_disabled" {
   default     = false
 }
 
-variable "memory_disabled_major" {
-  description = "Disable major alerting rule for memory detector"
+variable "memory_disabled_minor" {
+  description = "Disable minor alerting rule for memory detector"
   type        = bool
   default     = null
 }
 
-variable "memory_disabled_warning" {
-  description = "Disable warning alerting rule for memory detector"
+variable "memory_disabled_major" {
+  description = "Disable major alerting rule for memory detector"
   type        = bool
   default     = null
 }
@@ -200,14 +200,14 @@ variable "memory_transformation_function" {
   default     = ".min(over='15m')"
 }
 
-variable "memory_threshold_major" {
-  description = "major threshold for memory detector"
+variable "memory_threshold_minor" {
+  description = "minor threshold for memory detector"
   type        = number
   default     = 90
 }
 
-variable "memory_threshold_warning" {
-  description = "Warning threshold for memory detector"
+variable "memory_threshold_major" {
+  description = "Major threshold for memory detector"
   type        = number
   default     = 95
 }

--- a/container/kubernetes/common/variables.tf
+++ b/container/kubernetes/common/variables.tf
@@ -70,14 +70,14 @@ variable "node_ready_disabled" {
   default     = null
 }
 
-variable "node_ready_disabled_major" {
-  description = "Disable major alerting rule for node_ready detector"
+variable "node_ready_disabled_minor" {
+  description = "Disable minor alerting rule for node_ready detector"
   type        = bool
   default     = null
 }
 
-variable "node_ready_disabled_warning" {
-  description = "Disable warning alerting rule for node_ready detector"
+variable "node_ready_disabled_major" {
+  description = "Disable major alerting rule for node_ready detector"
   type        = bool
   default     = null
 }
@@ -164,8 +164,8 @@ variable "terminated_transformation_function" {
   default     = ""
 }
 
-variable "terminated_threshold_warning" {
-  description = "Warning threshold for terminated detector"
+variable "terminated_threshold_major" {
+  description = "Major threshold for terminated detector"
   type        = number
   default     = 0
 }
@@ -202,8 +202,8 @@ variable "oom_killed_transformation_function" {
   default     = ""
 }
 
-variable "oom_killed_threshold_warning" {
-  description = "Warning threshold for oom_killed detector"
+variable "oom_killed_threshold_major" {
+  description = "Major threshold for oom_killed detector"
   type        = number
   default     = 0
 }
@@ -234,8 +234,8 @@ variable "deployment_crashloopbackoff_transformation_function" {
   default     = ".sum(over='15m')"
 }
 
-variable "deployment_crashloopbackoff_threshold_warning" {
-  description = "Warning threshold for deployment_crashloopbackoff detector"
+variable "deployment_crashloopbackoff_threshold_major" {
+  description = "Major threshold for deployment_crashloopbackoff detector"
   type        = number
   default     = 0
 }
@@ -266,8 +266,8 @@ variable "daemonset_crashloopbackoff_transformation_function" {
   default     = ".sum(over='15m')"
 }
 
-variable "daemonset_crashloopbackoff_threshold_warning" {
-  description = "Warning threshold for daemonset_crashloopbackoff detector"
+variable "daemonset_crashloopbackoff_threshold_major" {
+  description = "Major threshold for daemonset_crashloopbackoff detector"
   type        = number
   default     = 0
 }
@@ -298,8 +298,8 @@ variable "job_failed_transformation_function" {
   default     = ""
 }
 
-variable "job_failed_threshold_warning" {
-  description = "Warning threshold for job_failed detector"
+variable "job_failed_threshold_major" {
+  description = "Major threshold for job_failed detector"
   type        = number
   default     = 0
 }

--- a/container/kubernetes/ingress/nginx/detectors-ingress-nginx.tf
+++ b/container/kubernetes/ingress/nginx/detectors-ingress-nginx.tf
@@ -6,7 +6,7 @@ resource "signalfx_detector" "nginx_ingress_5xx" {
     B = data('nginx_ingress_controller_requests', ${module.filter-tags.filter_custom}, rollup='delta', extrapolation='zero')${var.ingress_5xx_aggregation_function}${var.ingress_5xx_transformation_function}
     signal = (A/B).scale(100).fill(value=0).publish('signal')
     detect(when(signal > threshold(${var.ingress_5xx_threshold_critical}), lasting='${var.ingress_5xx_lasting_duration_seconds}s', at_least=${var.ingress_5xx_at_least_percentage}) and when(B > ${var.minimum_traffic})).publish('CRIT')
-    detect((when(signal > threshold(${var.ingress_5xx_threshold_warning}), lasting='${var.ingress_5xx_lasting_duration_seconds}s', at_least=${var.ingress_5xx_at_least_percentage}) and when(signal <= ${var.ingress_5xx_threshold_critical}) and when(B > ${var.minimum_traffic})), off=(when(signal <= ${var.ingress_5xx_threshold_warning}, lasting='${var.ingress_5xx_lasting_duration_seconds / 2}s') or when(signal >= ${var.ingress_5xx_threshold_critical}, lasting='${var.ingress_5xx_lasting_duration_seconds}s', at_least=${var.ingress_5xx_at_least_percentage})), mode='paired').publish('WARN')
+    detect((when(signal > threshold(${var.ingress_5xx_threshold_major}), lasting='${var.ingress_5xx_lasting_duration_seconds}s', at_least=${var.ingress_5xx_at_least_percentage}) and when(signal <= ${var.ingress_5xx_threshold_critical}) and when(B > ${var.minimum_traffic})), off=(when(signal <= ${var.ingress_5xx_threshold_major}, lasting='${var.ingress_5xx_lasting_duration_seconds / 2}s') or when(signal >= ${var.ingress_5xx_threshold_critical}, lasting='${var.ingress_5xx_lasting_duration_seconds}s', at_least=${var.ingress_5xx_at_least_percentage})), mode='paired').publish('MAJOR')
 EOF
 
   rule {
@@ -19,11 +19,11 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.ingress_5xx_threshold_warning}%"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.ingress_5xx_disabled_warning, var.ingress_5xx_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.ingress_5xx_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.ingress_5xx_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.ingress_5xx_disabled_major, var.ingress_5xx_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.ingress_5xx_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -36,7 +36,7 @@ resource "signalfx_detector" "nginx_ingress_4xx" {
     B = data('nginx_ingress_controller_requests', ${module.filter-tags.filter_custom}, rollup='delta', extrapolation='zero')${var.ingress_4xx_aggregation_function}${var.ingress_4xx_transformation_function}
     signal = (A/B).scale(100).fill(value=0).publish('signal')
     detect(when(signal > threshold(${var.ingress_4xx_threshold_critical}), lasting='${var.ingress_4xx_lasting_duration_seconds}s', at_least=${var.ingress_4xx_at_least_percentage}) and when(B > ${var.minimum_traffic})).publish('CRIT')
-    detect((when(signal > threshold(${var.ingress_4xx_threshold_warning}), lasting='${var.ingress_4xx_lasting_duration_seconds}s', at_least=${var.ingress_4xx_at_least_percentage}) and when(signal <= ${var.ingress_4xx_threshold_critical}) and when(B > ${var.minimum_traffic})), off=(when(signal <= ${var.ingress_4xx_threshold_warning}, lasting='${var.ingress_4xx_lasting_duration_seconds / 2}s') or when(signal >= ${var.ingress_4xx_threshold_critical}, lasting='${var.ingress_4xx_lasting_duration_seconds}s', at_least=${var.ingress_4xx_at_least_percentage})), mode='paired').publish('WARN')
+    detect((when(signal > threshold(${var.ingress_4xx_threshold_major}), lasting='${var.ingress_4xx_lasting_duration_seconds}s', at_least=${var.ingress_4xx_at_least_percentage}) and when(signal <= ${var.ingress_4xx_threshold_critical}) and when(B > ${var.minimum_traffic})), off=(when(signal <= ${var.ingress_4xx_threshold_major}, lasting='${var.ingress_4xx_lasting_duration_seconds / 2}s') or when(signal >= ${var.ingress_4xx_threshold_critical}, lasting='${var.ingress_4xx_lasting_duration_seconds}s', at_least=${var.ingress_4xx_at_least_percentage})), mode='paired').publish('MAJOR')
 EOF
 
   rule {
@@ -49,11 +49,11 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.ingress_4xx_threshold_warning}%"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.ingress_4xx_disabled_warning, var.ingress_4xx_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.ingress_4xx_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.ingress_4xx_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.ingress_4xx_disabled_major, var.ingress_4xx_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.ingress_4xx_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -64,7 +64,7 @@ resource "signalfx_detector" "nginx_ingress_latency" {
   program_text = <<-EOF
     signal = data('nginx_ingress_controller_ingress_upstream_latency_seconds', ${module.filter-tags.filter_custom}, rollup='delta', extrapolation='zero')${var.ingress_latency_aggregation_function}${var.ingress_latency_transformation_function}.publish('signal')
     detect(when(signal > threshold(${var.ingress_latency_threshold_critical}), lasting='${var.ingress_latency_lasting_duration_seconds}s', at_least=${var.ingress_latency_at_least_percentage})).publish('CRIT')
-    detect((when(signal > threshold(${var.ingress_latency_threshold_warning}), lasting='${var.ingress_latency_lasting_duration_seconds}s', at_least=${var.ingress_latency_at_least_percentage}) and when(signal <= ${var.ingress_latency_threshold_critical})), off=(when(signal <= ${var.ingress_latency_threshold_warning}, lasting='${var.ingress_latency_lasting_duration_seconds / 2}s') or when(signal >= ${var.ingress_latency_threshold_critical}, lasting='${var.ingress_latency_lasting_duration_seconds}s', at_least=${var.ingress_latency_at_least_percentage})), mode='paired').publish('WARN')
+    detect((when(signal > threshold(${var.ingress_latency_threshold_major}), lasting='${var.ingress_latency_lasting_duration_seconds}s', at_least=${var.ingress_latency_at_least_percentage}) and when(signal <= ${var.ingress_latency_threshold_critical})), off=(when(signal <= ${var.ingress_latency_threshold_major}, lasting='${var.ingress_latency_lasting_duration_seconds / 2}s') or when(signal >= ${var.ingress_latency_threshold_critical}, lasting='${var.ingress_latency_lasting_duration_seconds}s', at_least=${var.ingress_latency_at_least_percentage})), mode='paired').publish('MAJOR')
 EOF
 
   rule {
@@ -77,11 +77,11 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.ingress_latency_threshold_warning}s"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.ingress_latency_disabled_warning, var.ingress_latency_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.ingress_latency_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.ingress_latency_threshold_major}s"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.ingress_latency_disabled_major, var.ingress_latency_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.ingress_latency_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/container/kubernetes/ingress/nginx/variables.tf
+++ b/container/kubernetes/ingress/nginx/variables.tf
@@ -64,8 +64,8 @@ variable "ingress_5xx_disabled_critical" {
   default     = null
 }
 
-variable "ingress_5xx_disabled_warning" {
-  description = "Disable warning alerting rule for ingress_5xx detector"
+variable "ingress_5xx_disabled_major" {
+  description = "Disable major alerting rule for ingress_5xx detector"
   type        = bool
   default     = null
 }
@@ -108,8 +108,8 @@ variable "ingress_5xx_threshold_critical" {
   default     = 10
 }
 
-variable "ingress_5xx_threshold_warning" {
-  description = "Warning threshold for ingress_5xx detector"
+variable "ingress_5xx_threshold_major" {
+  description = "Major threshold for ingress_5xx detector"
   type        = number
   default     = 5
 }
@@ -128,8 +128,8 @@ variable "ingress_4xx_disabled_critical" {
   default     = null
 }
 
-variable "ingress_4xx_disabled_warning" {
-  description = "Disable warning alerting rule for ingress_4xx detector"
+variable "ingress_4xx_disabled_major" {
+  description = "Disable major alerting rule for ingress_4xx detector"
   type        = bool
   default     = null
 }
@@ -172,8 +172,8 @@ variable "ingress_4xx_threshold_critical" {
   default     = 40
 }
 
-variable "ingress_4xx_threshold_warning" {
-  description = "Warning threshold for ingress_4xx detector"
+variable "ingress_4xx_threshold_major" {
+  description = "Major threshold for ingress_4xx detector"
   type        = number
   default     = 20
 }
@@ -192,8 +192,8 @@ variable "ingress_latency_disabled_critical" {
   default     = null
 }
 
-variable "ingress_latency_disabled_warning" {
-  description = "Disable warning alerting rule for ingress_latency detector"
+variable "ingress_latency_disabled_major" {
+  description = "Disable major alerting rule for ingress_latency detector"
   type        = bool
   default     = null
 }
@@ -236,8 +236,8 @@ variable "ingress_latency_threshold_critical" {
   default     = 10
 }
 
-variable "ingress_latency_threshold_warning" {
-  description = "Warning threshold for ingress_latency detector"
+variable "ingress_latency_threshold_major" {
+  description = "Major threshold for ingress_latency detector"
   type        = number
   default     = 5
 }

--- a/container/kubernetes/velero/detectors-velero.tf
+++ b/container/kubernetes/velero/detectors-velero.tf
@@ -3,15 +3,15 @@ resource "signalfx_detector" "velero_scheduled_backup_missing" {
 
   program_text = <<-EOF
     signal = data('velero_backup_success_total', filter=filter('schedule', '*') and ${module.filter-tags.filter_custom}, extrapolation='zero', rollup='delta')${var.velero_scheduled_backup_missing_aggregation_function}${var.velero_scheduled_backup_missing_transformation_function}.publish('signal')
-    detect(when(signal < 1)).publish('WARN')
+    detect(when(signal < 1)).publish('MAJOR')
 EOF
 
   rule {
     description           = "is missing"
-    severity              = "Warning"
-    detect_label          = "WARN"
+    severity              = "Major"
+    detect_label          = "MAJOR"
     disabled              = coalesce(var.velero_scheduled_backup_missing_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.velero_scheduled_backup_missing_notifications, "warning", []), var.notifications.warning)
+    notifications         = coalescelist(lookup(var.velero_scheduled_backup_missing_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -21,15 +21,15 @@ resource "signalfx_detector" "velero_backup_failure" {
 
   program_text = <<-EOF
     signal = data('velero_backup_failure_total', filter=filter('schedule', '*') and ${module.filter-tags.filter_custom}, extrapolation='zero', rollup='delta')${var.velero_backup_failure_aggregation_function}${var.velero_backup_failure_transformation_function}.publish('signal')
-    detect(when(signal > 0)).publish('WARN')
+    detect(when(signal > 0)).publish('MAJOR')
 EOF
 
   rule {
     description           = "found"
-    severity              = "Warning"
-    detect_label          = "WARN"
+    severity              = "Major"
+    detect_label          = "MAJOR"
     disabled              = coalesce(var.velero_backup_failure_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.velero_backup_failure_notifications, "warning", []), var.notifications.warning)
+    notifications         = coalescelist(lookup(var.velero_backup_failure_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -39,15 +39,15 @@ resource "signalfx_detector" "velero_backup_partial_failure" {
 
   program_text = <<-EOF
     signal = data('velero_backup_partial_failure_total', filter=filter('schedule', '*') and ${module.filter-tags.filter_custom}, extrapolation='zero', rollup='delta')${var.velero_backup_partial_failure_aggregation_function}${var.velero_backup_partial_failure_transformation_function}.publish('signal')
-    detect(when(signal > 0)).publish('WARN')
+    detect(when(signal > 0)).publish('MAJOR')
 EOF
 
   rule {
     description           = "found"
-    severity              = "Warning"
-    detect_label          = "WARN"
+    severity              = "Major"
+    detect_label          = "MAJOR"
     disabled              = coalesce(var.velero_backup_partial_failure_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.velero_backup_partial_failure_notifications, "warning", []), var.notifications.warning)
+    notifications         = coalescelist(lookup(var.velero_backup_partial_failure_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -57,15 +57,15 @@ resource "signalfx_detector" "velero_backup_deletion_failure" {
 
   program_text = <<-EOF
     signal = data('velero_backup_deletion_failure_total', filter=filter('schedule', '*') and ${module.filter-tags.filter_custom}, extrapolation='zero', rollup='delta')${var.velero_backup_deletion_failure_aggregation_function}${var.velero_backup_deletion_failure_transformation_function}.publish('signal')
-    detect(when(signal > 0)).publish('WARN')
+    detect(when(signal > 0)).publish('MAJOR')
 EOF
 
   rule {
     description           = "found"
-    severity              = "Warning"
-    detect_label          = "WARN"
+    severity              = "Major"
+    detect_label          = "MAJOR"
     disabled              = coalesce(var.velero_backup_deletion_failure_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.velero_backup_deletion_failure_notifications, "warning", []), var.notifications.warning)
+    notifications         = coalescelist(lookup(var.velero_backup_deletion_failure_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -75,15 +75,15 @@ resource "signalfx_detector" "velero_volume_snapshot_failure" {
 
   program_text = <<-EOF
     signal = data('velero_volume_snapshot_failure_total', filter=filter('schedule', '*') and ${module.filter-tags.filter_custom}, extrapolation='zero', rollup='delta')${var.velero_volume_snapshot_failure_aggregation_function}${var.velero_volume_snapshot_failure_transformation_function}.publish('signal')
-    detect(when(signal > 0)).publish('WARN')
+    detect(when(signal > 0)).publish('MAJOR')
 EOF
 
   rule {
     description           = "found"
-    severity              = "Warning"
-    detect_label          = "WARN"
+    severity              = "Major"
+    detect_label          = "MAJOR"
     disabled              = coalesce(var.velero_volume_snapshot_failure_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.velero_volume_snapshot_failure_notifications, "warning", []), var.notifications.warning)
+    notifications         = coalescelist(lookup(var.velero_volume_snapshot_failure_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/container/kubernetes/volumes/detectors-kubernetes-volumes.tf
+++ b/container/kubernetes/volumes/detectors-kubernetes-volumes.tf
@@ -6,7 +6,7 @@ resource "signalfx_detector" "volume_space" {
     B = data('kubernetes.volume_capacity_bytes', ${module.filter-tags.filter_custom} and not filter('volume_type', 'configMap', 'secret'))${var.volume_space_aggregation_function}${var.volume_space_transformation_function}
     signal = ((B-A)/B).scale(100).publish('signal')
     detect(when(signal > ${var.volume_space_threshold_critical})).publish('CRIT')
-    detect(when(signal > ${var.volume_space_threshold_warning}) and when(signal < ${var.volume_space_threshold_critical})).publish('WARN')
+    detect(when(signal > ${var.volume_space_threshold_major}) and when(signal < ${var.volume_space_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -19,11 +19,11 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.volume_space_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.volume_space_disabled_warning, var.volume_space_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.volume_space_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.volume_space_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.volume_space_disabled_major, var.volume_space_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.volume_space_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -36,7 +36,7 @@ resource "signalfx_detector" "volume_inodes" {
     B = data('kubernetes.volume_inodes', ${module.filter-tags.filter_custom} and not filter('volume_type', 'configMap', 'secret'))${var.volume_inodes_aggregation_function}${var.volume_inodes_transformation_function}
     signal = ((B-A)/B).scale(100).publish('signal')
     detect(when(signal > ${var.volume_inodes_threshold_critical})).publish('CRIT')
-    detect(when(signal > ${var.volume_inodes_threshold_warning}) and when(signal < ${var.volume_inodes_threshold_critical})).publish('WARN')
+    detect(when(signal > ${var.volume_inodes_threshold_major}) and when(signal < ${var.volume_inodes_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -49,11 +49,11 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.volume_inodes_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.volume_inodes_disabled_warning, var.volume_inodes_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.volume_inodes_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.volume_inodes_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.volume_inodes_disabled_major, var.volume_inodes_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.volume_inodes_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/container/kubernetes/volumes/variables.tf
+++ b/container/kubernetes/volumes/variables.tf
@@ -58,8 +58,8 @@ variable "volume_space_disabled_critical" {
   default     = null
 }
 
-variable "volume_space_disabled_warning" {
-  description = "Disable warning alerting rule for volume_space detector"
+variable "volume_space_disabled_major" {
+  description = "Disable major alerting rule for volume_space detector"
   type        = bool
   default     = null
 }
@@ -88,8 +88,8 @@ variable "volume_space_threshold_critical" {
   default     = 95
 }
 
-variable "volume_space_threshold_warning" {
-  description = "Warning threshold for volume_space detector"
+variable "volume_space_threshold_major" {
+  description = "Major threshold for volume_space detector"
   type        = number
   default     = 90
 }
@@ -108,8 +108,8 @@ variable "volume_inodes_disabled_critical" {
   default     = null
 }
 
-variable "volume_inodes_disabled_warning" {
-  description = "Disable warning alerting rule for volume_inodes detector"
+variable "volume_inodes_disabled_major" {
+  description = "Disable major alerting rule for volume_inodes detector"
   type        = bool
   default     = null
 }
@@ -138,8 +138,8 @@ variable "volume_inodes_threshold_critical" {
   default     = 95
 }
 
-variable "volume_inodes_threshold_warning" {
-  description = "Warning threshold for volume_inodes detector"
+variable "volume_inodes_threshold_major" {
+  description = "Major threshold for volume_inodes detector"
   type        = number
   default     = 90
 }

--- a/database/elasticsearch/detectors-elasticsearch.tf
+++ b/database/elasticsearch/detectors-elasticsearch.tf
@@ -23,7 +23,7 @@ resource "signalfx_detector" "cluster_status" {
 
   program_text = <<-EOF
     signal = data('elasticsearch.cluster.status', filter=filter('plugin', 'elasticsearch') and ${module.filter-tags.filter_custom})${var.cluster_status_aggregation_function}${var.cluster_status_transformation_function}.publish('signal')
-    detect(when(signal == 1)).publish('WARN')
+    detect(when(signal == 1)).publish('MAJOR')
     detect(when(signal == 2)).publish('CRIT')
 EOF
 
@@ -38,10 +38,10 @@ EOF
 
   rule {
     description           = "is yellow"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.cluster_status_disabled_warning, var.cluster_status_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.cluster_status_notifications, "warning", []), var.notifications.warning)
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.cluster_status_disabled_major, var.cluster_status_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.cluster_status_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -52,7 +52,7 @@ resource "signalfx_detector" "cluster_initializing_shards" {
   program_text = <<-EOF
     signal = data('elasticsearch.cluster.initializing-shards', filter=filter('plugin', 'elasticsearch') and ${module.filter-tags.filter_custom}, rollup='average')${var.cluster_initializing_shards_aggregation_function}${var.cluster_initializing_shards_transformation_function}.publish('signal')
     detect(when(signal > ${var.cluster_initializing_shards_threshold_critical})).publish('CRIT')
-    detect(when(signal > ${var.cluster_initializing_shards_threshold_warning}) and when(signal <= ${var.cluster_initializing_shards_threshold_critical})).publish('WARN')
+    detect(when(signal > ${var.cluster_initializing_shards_threshold_major}) and when(signal <= ${var.cluster_initializing_shards_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -65,11 +65,11 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.cluster_initializing_shards_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.cluster_initializing_shards_disabled_warning, var.cluster_initializing_shards_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.cluster_initializing_shards_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.cluster_initializing_shards_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.cluster_initializing_shards_disabled_major, var.cluster_initializing_shards_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.cluster_initializing_shards_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -80,7 +80,7 @@ resource "signalfx_detector" "cluster_relocating_shards" {
   program_text = <<-EOF
     signal = data('elasticsearch.cluster.relocating-shards', filter=filter('plugin', 'elasticsearch') and ${module.filter-tags.filter_custom}, rollup='average')${var.cluster_relocating_shards_aggregation_function}${var.cluster_relocating_shards_transformation_function}.publish('signal')
     detect(when(signal > ${var.cluster_relocating_shards_threshold_critical})).publish('CRIT')
-    detect(when(signal > ${var.cluster_relocating_shards_threshold_warning}) and when(signal <= ${var.cluster_relocating_shards_threshold_critical})).publish('WARN')
+    detect(when(signal > ${var.cluster_relocating_shards_threshold_major}) and when(signal <= ${var.cluster_relocating_shards_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -93,11 +93,11 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.cluster_relocating_shards_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.cluster_relocating_shards_disabled_warning, var.cluster_relocating_shards_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.cluster_relocating_shards_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.cluster_relocating_shards_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.cluster_relocating_shards_disabled_major, var.cluster_relocating_shards_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.cluster_relocating_shards_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -108,7 +108,7 @@ resource "signalfx_detector" "cluster_unassigned_shards" {
   program_text = <<-EOF
     signal = data('elasticsearch.cluster.unassigned-shards', filter=filter('plugin', 'elasticsearch') and ${module.filter-tags.filter_custom}, rollup='average')${var.cluster_unassigned_shards_aggregation_function}${var.cluster_unassigned_shards_transformation_function}.publish('signal')
     detect(when(signal > ${var.cluster_unassigned_shards_threshold_critical})).publish('CRIT')
-    detect(when(signal > ${var.cluster_unassigned_shards_threshold_warning}) and when(signal <= ${var.cluster_unassigned_shards_threshold_critical})).publish('WARN')
+    detect(when(signal > ${var.cluster_unassigned_shards_threshold_major}) and when(signal <= ${var.cluster_unassigned_shards_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -121,11 +121,11 @@ EOF
   }
 
   rule {
-    description           = "are too high > ${var.cluster_unassigned_shards_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.cluster_unassigned_shards_disabled_warning, var.cluster_unassigned_shards_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.cluster_unassigned_shards_notifications, "warning", []), var.notifications.warning)
+    description           = "are too high > ${var.cluster_unassigned_shards_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.cluster_unassigned_shards_disabled_major, var.cluster_unassigned_shards_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.cluster_unassigned_shards_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -136,7 +136,7 @@ resource "signalfx_detector" "pending_tasks" {
   program_text = <<-EOF
     signal = data('elasticsearch.cluster.pending-tasks', filter=filter('plugin', 'elasticsearch') and ${module.filter-tags.filter_custom}, rollup='average')${var.pending_tasks_aggregation_function}${var.pending_tasks_transformation_function}.publish('signal')
     detect(when(signal > ${var.pending_tasks_threshold_critical})).publish('CRIT')
-    detect(when(signal > ${var.pending_tasks_threshold_warning}) and when(signal <= ${var.pending_tasks_threshold_critical})).publish('WARN')
+    detect(when(signal > ${var.pending_tasks_threshold_major}) and when(signal <= ${var.pending_tasks_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -149,11 +149,11 @@ EOF
   }
 
   rule {
-    description           = "are too high > ${var.pending_tasks_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.pending_tasks_disabled_warning, var.pending_tasks_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.pending_tasks_notifications, "warning", []), var.notifications.warning)
+    description           = "are too high > ${var.pending_tasks_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.pending_tasks_disabled_major, var.pending_tasks_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.pending_tasks_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -164,7 +164,7 @@ resource "signalfx_detector" "cpu_usage" {
   program_text = <<-EOF
     signal = data('elasticsearch.process.cpu.percent', filter=filter('plugin', 'elasticsearch') and filter('node_name', '*') and ${module.filter-tags.filter_custom}, rollup='average')${var.cpu_usage_aggregation_function}${var.cpu_usage_transformation_function}.publish('signal')
     detect(when(signal > ${var.cpu_usage_threshold_critical})).publish('CRIT')
-    detect(when(signal > ${var.cpu_usage_threshold_warning}) and when(signal <= ${var.cpu_usage_threshold_critical})).publish('WARN')
+    detect(when(signal > ${var.cpu_usage_threshold_major}) and when(signal <= ${var.cpu_usage_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -177,11 +177,11 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.cpu_usage_threshold_warning}%"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.cpu_usage_disabled_warning, var.cpu_usage_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.cpu_usage_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.cpu_usage_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.cpu_usage_disabled_major, var.cpu_usage_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.cpu_usage_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -194,7 +194,7 @@ resource "signalfx_detector" "file_descriptors" {
     B = data('elasticsearch.process.max_file_descriptors', filter=filter('plugin', 'elasticsearch') and filter('node_name', '*') and ${module.filter-tags.filter_custom}, rollup='average')${var.file_descriptors_aggregation_function}${var.file_descriptors_transformation_function}
     signal = (A/B).scale(100).publish('signal')
     detect(when(signal > ${var.file_descriptors_threshold_critical})).publish('CRIT')
-    detect(when(signal > ${var.file_descriptors_threshold_warning}) and when(signal <= ${var.file_descriptors_threshold_critical})).publish('WARN')
+    detect(when(signal > ${var.file_descriptors_threshold_major}) and when(signal <= ${var.file_descriptors_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -207,11 +207,11 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.file_descriptors_threshold_warning}%"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.file_descriptors_disabled_warning, var.file_descriptors_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.file_descriptors_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.file_descriptors_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.file_descriptors_disabled_major, var.file_descriptors_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.file_descriptors_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -222,7 +222,7 @@ resource "signalfx_detector" "jvm_heap_memory_usage" {
   program_text = <<-EOF
     signal = data('elasticsearch.jvm.mem.heap-used-percent', filter=filter('plugin', 'elasticsearch') and filter('node_name', '*') and ${module.filter-tags.filter_custom}, rollup='average')${var.jvm_heap_memory_usage_aggregation_function}${var.jvm_heap_memory_usage_transformation_function}.publish('signal')
     detect(when(signal > ${var.jvm_heap_memory_usage_threshold_critical})).publish('CRIT')
-    detect(when(signal > ${var.jvm_heap_memory_usage_threshold_warning}) and when(signal <= ${var.jvm_heap_memory_usage_threshold_critical})).publish('WARN')
+    detect(when(signal > ${var.jvm_heap_memory_usage_threshold_major}) and when(signal <= ${var.jvm_heap_memory_usage_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -235,11 +235,11 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.jvm_heap_memory_usage_threshold_warning}%"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.jvm_heap_memory_usage_disabled_warning, var.jvm_heap_memory_usage_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.jvm_heap_memory_usage_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.jvm_heap_memory_usage_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.jvm_heap_memory_usage_disabled_major, var.jvm_heap_memory_usage_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.jvm_heap_memory_usage_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -251,18 +251,9 @@ resource "signalfx_detector" "jvm_memory_young_usage" {
     A = data('elasticsearch.jvm.mem.pools.young.used_in_bytes', filter=filter('plugin', 'elasticsearch') and filter('node_name', '*') and ${module.filter-tags.filter_custom}, rollup='average')${var.jvm_memory_young_usage_aggregation_function}${var.jvm_memory_young_usage_transformation_function}
     B = data('elasticsearch.jvm.mem.pools.young.max_in_bytes', filter=filter('plugin', 'elasticsearch') and filter('node_name', '*') and ${module.filter-tags.filter_custom}, rollup='average')${var.jvm_memory_young_usage_aggregation_function}${var.jvm_memory_young_usage_transformation_function}
     signal = (A/B).fill(0).scale(100).publish('signal')
-    detect(when(signal > ${var.jvm_memory_young_usage_threshold_warning})).publish('WARN')
-    detect(when(signal > ${var.jvm_memory_young_usage_threshold_major}) and when(signal <= ${var.jvm_memory_young_usage_threshold_warning})).publish('MAJOR')
+    detect(when(signal > ${var.jvm_memory_young_usage_threshold_major})).publish('MAJOR')
+    detect(when(signal > ${var.jvm_memory_young_usage_threshold_minor}) and when(signal <= ${var.jvm_memory_young_usage_threshold_major})).publish('MINOR')
 EOF
-
-  rule {
-    description           = "is too high > ${var.jvm_memory_young_usage_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.jvm_memory_young_usage_disabled_warning, var.jvm_memory_young_usage_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.jvm_memory_young_usage_notifications, "warning", []), var.notifications.warning)
-    parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
-  }
 
   rule {
     description           = "is too high > ${var.jvm_memory_young_usage_threshold_major}"
@@ -270,6 +261,15 @@ EOF
     detect_label          = "MAJOR"
     disabled              = coalesce(var.jvm_memory_young_usage_disabled_major, var.jvm_memory_young_usage_disabled, var.detectors_disabled)
     notifications         = coalescelist(lookup(var.jvm_memory_young_usage_notifications, "major", []), var.notifications.major)
+    parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
+  }
+
+  rule {
+    description           = "is too high > ${var.jvm_memory_young_usage_threshold_minor}"
+    severity              = "Minor"
+    detect_label          = "MINOR"
+    disabled              = coalesce(var.jvm_memory_young_usage_disabled_minor, var.jvm_memory_young_usage_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.jvm_memory_young_usage_notifications, "minor", []), var.notifications.minor)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -281,18 +281,9 @@ resource "signalfx_detector" "jvm_memory_old_usage" {
     A = data('elasticsearch.jvm.mem.pools.old.used_in_bytes', filter=filter('plugin', 'elasticsearch') and filter('node_name', '*') and ${module.filter-tags.filter_custom}, rollup='average')${var.jvm_memory_old_usage_aggregation_function}${var.jvm_memory_old_usage_transformation_function}
     B = data('elasticsearch.jvm.mem.pools.old.max_in_bytes', filter=filter('plugin', 'elasticsearch') and filter('node_name', '*') and ${module.filter-tags.filter_custom}, rollup='average')${var.jvm_memory_old_usage_aggregation_function}${var.jvm_memory_old_usage_transformation_function}
     signal = (A/B).fill(0).scale(100).publish('signal')
-    detect(when(signal > ${var.jvm_memory_old_usage_threshold_warning})).publish('WARN')
-    detect(when(signal > ${var.jvm_memory_old_usage_threshold_major}) and when(signal <= ${var.jvm_memory_old_usage_threshold_warning})).publish('MAJOR')
+    detect(when(signal > ${var.jvm_memory_old_usage_threshold_major})).publish('MAJOR')
+    detect(when(signal > ${var.jvm_memory_old_usage_threshold_minor}) and when(signal <= ${var.jvm_memory_old_usage_threshold_major})).publish('MINOR')
 EOF
-
-  rule {
-    description           = "is too high > ${var.jvm_memory_old_usage_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.jvm_memory_old_usage_disabled_warning, var.jvm_memory_old_usage_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.jvm_memory_old_usage_notifications, "warning", []), var.notifications.warning)
-    parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
-  }
 
   rule {
     description           = "is too high > ${var.jvm_memory_old_usage_threshold_major}"
@@ -300,6 +291,15 @@ EOF
     detect_label          = "MAJOR"
     disabled              = coalesce(var.jvm_memory_old_usage_disabled_major, var.jvm_memory_old_usage_disabled, var.detectors_disabled)
     notifications         = coalescelist(lookup(var.jvm_memory_old_usage_notifications, "major", []), var.notifications.major)
+    parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
+  }
+
+  rule {
+    description           = "is too high > ${var.jvm_memory_old_usage_threshold_minor}"
+    severity              = "Minor"
+    detect_label          = "MINOR"
+    disabled              = coalesce(var.jvm_memory_old_usage_disabled_minor, var.jvm_memory_old_usage_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.jvm_memory_old_usage_notifications, "minor", []), var.notifications.minor)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -311,18 +311,9 @@ resource "signalfx_detector" "jvm_gc_old_collection_latency" {
     A = data('elasticsearch.jvm.gc.old-time', filter=filter('plugin', 'elasticsearch') and filter('node_name', '*') and ${module.filter-tags.filter_custom}, extrapolation='zero', rollup='delta')${var.jvm_gc_old_collection_latency_aggregation_function}${var.jvm_gc_old_collection_latency_transformation_function}
     B = data('elasticsearch.jvm.gc.old-count', filter=filter('plugin', 'elasticsearch') and filter('node_name', '*') and ${module.filter-tags.filter_custom}, extrapolation='zero', rollup='delta')${var.jvm_gc_old_collection_latency_aggregation_function}${var.jvm_gc_old_collection_latency_transformation_function}
     signal = (A/B).fill(0).publish('signal')
-    detect(when(signal > ${var.jvm_gc_old_collection_latency_threshold_warning})).publish('WARN')
-    detect(when(signal > ${var.jvm_gc_old_collection_latency_threshold_major}) and when(signal <= ${var.jvm_gc_old_collection_latency_threshold_warning})).publish('MAJOR')
+    detect(when(signal > ${var.jvm_gc_old_collection_latency_threshold_major})).publish('MAJOR')
+    detect(when(signal > ${var.jvm_gc_old_collection_latency_threshold_minor}) and when(signal <= ${var.jvm_gc_old_collection_latency_threshold_major})).publish('MINOR')
 EOF
-
-  rule {
-    description           = "is too high > ${var.jvm_gc_old_collection_latency_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.jvm_gc_old_collection_latency_disabled_warning, var.jvm_gc_old_collection_latency_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.jvm_gc_old_collection_latency_notifications, "warning", []), var.notifications.warning)
-    parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
-  }
 
   rule {
     description           = "is too high > ${var.jvm_gc_old_collection_latency_threshold_major}"
@@ -330,6 +321,15 @@ EOF
     detect_label          = "MAJOR"
     disabled              = coalesce(var.jvm_gc_old_collection_latency_disabled_major, var.jvm_gc_old_collection_latency_disabled, var.detectors_disabled)
     notifications         = coalescelist(lookup(var.jvm_gc_old_collection_latency_notifications, "major", []), var.notifications.major)
+    parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
+  }
+
+  rule {
+    description           = "is too high > ${var.jvm_gc_old_collection_latency_threshold_minor}"
+    severity              = "Minor"
+    detect_label          = "MINOR"
+    disabled              = coalesce(var.jvm_gc_old_collection_latency_disabled_minor, var.jvm_gc_old_collection_latency_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.jvm_gc_old_collection_latency_notifications, "minor", []), var.notifications.minor)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -341,18 +341,9 @@ resource "signalfx_detector" "jvm_gc_young_collection_latency" {
     A = data('elasticsearch.jvm.gc.time', filter=filter('plugin', 'elasticsearch') and filter('node_name', '*') and ${module.filter-tags.filter_custom}, extrapolation='zero', rollup='delta')${var.jvm_gc_young_collection_latency_aggregation_function}${var.jvm_gc_young_collection_latency_transformation_function}
     B = data('elasticsearch.jvm.gc.count', filter=filter('plugin', 'elasticsearch') and ${module.filter-tags.filter_custom}, extrapolation='zero', rollup='delta')${var.jvm_gc_young_collection_latency_aggregation_function}${var.jvm_gc_young_collection_latency_transformation_function}
     signal = (A/B).fill(0).publish('signal')
-    detect(when(signal > ${var.jvm_gc_young_collection_latency_threshold_warning})).publish('WARN')
-    detect(when(signal > ${var.jvm_gc_young_collection_latency_threshold_major}) and when(signal <= ${var.jvm_gc_young_collection_latency_threshold_warning})).publish('MAJOR')
+    detect(when(signal > ${var.jvm_gc_young_collection_latency_threshold_major})).publish('MAJOR')
+    detect(when(signal > ${var.jvm_gc_young_collection_latency_threshold_minor}) and when(signal <= ${var.jvm_gc_young_collection_latency_threshold_major})).publish('MINOR')
 EOF
-
-  rule {
-    description           = "is too high > ${var.jvm_gc_young_collection_latency_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.jvm_gc_young_collection_latency_disabled_warning, var.jvm_gc_young_collection_latency_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.jvm_gc_young_collection_latency_notifications, "warning", []), var.notifications.warning)
-    parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
-  }
 
   rule {
     description           = "is too high > ${var.jvm_gc_young_collection_latency_threshold_major}"
@@ -360,6 +351,15 @@ EOF
     detect_label          = "MAJOR"
     disabled              = coalesce(var.jvm_gc_young_collection_latency_disabled_major, var.jvm_gc_young_collection_latency_disabled, var.detectors_disabled)
     notifications         = coalescelist(lookup(var.jvm_gc_young_collection_latency_notifications, "major", []), var.notifications.major)
+    parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
+  }
+
+  rule {
+    description           = "is too high > ${var.jvm_gc_young_collection_latency_threshold_minor}"
+    severity              = "Minor"
+    detect_label          = "MINOR"
+    disabled              = coalesce(var.jvm_gc_young_collection_latency_disabled_minor, var.jvm_gc_young_collection_latency_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.jvm_gc_young_collection_latency_notifications, "minor", []), var.notifications.minor)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -371,18 +371,9 @@ resource "signalfx_detector" "indexing_latency" {
     A = data('elasticsearch.indices.indexing.index-time', filter=filter('plugin', 'elasticsearch') and filter('node_name', '*') and ${module.filter-tags.filter_custom}, extrapolation='zero', rollup='delta')${var.indexing_latency_aggregation_function}${var.indexing_latency_transformation_function}
     B = data('elasticsearch.indices.indexing.index-total', filter=filter('plugin', 'elasticsearch') and filter('node_name', '*') and ${module.filter-tags.filter_custom}, extrapolation='zero', rollup='delta')${var.indexing_latency_aggregation_function}${var.indexing_latency_transformation_function}
     signal = (A/B).fill(0).publish('signal')
-    detect(when(signal > ${var.indexing_latency_threshold_warning})).publish('WARN')
-    detect(when(signal > ${var.indexing_latency_threshold_major}) and when(signal <= ${var.indexing_latency_threshold_warning})).publish('MAJOR')
+    detect(when(signal > ${var.indexing_latency_threshold_major})).publish('MAJOR')
+    detect(when(signal > ${var.indexing_latency_threshold_minor}) and when(signal <= ${var.indexing_latency_threshold_major})).publish('MINOR')
 EOF
-
-  rule {
-    description           = "is too high > ${var.indexing_latency_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.indexing_latency_disabled_warning, var.indexing_latency_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.indexing_latency_notifications, "warning", []), var.notifications.warning)
-    parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
-  }
 
   rule {
     description           = "is too high > ${var.indexing_latency_threshold_major}"
@@ -390,6 +381,15 @@ EOF
     detect_label          = "MAJOR"
     disabled              = coalesce(var.indexing_latency_disabled_major, var.indexing_latency_disabled, var.detectors_disabled)
     notifications         = coalescelist(lookup(var.indexing_latency_notifications, "major", []), var.notifications.major)
+    parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
+  }
+
+  rule {
+    description           = "is too high > ${var.indexing_latency_threshold_minor}"
+    severity              = "Minor"
+    detect_label          = "MINOR"
+    disabled              = coalesce(var.indexing_latency_disabled_minor, var.indexing_latency_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.indexing_latency_notifications, "minor", []), var.notifications.minor)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -401,18 +401,9 @@ resource "signalfx_detector" "flush_latency" {
     A = data('elasticsearch.indices.flush.total-time', filter=filter('plugin', 'elasticsearch') and filter('node_name', '*') and ${module.filter-tags.filter_custom}, extrapolation='zero', rollup='delta')${var.flush_latency_aggregation_function}${var.flush_latency_transformation_function}
     B = data('elasticsearch.indices.flush.total', filter=filter('plugin', 'elasticsearch') and filter('node_name', '*') and ${module.filter-tags.filter_custom}, extrapolation='zero', rollup='delta')${var.flush_latency_aggregation_function}${var.flush_latency_transformation_function}
     signal = (A/B).fill(0).publish('signal')
-    detect(when(signal > ${var.flush_latency_threshold_warning})).publish('WARN')
-    detect(when(signal > ${var.flush_latency_threshold_major}) and when(signal <= ${var.flush_latency_threshold_warning})).publish('MAJOR')
+    detect(when(signal > ${var.flush_latency_threshold_major})).publish('MAJOR')
+    detect(when(signal > ${var.flush_latency_threshold_minor}) and when(signal <= ${var.flush_latency_threshold_major})).publish('MINOR')
 EOF
-
-  rule {
-    description           = "is too high > ${var.flush_latency_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.flush_latency_disabled_warning, var.flush_latency_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.flush_latency_notifications, "warning", []), var.notifications.warning)
-    parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
-  }
 
   rule {
     description           = "is too high > ${var.flush_latency_threshold_major}"
@@ -420,6 +411,15 @@ EOF
     detect_label          = "MAJOR"
     disabled              = coalesce(var.flush_latency_disabled_major, var.flush_latency_disabled, var.detectors_disabled)
     notifications         = coalescelist(lookup(var.flush_latency_notifications, "major", []), var.notifications.major)
+    parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
+  }
+
+  rule {
+    description           = "is too high > ${var.flush_latency_threshold_minor}"
+    severity              = "Minor"
+    detect_label          = "MINOR"
+    disabled              = coalesce(var.flush_latency_disabled_minor, var.flush_latency_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.flush_latency_notifications, "minor", []), var.notifications.minor)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -431,18 +431,9 @@ resource "signalfx_detector" "search_latency" {
     A = data('elasticsearch.indices.search.query-time', filter=filter('plugin', 'elasticsearch') and filter('node_name', '*') and ${module.filter-tags.filter_custom}, extrapolation='zero', rollup='delta')${var.search_latency_aggregation_function}${var.search_latency_transformation_function}
     B = data('elasticsearch.indices.search.query-total', filter=filter('plugin', 'elasticsearch') and filter('node_name', '*') and ${module.filter-tags.filter_custom}, extrapolation='zero', rollup='delta')${var.search_latency_aggregation_function}${var.search_latency_transformation_function}
     signal = (A/B).fill(0).publish('signal')
-    detect(when(signal > ${var.search_latency_threshold_warning})).publish('WARN')
-    detect(when(signal > ${var.search_latency_threshold_major}) and when(signal <= ${var.search_latency_threshold_warning})).publish('MAJOR')
+    detect(when(signal > ${var.search_latency_threshold_major})).publish('MAJOR')
+    detect(when(signal > ${var.search_latency_threshold_minor}) and when(signal <= ${var.search_latency_threshold_major})).publish('MINOR')
 EOF
-
-  rule {
-    description           = "is too high > ${var.search_latency_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.search_latency_disabled_warning, var.search_latency_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.search_latency_notifications, "warning", []), var.notifications.warning)
-    parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
-  }
 
   rule {
     description           = "is too high > ${var.search_latency_threshold_major}"
@@ -450,6 +441,15 @@ EOF
     detect_label          = "MAJOR"
     disabled              = coalesce(var.search_latency_disabled_major, var.search_latency_disabled, var.detectors_disabled)
     notifications         = coalescelist(lookup(var.search_latency_notifications, "major", []), var.notifications.major)
+    parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
+  }
+
+  rule {
+    description           = "is too high > ${var.search_latency_threshold_minor}"
+    severity              = "Minor"
+    detect_label          = "MINOR"
+    disabled              = coalesce(var.search_latency_disabled_minor, var.search_latency_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.search_latency_notifications, "minor", []), var.notifications.minor)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -461,18 +461,9 @@ resource "signalfx_detector" "fetch_latency" {
     A = data('elasticsearch.indices.search.fetch-time', filter=filter('plugin', 'elasticsearch') and filter('node_name', '*') and ${module.filter-tags.filter_custom}, extrapolation='zero', rollup='delta')${var.fetch_latency_aggregation_function}${var.fetch_latency_transformation_function}
     B = data('elasticsearch.indices.search.fetch-total', filter=filter('plugin', 'elasticsearch') and filter('node_name', '*') and ${module.filter-tags.filter_custom}, extrapolation='zero', rollup='delta')${var.fetch_latency_aggregation_function}${var.fetch_latency_transformation_function}
     signal = (A/B).fill(0).publish('signal')
-    detect(when(signal > ${var.fetch_latency_threshold_warning})).publish('WARN')
-    detect(when(signal > ${var.fetch_latency_threshold_major}) and when(signal <= ${var.fetch_latency_threshold_warning})).publish('MAJOR')
+    detect(when(signal > ${var.fetch_latency_threshold_major})).publish('MAJOR')
+    detect(when(signal > ${var.fetch_latency_threshold_minor}) and when(signal <= ${var.fetch_latency_threshold_major})).publish('MINOR')
 EOF
-
-  rule {
-    description           = "is too high > ${var.fetch_latency_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.fetch_latency_disabled_warning, var.fetch_latency_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.fetch_latency_notifications, "warning", []), var.notifications.warning)
-    parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
-  }
 
   rule {
     description           = "is too high > ${var.fetch_latency_threshold_major}"
@@ -482,6 +473,15 @@ EOF
     notifications         = coalescelist(lookup(var.fetch_latency_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
+
+  rule {
+    description           = "is too high > ${var.fetch_latency_threshold_minor}"
+    severity              = "Minor"
+    detect_label          = "MINOR"
+    disabled              = coalesce(var.fetch_latency_disabled_minor, var.fetch_latency_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.fetch_latency_notifications, "minor", []), var.notifications.minor)
+    parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
+  }
 }
 
 resource "signalfx_detector" "field_data_evictions_change" {
@@ -489,18 +489,9 @@ resource "signalfx_detector" "field_data_evictions_change" {
 
   program_text = <<-EOF
     signal = data('elasticsearch.indices.fielddata.evictions', filter=filter('plugin', 'elasticsearch') and filter('node_name', '*') and ${module.filter-tags.filter_custom}, extrapolation='zero', rollup='delta').rateofchange()${var.field_data_evictions_change_aggregation_function}${var.field_data_evictions_change_transformation_function}.publish('signal')
-    detect(when(signal > ${var.field_data_evictions_change_threshold_warning})).publish('WARN')
-    detect(when(signal > ${var.field_data_evictions_change_threshold_major}) and when(signal <= ${var.field_data_evictions_change_threshold_warning})).publish('MAJOR')
+    detect(when(signal > ${var.field_data_evictions_change_threshold_major})).publish('MAJOR')
+    detect(when(signal > ${var.field_data_evictions_change_threshold_minor}) and when(signal <= ${var.field_data_evictions_change_threshold_major})).publish('MINOR')
 EOF
-
-  rule {
-    description           = "is too high > ${var.field_data_evictions_change_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.field_data_evictions_change_disabled_warning, var.field_data_evictions_change_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.field_data_evictions_change_notifications, "warning", []), var.notifications.warning)
-    parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
-  }
 
   rule {
     description           = "is too high > ${var.field_data_evictions_change_threshold_major}"
@@ -510,6 +501,15 @@ EOF
     notifications         = coalescelist(lookup(var.field_data_evictions_change_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
+
+  rule {
+    description           = "is too high > ${var.field_data_evictions_change_threshold_minor}"
+    severity              = "Minor"
+    detect_label          = "MINOR"
+    disabled              = coalesce(var.field_data_evictions_change_disabled_minor, var.field_data_evictions_change_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.field_data_evictions_change_notifications, "minor", []), var.notifications.minor)
+    parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
+  }
 }
 
 resource "signalfx_detector" "query_cache_evictions_change" {
@@ -517,18 +517,9 @@ resource "signalfx_detector" "query_cache_evictions_change" {
 
   program_text = <<-EOF
     signal = data('elasticsearch.indices.query-cache.evictions', filter=filter('plugin', 'elasticsearch') and filter('node_name', '*') and ${module.filter-tags.filter_custom}, extrapolation='zero', rollup='delta').rateofchange()${var.query_cache_evictions_change_aggregation_function}${var.query_cache_evictions_change_transformation_function}.publish('signal')
-    detect(when(signal > ${var.query_cache_evictions_change_threshold_warning})).publish('WARN')
-    detect(when(signal > ${var.query_cache_evictions_change_threshold_major}) and when(signal <= ${var.query_cache_evictions_change_threshold_warning})).publish('MAJOR')
+    detect(when(signal > ${var.query_cache_evictions_change_threshold_major})).publish('MAJOR')
+    detect(when(signal > ${var.query_cache_evictions_change_threshold_minor}) and when(signal <= ${var.query_cache_evictions_change_threshold_major})).publish('MINOR')
 EOF
-
-  rule {
-    description           = "is too high > ${var.query_cache_evictions_change_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.query_cache_evictions_change_disabled_warning, var.query_cache_evictions_change_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.query_cache_evictions_change_notifications, "warning", []), var.notifications.warning)
-    parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
-  }
 
   rule {
     description           = "is too high > ${var.query_cache_evictions_change_threshold_major}"
@@ -538,6 +529,15 @@ EOF
     notifications         = coalescelist(lookup(var.query_cache_evictions_change_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
+
+  rule {
+    description           = "is too high > ${var.query_cache_evictions_change_threshold_minor}"
+    severity              = "Minor"
+    detect_label          = "MINOR"
+    disabled              = coalesce(var.query_cache_evictions_change_disabled_minor, var.query_cache_evictions_change_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.query_cache_evictions_change_notifications, "minor", []), var.notifications.minor)
+    parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
+  }
 }
 
 resource "signalfx_detector" "request_cache_evictions_change" {
@@ -545,18 +545,9 @@ resource "signalfx_detector" "request_cache_evictions_change" {
 
   program_text = <<-EOF
     signal = data('elasticsearch.indices.request-cache.evictions', filter=filter('plugin', 'elasticsearch') and filter('node_name', '*') and ${module.filter-tags.filter_custom}, extrapolation='zero', rollup='delta').rateofchange()${var.request_cache_evictions_change_aggregation_function}${var.request_cache_evictions_change_transformation_function}.publish('signal')
-    detect(when(signal > ${var.request_cache_evictions_change_threshold_warning})).publish('WARN')
-    detect(when(signal > ${var.request_cache_evictions_change_threshold_major}) and when(signal <= ${var.request_cache_evictions_change_threshold_warning})).publish('MAJOR')
+    detect(when(signal > ${var.request_cache_evictions_change_threshold_major})).publish('MAJOR')
+    detect(when(signal > ${var.request_cache_evictions_change_threshold_minor}) and when(signal <= ${var.request_cache_evictions_change_threshold_major})).publish('MINOR')
 EOF
-
-  rule {
-    description           = "is too high > ${var.request_cache_evictions_change_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.request_cache_evictions_change_disabled_warning, var.request_cache_evictions_change_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.request_cache_evictions_change_notifications, "warning", []), var.notifications.warning)
-    parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
-  }
 
   rule {
     description           = "is too high > ${var.request_cache_evictions_change_threshold_major}"
@@ -566,6 +557,15 @@ EOF
     notifications         = coalescelist(lookup(var.request_cache_evictions_change_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
+
+  rule {
+    description           = "is too high > ${var.request_cache_evictions_change_threshold_minor}"
+    severity              = "Minor"
+    detect_label          = "MINOR"
+    disabled              = coalesce(var.request_cache_evictions_change_disabled_minor, var.request_cache_evictions_change_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.request_cache_evictions_change_notifications, "minor", []), var.notifications.minor)
+    parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
+  }
 }
 
 resource "signalfx_detector" "task_time_in_queue_change" {
@@ -573,18 +573,9 @@ resource "signalfx_detector" "task_time_in_queue_change" {
 
   program_text = <<-EOF
     signal = data('elasticsearch.cluster.task-max-wait-time', filter=filter('plugin', 'elasticsearch') and ${module.filter-tags.filter_custom}, rollup='average').rateofchange()${var.task_time_in_queue_change_aggregation_function}${var.task_time_in_queue_change_transformation_function}.publish('signal')
-    detect(when(signal > ${var.task_time_in_queue_change_threshold_warning})).publish('WARN')
-    detect(when(signal > ${var.task_time_in_queue_change_threshold_major}) and when(signal <= ${var.task_time_in_queue_change_threshold_warning})).publish('MAJOR')
+    detect(when(signal > ${var.task_time_in_queue_change_threshold_major})).publish('MAJOR')
+    detect(when(signal > ${var.task_time_in_queue_change_threshold_minor}) and when(signal <= ${var.task_time_in_queue_change_threshold_major})).publish('MINOR')
 EOF
-
-  rule {
-    description           = "is too high > ${var.task_time_in_queue_change_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.task_time_in_queue_change_disabled_warning, var.task_time_in_queue_change_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.task_time_in_queue_change_notifications, "warning", []), var.notifications.warning)
-    parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
-  }
 
   rule {
     description           = "is too high > ${var.task_time_in_queue_change_threshold_major}"
@@ -592,6 +583,15 @@ EOF
     detect_label          = "MAJOR"
     disabled              = coalesce(var.task_time_in_queue_change_disabled_major, var.task_time_in_queue_change_disabled, var.detectors_disabled)
     notifications         = coalescelist(lookup(var.task_time_in_queue_change_notifications, "major", []), var.notifications.major)
+    parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
+  }
+
+  rule {
+    description           = "is too high > ${var.task_time_in_queue_change_threshold_minor}"
+    severity              = "Minor"
+    detect_label          = "MINOR"
+    disabled              = coalesce(var.task_time_in_queue_change_disabled_minor, var.task_time_in_queue_change_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.task_time_in_queue_change_notifications, "minor", []), var.notifications.minor)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/database/elasticsearch/variables.tf
+++ b/database/elasticsearch/variables.tf
@@ -76,8 +76,8 @@ variable "cluster_status_disabled_critical" {
   default     = null
 }
 
-variable "cluster_status_disabled_warning" {
-  description = "Disable warning alerting rule for cluster_status_not_green detector"
+variable "cluster_status_disabled_major" {
+  description = "Disable major alerting rule for cluster_status_not_green detector"
   type        = bool
   default     = null
 }
@@ -114,8 +114,8 @@ variable "cluster_initializing_shards_disabled_critical" {
   default     = null
 }
 
-variable "cluster_initializing_shards_disabled_warning" {
-  description = "Disable warning alerting rule for cluster_initializing_shards detector"
+variable "cluster_initializing_shards_disabled_major" {
+  description = "Disable major alerting rule for cluster_initializing_shards detector"
   type        = bool
   default     = null
 }
@@ -144,8 +144,8 @@ variable "cluster_initializing_shards_threshold_critical" {
   default     = 1
 }
 
-variable "cluster_initializing_shards_threshold_warning" {
-  description = "Warning threshold for cluster_initializing_shards detector"
+variable "cluster_initializing_shards_threshold_major" {
+  description = "Major threshold for cluster_initializing_shards detector"
   type        = number
   default     = 0
 }
@@ -164,8 +164,8 @@ variable "cluster_relocating_shards_disabled_critical" {
   default     = null
 }
 
-variable "cluster_relocating_shards_disabled_warning" {
-  description = "Disable warning alerting rule for cluster_relocating_shards detector"
+variable "cluster_relocating_shards_disabled_major" {
+  description = "Disable major alerting rule for cluster_relocating_shards detector"
   type        = bool
   default     = true
 }
@@ -194,8 +194,8 @@ variable "cluster_relocating_shards_threshold_critical" {
   default     = 0
 }
 
-variable "cluster_relocating_shards_threshold_warning" {
-  description = "Warning threshold for cluster_relocating_shards detector"
+variable "cluster_relocating_shards_threshold_major" {
+  description = "Major threshold for cluster_relocating_shards detector"
   type        = number
   default     = -1
 }
@@ -214,8 +214,8 @@ variable "cluster_unassigned_shards_disabled_critical" {
   default     = null
 }
 
-variable "cluster_unassigned_shards_disabled_warning" {
-  description = "Disable warning alerting rule for cluster_unassigned_shards detector"
+variable "cluster_unassigned_shards_disabled_major" {
+  description = "Disable major alerting rule for cluster_unassigned_shards detector"
   type        = bool
   default     = true
 }
@@ -244,8 +244,8 @@ variable "cluster_unassigned_shards_threshold_critical" {
   default     = 0
 }
 
-variable "cluster_unassigned_shards_threshold_warning" {
-  description = "Warning threshold for cluster_unassigned_shards detector"
+variable "cluster_unassigned_shards_threshold_major" {
+  description = "Major threshold for cluster_unassigned_shards detector"
   type        = number
   default     = -1
 }
@@ -264,8 +264,8 @@ variable "pending_tasks_disabled_critical" {
   default     = null
 }
 
-variable "pending_tasks_disabled_warning" {
-  description = "Disable warning alerting rule for pending_tasks detector"
+variable "pending_tasks_disabled_major" {
+  description = "Disable major alerting rule for pending_tasks detector"
   type        = bool
   default     = null
 }
@@ -294,8 +294,8 @@ variable "pending_tasks_threshold_critical" {
   default     = 5
 }
 
-variable "pending_tasks_threshold_warning" {
-  description = "Warning threshold for pending_tasks detector"
+variable "pending_tasks_threshold_major" {
+  description = "Major threshold for pending_tasks detector"
   type        = number
   default     = 0
 }
@@ -314,8 +314,8 @@ variable "jvm_heap_memory_usage_disabled_critical" {
   default     = null
 }
 
-variable "jvm_heap_memory_usage_disabled_warning" {
-  description = "Disable warning alerting rule for jvm_heap_memory_usage detector"
+variable "jvm_heap_memory_usage_disabled_major" {
+  description = "Disable major alerting rule for jvm_heap_memory_usage detector"
   type        = bool
   default     = null
 }
@@ -344,8 +344,8 @@ variable "jvm_heap_memory_usage_threshold_critical" {
   default     = 90
 }
 
-variable "jvm_heap_memory_usage_threshold_warning" {
-  description = "Warning threshold for jvm_heap_memory_usage detector"
+variable "jvm_heap_memory_usage_threshold_major" {
+  description = "Major threshold for jvm_heap_memory_usage detector"
   type        = number
   default     = 80
 }
@@ -364,8 +364,8 @@ variable "cpu_usage_disabled_critical" {
   default     = null
 }
 
-variable "cpu_usage_disabled_warning" {
-  description = "Disable warning alerting rule for cpu_usage detector"
+variable "cpu_usage_disabled_major" {
+  description = "Disable major alerting rule for cpu_usage detector"
   type        = bool
   default     = null
 }
@@ -394,8 +394,8 @@ variable "cpu_usage_threshold_critical" {
   default     = 95
 }
 
-variable "cpu_usage_threshold_warning" {
-  description = "Warning threshold for cpu_usage detector"
+variable "cpu_usage_threshold_major" {
+  description = "Major threshold for cpu_usage detector"
   type        = number
   default     = 85
 }
@@ -414,8 +414,8 @@ variable "file_descriptors_disabled_critical" {
   default     = null
 }
 
-variable "file_descriptors_disabled_warning" {
-  description = "Disable warning alerting rule for file_descriptors detector"
+variable "file_descriptors_disabled_major" {
+  description = "Disable major alerting rule for file_descriptors detector"
   type        = bool
   default     = null
 }
@@ -444,8 +444,8 @@ variable "file_descriptors_threshold_critical" {
   default     = 95
 }
 
-variable "file_descriptors_threshold_warning" {
-  description = "Warning threshold for file_descriptors detector"
+variable "file_descriptors_threshold_major" {
+  description = "Major threshold for file_descriptors detector"
   type        = number
   default     = 90
 }
@@ -458,14 +458,14 @@ variable "jvm_memory_young_usage_disabled" {
   default     = null
 }
 
-variable "jvm_memory_young_usage_disabled_warning" {
-  description = "Disable warning alerting rule for jvm_memory_young_usage detector"
+variable "jvm_memory_young_usage_disabled_major" {
+  description = "Disable major alerting rule for jvm_memory_young_usage detector"
   type        = bool
   default     = null
 }
 
-variable "jvm_memory_young_usage_disabled_major" {
-  description = "Disable major alerting rule for jvm_memory_young_usage detector"
+variable "jvm_memory_young_usage_disabled_minor" {
+  description = "Disable minor alerting rule for jvm_memory_young_usage detector"
   type        = bool
   default     = null
 }
@@ -488,14 +488,14 @@ variable "jvm_memory_young_usage_transformation_function" {
   default     = ".mean(over='10m')"
 }
 
-variable "jvm_memory_young_usage_threshold_warning" {
-  description = "warning threshold for jvm_memory_young_usage detector"
+variable "jvm_memory_young_usage_threshold_major" {
+  description = "major threshold for jvm_memory_young_usage detector"
   type        = number
   default     = 90
 }
 
-variable "jvm_memory_young_usage_threshold_major" {
-  description = "major threshold for jvm_memory_young_usage detector"
+variable "jvm_memory_young_usage_threshold_minor" {
+  description = "minor threshold for jvm_memory_young_usage detector"
   type        = number
   default     = 80
 }
@@ -508,14 +508,14 @@ variable "jvm_memory_old_usage_disabled" {
   default     = null
 }
 
-variable "jvm_memory_old_usage_disabled_warning" {
-  description = "Disable warning alerting rule for jvm_memory_old_usage detector"
+variable "jvm_memory_old_usage_disabled_major" {
+  description = "Disable major alerting rule for jvm_memory_old_usage detector"
   type        = bool
   default     = null
 }
 
-variable "jvm_memory_old_usage_disabled_major" {
-  description = "Disable major alerting rule for jvm_memory_old_usage detector"
+variable "jvm_memory_old_usage_disabled_minor" {
+  description = "Disable minor alerting rule for jvm_memory_old_usage detector"
   type        = bool
   default     = null
 }
@@ -538,14 +538,14 @@ variable "jvm_memory_old_usage_transformation_function" {
   default     = ".mean(over='10m')"
 }
 
-variable "jvm_memory_old_usage_threshold_warning" {
-  description = "warning threshold for jvm_memory_old_usage detector"
+variable "jvm_memory_old_usage_threshold_major" {
+  description = "major threshold for jvm_memory_old_usage detector"
   type        = number
   default     = 90
 }
 
-variable "jvm_memory_old_usage_threshold_major" {
-  description = "major threshold for jvm_memory_old_usage detector"
+variable "jvm_memory_old_usage_threshold_minor" {
+  description = "minor threshold for jvm_memory_old_usage detector"
   type        = number
   default     = 80
 }
@@ -558,14 +558,14 @@ variable "jvm_gc_old_collection_latency_disabled" {
   default     = null
 }
 
-variable "jvm_gc_old_collection_latency_disabled_warning" {
-  description = "Disable warning alerting rule for jvm_gc_old_collection_latency detector"
+variable "jvm_gc_old_collection_latency_disabled_major" {
+  description = "Disable major alerting rule for jvm_gc_old_collection_latency detector"
   type        = bool
   default     = null
 }
 
-variable "jvm_gc_old_collection_latency_disabled_major" {
-  description = "Disable major alerting rule for jvm_gc_old_collection_latency detector"
+variable "jvm_gc_old_collection_latency_disabled_minor" {
+  description = "Disable minor alerting rule for jvm_gc_old_collection_latency detector"
   type        = bool
   default     = null
 }
@@ -588,14 +588,14 @@ variable "jvm_gc_old_collection_latency_transformation_function" {
   default     = ".mean(over='15m')"
 }
 
-variable "jvm_gc_old_collection_latency_threshold_warning" {
-  description = "warning threshold for jvm_gc_old_collection_latency detector"
+variable "jvm_gc_old_collection_latency_threshold_major" {
+  description = "major threshold for jvm_gc_old_collection_latency detector"
   type        = number
   default     = 300
 }
 
-variable "jvm_gc_old_collection_latency_threshold_major" {
-  description = "major threshold for jvm_gc_old_collection_latency detector"
+variable "jvm_gc_old_collection_latency_threshold_minor" {
+  description = "minor threshold for jvm_gc_old_collection_latency detector"
   type        = number
   default     = 200
 }
@@ -608,14 +608,14 @@ variable "jvm_gc_young_collection_latency_disabled" {
   default     = null
 }
 
-variable "jvm_gc_young_collection_latency_disabled_warning" {
-  description = "Disable warning alerting rule for jvm_gc_young_collection_latency detector"
+variable "jvm_gc_young_collection_latency_disabled_major" {
+  description = "Disable major alerting rule for jvm_gc_young_collection_latency detector"
   type        = bool
   default     = null
 }
 
-variable "jvm_gc_young_collection_latency_disabled_major" {
-  description = "Disable major alerting rule for jvm_gc_young_collection_latency detector"
+variable "jvm_gc_young_collection_latency_disabled_minor" {
+  description = "Disable minor alerting rule for jvm_gc_young_collection_latency detector"
   type        = bool
   default     = null
 }
@@ -638,14 +638,14 @@ variable "jvm_gc_young_collection_latency_transformation_function" {
   default     = ".mean(over='15m')"
 }
 
-variable "jvm_gc_young_collection_latency_threshold_warning" {
-  description = "warning threshold for jvm_gc_young_collection_latency detector"
+variable "jvm_gc_young_collection_latency_threshold_major" {
+  description = "major threshold for jvm_gc_young_collection_latency detector"
   type        = number
   default     = 40
 }
 
-variable "jvm_gc_young_collection_latency_threshold_major" {
-  description = "major threshold for jvm_gc_young_collection_latency detector"
+variable "jvm_gc_young_collection_latency_threshold_minor" {
+  description = "minor threshold for jvm_gc_young_collection_latency detector"
   type        = number
   default     = 20
 }
@@ -658,14 +658,14 @@ variable "indexing_latency_disabled" {
   default     = null
 }
 
-variable "indexing_latency_disabled_warning" {
-  description = "Disable warning alerting rule for indexing_latency detector"
+variable "indexing_latency_disabled_major" {
+  description = "Disable major alerting rule for indexing_latency detector"
   type        = bool
   default     = null
 }
 
-variable "indexing_latency_disabled_major" {
-  description = "Disable major alerting rule for indexing_latency detector"
+variable "indexing_latency_disabled_minor" {
+  description = "Disable minor alerting rule for indexing_latency detector"
   type        = bool
   default     = null
 }
@@ -688,14 +688,14 @@ variable "indexing_latency_transformation_function" {
   default     = ".mean(over='15m')"
 }
 
-variable "indexing_latency_threshold_warning" {
-  description = "warning threshold for indexing_latency detector"
+variable "indexing_latency_threshold_major" {
+  description = "major threshold for indexing_latency detector"
   type        = number
   default     = 30
 }
 
-variable "indexing_latency_threshold_major" {
-  description = "major threshold for indexing_latency detector"
+variable "indexing_latency_threshold_minor" {
+  description = "minor threshold for indexing_latency detector"
   type        = number
   default     = 15
 }
@@ -708,14 +708,14 @@ variable "flush_latency_disabled" {
   default     = null
 }
 
-variable "flush_latency_disabled_warning" {
-  description = "Disable warning alerting rule for flush_latency detector"
+variable "flush_latency_disabled_major" {
+  description = "Disable major alerting rule for flush_latency detector"
   type        = bool
   default     = null
 }
 
-variable "flush_latency_disabled_major" {
-  description = "Disable major alerting rule for flush_latency detector"
+variable "flush_latency_disabled_minor" {
+  description = "Disable minor alerting rule for flush_latency detector"
   type        = bool
   default     = null
 }
@@ -738,14 +738,14 @@ variable "flush_latency_transformation_function" {
   default     = ".mean(over='15m')"
 }
 
-variable "flush_latency_threshold_warning" {
-  description = "warning threshold for flush_latency detector"
+variable "flush_latency_threshold_major" {
+  description = "major threshold for flush_latency detector"
   type        = number
   default     = 150
 }
 
-variable "flush_latency_threshold_major" {
-  description = "major threshold for flush_latency detector"
+variable "flush_latency_threshold_minor" {
+  description = "minor threshold for flush_latency detector"
   type        = number
   default     = 100
 }
@@ -758,14 +758,14 @@ variable "search_latency_disabled" {
   default     = null
 }
 
-variable "search_latency_disabled_warning" {
-  description = "Disable warning alerting rule for search_latency detector"
+variable "search_latency_disabled_major" {
+  description = "Disable major alerting rule for search_latency detector"
   type        = bool
   default     = null
 }
 
-variable "search_latency_disabled_major" {
-  description = "Disable major alerting rule for search_latency detector"
+variable "search_latency_disabled_minor" {
+  description = "Disable minor alerting rule for search_latency detector"
   type        = bool
   default     = null
 }
@@ -788,14 +788,14 @@ variable "search_latency_transformation_function" {
   default     = ".min(over='30m')"
 }
 
-variable "search_latency_threshold_warning" {
-  description = "warning threshold for search_latency detector"
+variable "search_latency_threshold_major" {
+  description = "major threshold for search_latency detector"
   type        = number
   default     = 20
 }
 
-variable "search_latency_threshold_major" {
-  description = "major threshold for search_latency detector"
+variable "search_latency_threshold_minor" {
+  description = "minor threshold for search_latency detector"
   type        = number
   default     = 10
 }
@@ -808,14 +808,14 @@ variable "fetch_latency_disabled" {
   default     = null
 }
 
-variable "fetch_latency_disabled_warning" {
-  description = "Disable warning alerting rule for fetch_latency detector"
+variable "fetch_latency_disabled_major" {
+  description = "Disable major alerting rule for fetch_latency detector"
   type        = bool
   default     = null
 }
 
-variable "fetch_latency_disabled_major" {
-  description = "Disable major alerting rule for fetch_latency detector"
+variable "fetch_latency_disabled_minor" {
+  description = "Disable minor alerting rule for fetch_latency detector"
   type        = bool
   default     = null
 }
@@ -838,14 +838,14 @@ variable "fetch_latency_transformation_function" {
   default     = ".min(over='15m')"
 }
 
-variable "fetch_latency_threshold_warning" {
-  description = "warning threshold for fetch_latency detector"
+variable "fetch_latency_threshold_major" {
+  description = "major threshold for fetch_latency detector"
   type        = number
   default     = 20
 }
 
-variable "fetch_latency_threshold_major" {
-  description = "major threshold for fetch_latency detector"
+variable "fetch_latency_threshold_minor" {
+  description = "minor threshold for fetch_latency detector"
   type        = number
   default     = 10
 }
@@ -858,14 +858,14 @@ variable "field_data_evictions_change_disabled" {
   default     = null
 }
 
-variable "field_data_evictions_change_disabled_warning" {
-  description = "Disable warning alerting rule for field_data_evictions_change detector"
+variable "field_data_evictions_change_disabled_major" {
+  description = "Disable major alerting rule for field_data_evictions_change detector"
   type        = bool
   default     = null
 }
 
-variable "field_data_evictions_change_disabled_major" {
-  description = "Disable major alerting rule for field_data_evictions_change detector"
+variable "field_data_evictions_change_disabled_minor" {
+  description = "Disable minor alerting rule for field_data_evictions_change detector"
   type        = bool
   default     = null
 }
@@ -888,14 +888,14 @@ variable "field_data_evictions_change_transformation_function" {
   default     = ".mean(over='15m')"
 }
 
-variable "field_data_evictions_change_threshold_warning" {
-  description = "warning threshold for field_data_evictions_change detector"
+variable "field_data_evictions_change_threshold_major" {
+  description = "major threshold for field_data_evictions_change detector"
   type        = number
   default     = 120
 }
 
-variable "field_data_evictions_change_threshold_major" {
-  description = "major threshold for field_data_evictions_change detector"
+variable "field_data_evictions_change_threshold_minor" {
+  description = "minor threshold for field_data_evictions_change detector"
   type        = number
   default     = 60
 }
@@ -908,14 +908,14 @@ variable "query_cache_evictions_change_disabled" {
   default     = null
 }
 
-variable "query_cache_evictions_change_disabled_warning" {
-  description = "Disable warning alerting rule for query_cache_evictions_change detector"
+variable "query_cache_evictions_change_disabled_major" {
+  description = "Disable major alerting rule for query_cache_evictions_change detector"
   type        = bool
   default     = null
 }
 
-variable "query_cache_evictions_change_disabled_major" {
-  description = "Disable major alerting rule for query_cache_evictions_change detector"
+variable "query_cache_evictions_change_disabled_minor" {
+  description = "Disable minor alerting rule for query_cache_evictions_change detector"
   type        = bool
   default     = null
 }
@@ -938,14 +938,14 @@ variable "query_cache_evictions_change_transformation_function" {
   default     = ".mean(over='15m')"
 }
 
-variable "query_cache_evictions_change_threshold_warning" {
-  description = "warning threshold for query_cache_evictions_change detector"
+variable "query_cache_evictions_change_threshold_major" {
+  description = "major threshold for query_cache_evictions_change detector"
   type        = number
   default     = 120
 }
 
-variable "query_cache_evictions_change_threshold_major" {
-  description = "major threshold for query_cache_evictions_change detector"
+variable "query_cache_evictions_change_threshold_minor" {
+  description = "minor threshold for query_cache_evictions_change detector"
   type        = number
   default     = 60
 }
@@ -958,14 +958,14 @@ variable "request_cache_evictions_change_disabled" {
   default     = null
 }
 
-variable "request_cache_evictions_change_disabled_warning" {
-  description = "Disable warning alerting rule for request_cache_evictions_change detector"
+variable "request_cache_evictions_change_disabled_major" {
+  description = "Disable major alerting rule for request_cache_evictions_change detector"
   type        = bool
   default     = null
 }
 
-variable "request_cache_evictions_change_disabled_major" {
-  description = "Disable major alerting rule for request_cache_evictions_change detector"
+variable "request_cache_evictions_change_disabled_minor" {
+  description = "Disable minor alerting rule for request_cache_evictions_change detector"
   type        = bool
   default     = null
 }
@@ -988,14 +988,14 @@ variable "request_cache_evictions_change_transformation_function" {
   default     = ".mean(over='15m')"
 }
 
-variable "request_cache_evictions_change_threshold_warning" {
-  description = "warning threshold for request_cache_evictions_change detector"
+variable "request_cache_evictions_change_threshold_major" {
+  description = "major threshold for request_cache_evictions_change detector"
   type        = number
   default     = 120
 }
 
-variable "request_cache_evictions_change_threshold_major" {
-  description = "major threshold for request_cache_evictions_change detector"
+variable "request_cache_evictions_change_threshold_minor" {
+  description = "minor threshold for request_cache_evictions_change detector"
   type        = number
   default     = 60
 }
@@ -1008,14 +1008,14 @@ variable "task_time_in_queue_change_disabled" {
   default     = null
 }
 
-variable "task_time_in_queue_change_disabled_warning" {
-  description = "Disable warning alerting rule for task_time_in_queue_change detector"
+variable "task_time_in_queue_change_disabled_major" {
+  description = "Disable major alerting rule for task_time_in_queue_change detector"
   type        = bool
   default     = null
 }
 
-variable "task_time_in_queue_change_disabled_major" {
-  description = "Disable major alerting rule for task_time_in_queue_change detector"
+variable "task_time_in_queue_change_disabled_minor" {
+  description = "Disable minor alerting rule for task_time_in_queue_change detector"
   type        = bool
   default     = null
 }
@@ -1038,14 +1038,14 @@ variable "task_time_in_queue_change_transformation_function" {
   default     = ".mean(over='15m')"
 }
 
-variable "task_time_in_queue_change_threshold_warning" {
-  description = "warning threshold for task_time_in_queue_change detector"
+variable "task_time_in_queue_change_threshold_major" {
+  description = "major threshold for task_time_in_queue_change detector"
   type        = number
   default     = 200
 }
 
-variable "task_time_in_queue_change_threshold_major" {
-  description = "major threshold for task_time_in_queue_change detector"
+variable "task_time_in_queue_change_threshold_minor" {
+  description = "minor threshold for task_time_in_queue_change detector"
   type        = number
   default     = 100
 }

--- a/database/mysql/variables.tf
+++ b/database/mysql/variables.tf
@@ -76,8 +76,8 @@ variable "mysql_connections_disabled_critical" {
   default     = null
 }
 
-variable "mysql_connections_disabled_warning" {
-  description = "Disable warning alerting rule for mysql_connection detector"
+variable "mysql_connections_disabled_major" {
+  description = "Disable major alerting rule for mysql_connection detector"
   type        = bool
   default     = null
 }
@@ -106,8 +106,8 @@ variable "mysql_connections_threshold_critical" {
   default     = 90
 }
 
-variable "mysql_connections_threshold_warning" {
-  description = "Warning threshold for mysql_connection detector"
+variable "mysql_connections_threshold_major" {
+  description = "Major threshold for mysql_connection detector"
   type        = number
   default     = 70
 }
@@ -120,14 +120,14 @@ variable "mysql_pool_efficiency_disabled" {
   default     = null
 }
 
-variable "mysql_pool_efficiency_disabled_major" {
-  description = "Disable major alerting rule for mysql_pool_efficiency detector"
+variable "mysql_pool_efficiency_disabled_minor" {
+  description = "Disable minor alerting rule for mysql_pool_efficiency detector"
   type        = bool
   default     = null
 }
 
-variable "mysql_pool_efficiency_disabled_minor" {
-  description = "Disable minor alerting rule for mysql_pool_efficiency detector"
+variable "mysql_pool_efficiency_disabled_warning" {
+  description = "Disable warning alerting rule for mysql_pool_efficiency detector"
   type        = bool
   default     = null
 }
@@ -150,14 +150,14 @@ variable "mysql_pool_efficiency_transformation_function" {
   default     = ".min(over='1h')"
 }
 
-variable "mysql_pool_efficiency_threshold_major" {
-  description = "major threshold for mysql_pool_efficiency detector"
+variable "mysql_pool_efficiency_threshold_minor" {
+  description = "minor threshold for mysql_pool_efficiency detector"
   type        = number
   default     = 30
 }
 
-variable "mysql_pool_efficiency_threshold_minor" {
-  description = "minor threshold for mysql_pool_efficiency detector"
+variable "mysql_pool_efficiency_threshold_warning" {
+  description = "warning threshold for mysql_pool_efficiency detector"
   type        = number
   default     = 20
 }
@@ -170,14 +170,14 @@ variable "mysql_pool_utilization_disabled" {
   default     = null
 }
 
-variable "mysql_pool_utilization_disabled_major" {
-  description = "Disable major alerting rule for mysql_pool_utilization detector"
+variable "mysql_pool_utilization_disabled_minor" {
+  description = "Disable minor alerting rule for mysql_pool_utilization detector"
   type        = bool
   default     = null
 }
 
-variable "mysql_pool_utilization_disabled_minor" {
-  description = "Disable minor alerting rule for mysql_pool_utilization detector"
+variable "mysql_pool_utilization_disabled_warning" {
+  description = "Disable warning alerting rule for mysql_pool_utilization detector"
   type        = bool
   default     = null
 }
@@ -200,14 +200,14 @@ variable "mysql_pool_utilization_transformation_function" {
   default     = ".min(over='1h')"
 }
 
-variable "mysql_pool_utilization_threshold_major" {
-  description = "major threshold for mysql_pool_utilization detector"
+variable "mysql_pool_utilization_threshold_minor" {
+  description = "minor threshold for mysql_pool_utilization detector"
   type        = number
   default     = 95
 }
 
-variable "mysql_pool_utilization_threshold_minor" {
-  description = "minor threshold for mysql_pool_utilization detector"
+variable "mysql_pool_utilization_threshold_warning" {
+  description = "warning threshold for mysql_pool_utilization detector"
   type        = number
   default     = 80
 }
@@ -226,8 +226,8 @@ variable "mysql_slow_disabled_critical" {
   default     = null
 }
 
-variable "mysql_slow_disabled_warning" {
-  description = "Disable warning alerting rule for mysql_slow detector"
+variable "mysql_slow_disabled_major" {
+  description = "Disable major alerting rule for mysql_slow detector"
   type        = bool
   default     = null
 }
@@ -256,8 +256,8 @@ variable "mysql_slow_threshold_critical" {
   default     = 25
 }
 
-variable "mysql_slow_threshold_warning" {
-  description = "Warning threshold for mysql_slow detector"
+variable "mysql_slow_threshold_major" {
+  description = "Major threshold for mysql_slow detector"
   type        = number
   default     = 10
 }
@@ -400,8 +400,8 @@ variable "mysql_replication_lag_disabled_critical" {
   default     = null
 }
 
-variable "mysql_replication_lag_disabled_warning" {
-  description = "Disable warning alerting rule for mysql_replication_lag detector"
+variable "mysql_replication_lag_disabled_major" {
+  description = "Disable major alerting rule for mysql_replication_lag detector"
   type        = bool
   default     = null
 }
@@ -430,8 +430,8 @@ variable "mysql_replication_lag_threshold_critical" {
   default     = 200
 }
 
-variable "mysql_replication_lag_threshold_warning" {
-  description = "Warning threshold for mysql_replication_lag detector"
+variable "mysql_replication_lag_threshold_major" {
+  description = "Major threshold for mysql_replication_lag detector"
   type        = number
   default     = 100
 }

--- a/database/postgresql/variables.tf
+++ b/database/postgresql/variables.tf
@@ -70,14 +70,14 @@ variable "deadlocks_disabled" {
   default     = null
 }
 
-variable "deadlocks_disabled_major" {
-  description = "Disable major alerting rule for deadlocks detector"
+variable "deadlocks_disabled_minor" {
+  description = "Disable minor alerting rule for deadlocks detector"
   type        = bool
   default     = null
 }
 
-variable "deadlocks_disabled_warning" {
-  description = "Disable warning alerting rule for deadlocks detector"
+variable "deadlocks_disabled_major" {
+  description = "Disable major alerting rule for deadlocks detector"
   type        = bool
   default     = null
 }
@@ -100,14 +100,14 @@ variable "deadlocks_transformation_function" {
   default     = ".max(over='5m')"
 }
 
-variable "deadlocks_threshold_major" {
-  description = "major threshold for deadlocks detector"
+variable "deadlocks_threshold_minor" {
+  description = "minor threshold for deadlocks detector"
   type        = number
   default     = 0
 }
 
-variable "deadlocks_threshold_warning" {
-  description = "Warning threshold for deadlocks detector"
+variable "deadlocks_threshold_major" {
+  description = "Major threshold for deadlocks detector"
   type        = number
   default     = 0.1
 }
@@ -120,14 +120,14 @@ variable "hit_ratio_disabled" {
   default     = null
 }
 
-variable "hit_ratio_disabled_minor" {
-  description = "Disable minor alerting rule for hit_ratio detector"
+variable "hit_ratio_disabled_warning" {
+  description = "Disable warning alerting rule for hit_ratio detector"
   type        = bool
   default     = null
 }
 
-variable "hit_ratio_disabled_major" {
-  description = "Disable major alerting rule for hit_ratio detector"
+variable "hit_ratio_disabled_minor" {
+  description = "Disable minor alerting rule for hit_ratio detector"
   type        = bool
   default     = null
 }
@@ -150,14 +150,14 @@ variable "hit_ratio_transformation_function" {
   default     = ".max(over='1h')"
 }
 
-variable "hit_ratio_threshold_minor" {
-  description = "minor threshold for hit_ratio detector"
+variable "hit_ratio_threshold_warning" {
+  description = "warning threshold for hit_ratio detector"
   type        = number
   default     = 50
 }
 
-variable "hit_ratio_threshold_major" {
-  description = "Major threshold for hit_ratio detector"
+variable "hit_ratio_threshold_minor" {
+  description = "Minor threshold for hit_ratio detector"
   type        = number
   default     = 75
 }
@@ -170,14 +170,14 @@ variable "rollbacks_disabled" {
   default     = null
 }
 
-variable "rollbacks_disabled_warning" {
-  description = "Disable warning alerting rule for rollbacks detector"
+variable "rollbacks_disabled_major" {
+  description = "Disable major alerting rule for rollbacks detector"
   type        = bool
   default     = null
 }
 
-variable "rollbacks_disabled_major" {
-  description = "Disable major alerting rule for rollbacks detector"
+variable "rollbacks_disabled_minor" {
+  description = "Disable minor alerting rule for rollbacks detector"
   type        = bool
   default     = null
 }
@@ -200,14 +200,14 @@ variable "rollbacks_transformation_function" {
   default     = ".min(over='10m')"
 }
 
-variable "rollbacks_threshold_warning" {
-  description = "Warning threshold for rollbacks detector"
+variable "rollbacks_threshold_major" {
+  description = "Major threshold for rollbacks detector"
   type        = number
   default     = 20
 }
 
-variable "rollbacks_threshold_major" {
-  description = "Major threshold for rollbacks detector"
+variable "rollbacks_threshold_minor" {
+  description = "Minor threshold for rollbacks detector"
   type        = number
   default     = 10
 }
@@ -220,14 +220,14 @@ variable "conflicts_disabled" {
   default     = null
 }
 
-variable "conflicts_disabled_major" {
-  description = "Disable major alerting rule for conflicts detector"
+variable "conflicts_disabled_minor" {
+  description = "Disable minor alerting rule for conflicts detector"
   type        = bool
   default     = null
 }
 
-variable "conflicts_disabled_warning" {
-  description = "Disable warning alerting rule for conflicts detector"
+variable "conflicts_disabled_major" {
+  description = "Disable major alerting rule for conflicts detector"
   type        = bool
   default     = null
 }
@@ -250,14 +250,14 @@ variable "conflicts_transformation_function" {
   default     = ".max(over='5m')"
 }
 
-variable "conflicts_threshold_major" {
-  description = "major threshold for conflicts detector"
+variable "conflicts_threshold_minor" {
+  description = "minor threshold for conflicts detector"
   type        = number
   default     = 0
 }
 
-variable "conflicts_threshold_warning" {
-  description = "warning threshold for conflicts detector"
+variable "conflicts_threshold_major" {
+  description = "major threshold for conflicts detector"
   type        = number
   default     = 1
 }
@@ -276,8 +276,8 @@ variable "max_connections_disabled_critical" {
   default     = null
 }
 
-variable "max_connections_disabled_warning" {
-  description = "Disable warning alerting rule for max_connections detector"
+variable "max_connections_disabled_major" {
+  description = "Disable major alerting rule for max_connections detector"
   type        = bool
   default     = null
 }
@@ -306,8 +306,8 @@ variable "max_connections_threshold_critical" {
   default     = 90
 }
 
-variable "max_connections_threshold_warning" {
-  description = "Warning threshold for max_connections detector"
+variable "max_connections_threshold_major" {
+  description = "Major threshold for max_connections detector"
   type        = number
   default     = 80
 }
@@ -326,8 +326,8 @@ variable "replication_lag_disabled_critical" {
   default     = null
 }
 
-variable "replication_lag_disabled_warning" {
-  description = "Disable warning alerting rule for replication_lag detector"
+variable "replication_lag_disabled_major" {
+  description = "Disable major alerting rule for replication_lag detector"
   type        = bool
   default     = null
 }
@@ -356,8 +356,8 @@ variable "replication_lag_threshold_critical" {
   default     = 200
 }
 
-variable "replication_lag_threshold_warning" {
-  description = "Warning threshold for replication_lag detector"
+variable "replication_lag_threshold_major" {
+  description = "Major threshold for replication_lag detector"
   type        = number
   default     = 100
 }

--- a/database/redis/variables.tf
+++ b/database/redis/variables.tf
@@ -76,8 +76,8 @@ variable "evicted_keys_disabled_critical" {
   default     = null
 }
 
-variable "evicted_keys_disabled_warning" {
-  description = "Disable warning alerting rule for evicted_keys detector"
+variable "evicted_keys_disabled_major" {
+  description = "Disable major alerting rule for evicted_keys detector"
   type        = bool
   default     = null
 }
@@ -106,8 +106,8 @@ variable "evicted_keys_threshold_critical" {
   default     = 50
 }
 
-variable "evicted_keys_threshold_warning" {
-  description = "Warning threshold for evicted_keys detector"
+variable "evicted_keys_threshold_major" {
+  description = "Major threshold for evicted_keys detector"
   type        = number
   default     = 25
 }
@@ -126,8 +126,8 @@ variable "expirations_disabled_critical" {
   default     = null
 }
 
-variable "expirations_disabled_warning" {
-  description = "Disable warning alerting rule for expirations detector"
+variable "expirations_disabled_major" {
+  description = "Disable major alerting rule for expirations detector"
   type        = bool
   default     = null
 }
@@ -156,8 +156,8 @@ variable "expirations_threshold_critical" {
   default     = 100
 }
 
-variable "expirations_threshold_warning" {
-  description = "Warning threshold for expirations detector"
+variable "expirations_threshold_major" {
+  description = "Major threshold for expirations detector"
   type        = number
   default     = 50
 }
@@ -170,14 +170,14 @@ variable "blocked_clients_disabled" {
   default     = null
 }
 
-variable "blocked_clients_disabled_major" {
-  description = "Disable major alerting rule for blocked_clients detector"
+variable "blocked_clients_disabled_minor" {
+  description = "Disable minor alerting rule for blocked_clients detector"
   type        = bool
   default     = null
 }
 
-variable "blocked_clients_disabled_minor" {
-  description = "Disable minor alerting rule for blocked_clients detector"
+variable "blocked_clients_disabled_warning" {
+  description = "Disable warning alerting rule for blocked_clients detector"
   type        = bool
   default     = null
 }
@@ -200,14 +200,14 @@ variable "blocked_clients_transformation_function" {
   default     = ".mean(over='1h')"
 }
 
-variable "blocked_clients_threshold_major" {
-  description = "major threshold for blocked_clients detector"
+variable "blocked_clients_threshold_minor" {
+  description = "minor threshold for blocked_clients detector"
   type        = number
   default     = 5
 }
 
-variable "blocked_clients_threshold_minor" {
-  description = "minor threshold for blocked_clients detector"
+variable "blocked_clients_threshold_warning" {
+  description = "warning threshold for blocked_clients detector"
   type        = number
   default     = 0
 }
@@ -252,8 +252,8 @@ variable "memory_used_max_disabled_critical" {
   default     = null
 }
 
-variable "memory_used_max_disabled_warning" {
-  description = "Disable warning alerting rule for memory_used_max detector"
+variable "memory_used_max_disabled_major" {
+  description = "Disable major alerting rule for memory_used_max detector"
   type        = bool
   default     = null
 }
@@ -282,8 +282,8 @@ variable "memory_used_max_threshold_critical" {
   default     = 95
 }
 
-variable "memory_used_max_threshold_warning" {
-  description = "Warning threshold for memory_used_max detector"
+variable "memory_used_max_threshold_major" {
+  description = "Major threshold for memory_used_max detector"
   type        = number
   default     = 85
 }
@@ -302,8 +302,8 @@ variable "memory_used_total_disabled_critical" {
   default     = null
 }
 
-variable "memory_used_total_disabled_warning" {
-  description = "Disable warning alerting rule for memory_used_total detector"
+variable "memory_used_total_disabled_major" {
+  description = "Disable major alerting rule for memory_used_total detector"
   type        = bool
   default     = null
 }
@@ -332,8 +332,8 @@ variable "memory_used_total_threshold_critical" {
   default     = 95
 }
 
-variable "memory_used_total_threshold_warning" {
-  description = "Warning threshold for memory_used_total detector"
+variable "memory_used_total_threshold_major" {
+  description = "Major threshold for memory_used_total detector"
   type        = number
   default     = 85
 }
@@ -352,8 +352,8 @@ variable "memory_frag_high_disabled_critical" {
   default     = null
 }
 
-variable "memory_frag_high_disabled_warning" {
-  description = "Disable warning alerting rule for memory_frag_high detector"
+variable "memory_frag_high_disabled_major" {
+  description = "Disable major alerting rule for memory_frag_high detector"
   type        = bool
   default     = null
 }
@@ -382,8 +382,8 @@ variable "memory_frag_high_threshold_critical" {
   default     = 5
 }
 
-variable "memory_frag_high_threshold_warning" {
-  description = "Warning threshold for memory_frag_high detector"
+variable "memory_frag_high_threshold_major" {
+  description = "Major threshold for memory_frag_high detector"
   type        = number
   default     = 2
 }
@@ -402,8 +402,8 @@ variable "memory_frag_low_disabled_critical" {
   default     = null
 }
 
-variable "memory_frag_low_disabled_warning" {
-  description = "Disable warning alerting rule for memory_frag_low detector"
+variable "memory_frag_low_disabled_major" {
+  description = "Disable major alerting rule for memory_frag_low detector"
   type        = bool
   default     = null
 }
@@ -432,8 +432,8 @@ variable "memory_frag_low_threshold_critical" {
   default     = 0.75
 }
 
-variable "memory_frag_low_threshold_warning" {
-  description = "Warning threshold for memory_frag_low detector"
+variable "memory_frag_low_threshold_major" {
+  description = "Major threshold for memory_frag_low detector"
   type        = number
   default     = 1
 }
@@ -452,8 +452,8 @@ variable "rejected_connections_disabled_critical" {
   default     = null
 }
 
-variable "rejected_connections_disabled_warning" {
-  description = "Disable warning alerting rule for rejected_connections detector"
+variable "rejected_connections_disabled_major" {
+  description = "Disable major alerting rule for rejected_connections detector"
   type        = bool
   default     = null
 }
@@ -482,8 +482,8 @@ variable "rejected_connections_threshold_critical" {
   default     = 5
 }
 
-variable "rejected_connections_threshold_warning" {
-  description = "Warning threshold for rejected_connections detector"
+variable "rejected_connections_threshold_major" {
+  description = "Major threshold for rejected_connections detector"
   type        = number
   default     = 0
 }
@@ -502,8 +502,8 @@ variable "hitrate_disabled_critical" {
   default     = null
 }
 
-variable "hitrate_disabled_warning" {
-  description = "Disable warning alerting rule for hitrate detector"
+variable "hitrate_disabled_major" {
+  description = "Disable major alerting rule for hitrate detector"
   type        = bool
   default     = null
 }
@@ -532,8 +532,8 @@ variable "hitrate_threshold_critical" {
   default     = 10
 }
 
-variable "hitrate_threshold_warning" {
-  description = "Warning threshold for hitrate detector"
+variable "hitrate_threshold_major" {
+  description = "Major threshold for hitrate detector"
   type        = number
   default     = 30
 }

--- a/database/solr/detectors-solr.tf
+++ b/database/solr/detectors-solr.tf
@@ -24,7 +24,7 @@ resource "signalfx_detector" "errors" {
   program_text = <<-EOF
     signal = data('counter.solr.zookeeper_errors', ${module.filter-tags.filter_custom})${var.errors_aggregation_function}${var.errors_transformation_function}.publish('signal')
     detect(when(signal >= ${var.errors_threshold_critical})).publish('CRIT')
-    detect(when(signal >= ${var.errors_threshold_warning}) and when(signal <= ${var.errors_threshold_critical})).publish('WARN')
+    detect(when(signal >= ${var.errors_threshold_major}) and when(signal <= ${var.errors_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -37,11 +37,11 @@ EOF
   }
 
   rule {
-    description           = "is too high >= ${var.errors_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.errors_disabled_warning, var.errors_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.errors_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high >= ${var.errors_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.errors_disabled_major, var.errors_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.errors_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -52,7 +52,7 @@ resource "signalfx_detector" "searcher_warmup_time" {
   program_text = <<-EOF
     signal = data('gauge.solr.searcher_warmup', ${module.filter-tags.filter_custom})${var.searcher_warmup_time_aggregation_function}${var.searcher_warmup_time_transformation_function}.publish('signal')
     detect(when(signal >= ${var.searcher_warmup_time_threshold_critical})).publish('CRIT')
-    detect(when(signal >= ${var.searcher_warmup_time_threshold_warning}) and when(signal <= ${var.searcher_warmup_time_threshold_critical})).publish('WARN')
+    detect(when(signal >= ${var.searcher_warmup_time_threshold_major}) and when(signal <= ${var.searcher_warmup_time_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -65,11 +65,11 @@ EOF
   }
 
   rule {
-    description           = "is too high >= ${var.searcher_warmup_time_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.searcher_warmup_time_disabled_warning, var.searcher_warmup_time_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.searcher_warmup_time_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high >= ${var.searcher_warmup_time_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.searcher_warmup_time_disabled_major, var.searcher_warmup_time_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.searcher_warmup_time_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/database/solr/variables.tf
+++ b/database/solr/variables.tf
@@ -76,8 +76,8 @@ variable "errors_disabled_critical" {
   default     = null
 }
 
-variable "errors_disabled_warning" {
-  description = "Disable warning alerting rule for errors detector"
+variable "errors_disabled_major" {
+  description = "Disable major alerting rule for errors detector"
   type        = bool
   default     = null
 }
@@ -106,8 +106,8 @@ variable "errors_threshold_critical" {
   default     = 5
 }
 
-variable "errors_threshold_warning" {
-  description = "Warning threshold for errors detector"
+variable "errors_threshold_major" {
+  description = "Major threshold for errors detector"
   type        = number
   default     = 0
 }
@@ -126,8 +126,8 @@ variable "searcher_warmup_time_disabled_critical" {
   default     = null
 }
 
-variable "searcher_warmup_time_disabled_warning" {
-  description = "Disable warning alerting rule for searcher_warmup_time detector"
+variable "searcher_warmup_time_disabled_major" {
+  description = "Disable major alerting rule for searcher_warmup_time detector"
   type        = bool
   default     = null
 }
@@ -156,8 +156,8 @@ variable "searcher_warmup_time_threshold_critical" {
   default     = 5000
 }
 
-variable "searcher_warmup_time_threshold_warning" {
-  description = "Warning threshold for searcher_warmup_time detector"
+variable "searcher_warmup_time_threshold_major" {
+  description = "Major threshold for searcher_warmup_time detector"
   type        = number
   default     = 2000
 }

--- a/database/zookeeper/detectors-zookeeper.tf
+++ b/database/zookeeper/detectors-zookeeper.tf
@@ -42,7 +42,7 @@ resource "signalfx_detector" "zookeeper_latency" {
   program_text = <<-EOF
     signal = data('gauge.zk_avg_latency', filter=filter('plugin', 'zookeeper') and ${module.filter-tags.filter_custom})${var.zookeeper_latency_aggregation_function}${var.zookeeper_latency_transformation_function}.publish('signal')
     detect(when(signal > ${var.zookeeper_latency_threshold_critical})).publish('CRIT')
-    detect(when(signal > ${var.zookeeper_latency_threshold_warning}) and when(signal <= ${var.zookeeper_latency_threshold_critical})).publish('WARN')
+    detect(when(signal > ${var.zookeeper_latency_threshold_major}) and when(signal <= ${var.zookeeper_latency_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -55,11 +55,11 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.zookeeper_latency_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.zookeeper_latency_disabled_warning, var.zookeeper_latency_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.zookeeper_latency_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.zookeeper_latency_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.zookeeper_latency_disabled_major, var.zookeeper_latency_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.zookeeper_latency_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -72,7 +72,7 @@ resource "signalfx_detector" "file_descriptors" {
     B = data('gauge.zk_max_file_descriptor_count', filter=filter('plugin', 'zookeeper') and ${module.filter-tags.filter_custom}, rollup='average')${var.file_descriptors_aggregation_function}${var.file_descriptors_transformation_function}
     signal = (A/B).scale(100).publish('signal')
     detect(when(signal > ${var.file_descriptors_threshold_critical})).publish('CRIT')
-    detect(when(signal > ${var.file_descriptors_threshold_warning}) and when(signal <= ${var.file_descriptors_threshold_critical})).publish('WARN')
+    detect(when(signal > ${var.file_descriptors_threshold_major}) and when(signal <= ${var.file_descriptors_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -85,11 +85,11 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.file_descriptors_threshold_warning}%"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.file_descriptors_disabled_warning, var.file_descriptors_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.file_descriptors_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.file_descriptors_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.file_descriptors_disabled_major, var.file_descriptors_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.file_descriptors_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/database/zookeeper/variables.tf
+++ b/database/zookeeper/variables.tf
@@ -108,8 +108,8 @@ variable "zookeeper_latency_disabled_critical" {
   default     = null
 }
 
-variable "zookeeper_latency_disabled_warning" {
-  description = "Disable warning alerting rule for zookeeper_latency detector"
+variable "zookeeper_latency_disabled_major" {
+  description = "Disable major alerting rule for zookeeper_latency detector"
   type        = bool
   default     = null
 }
@@ -138,8 +138,8 @@ variable "zookeeper_latency_threshold_critical" {
   default     = 300000
 }
 
-variable "zookeeper_latency_threshold_warning" {
-  description = "Warning threshold for zookeeper_latency detector"
+variable "zookeeper_latency_threshold_major" {
+  description = "Major threshold for zookeeper_latency detector"
   type        = number
   default     = 250000
 }
@@ -158,8 +158,8 @@ variable "file_descriptors_disabled_critical" {
   default     = null
 }
 
-variable "file_descriptors_disabled_warning" {
-  description = "Disable warning alerting rule for file_descriptors detector"
+variable "file_descriptors_disabled_major" {
+  description = "Disable major alerting rule for file_descriptors detector"
   type        = bool
   default     = null
 }
@@ -188,8 +188,8 @@ variable "file_descriptors_threshold_critical" {
   default     = 95
 }
 
-variable "file_descriptors_threshold_warning" {
-  description = "Warning threshold for file_descriptors detector"
+variable "file_descriptors_threshold_major" {
+  description = "Major threshold for file_descriptors detector"
   type        = number
   default     = 90
 }

--- a/middleware/apache/detectors-apache.tf
+++ b/middleware/apache/detectors-apache.tf
@@ -26,7 +26,7 @@ resource "signalfx_detector" "apache_workers" {
     B = data('apache_idle_workers', ${module.filter-tags.filter_custom})${var.apache_workers_aggregation_function}${var.apache_workers_transformation_function}
     signal = ((A / (A+B)).scale(100)).publish('signal')
     detect(when(signal > ${var.apache_workers_threshold_critical})).publish('CRIT')
-    detect(when(signal > ${var.apache_workers_threshold_warning}) and when(signal <= ${var.apache_workers_threshold_critical})).publish('WARN')
+    detect(when(signal > ${var.apache_workers_threshold_major}) and when(signal <= ${var.apache_workers_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -39,11 +39,11 @@ EOF
   }
 
   rule {
-    description           = "are too high > ${var.apache_workers_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.apache_workers_disabled_warning, var.apache_workers_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.apache_workers_notifications, "warning", []), var.notifications.warning)
+    description           = "are too high > ${var.apache_workers_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.apache_workers_disabled_major, var.apache_workers_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.apache_workers_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/middleware/apache/variables.tf
+++ b/middleware/apache/variables.tf
@@ -76,8 +76,8 @@ variable "apache_workers_disabled_critical" {
   default     = null
 }
 
-variable "apache_workers_disabled_warning" {
-  description = "Disable warning alerting rule for apache_workers detector"
+variable "apache_workers_disabled_major" {
+  description = "Disable major alerting rule for apache_workers detector"
   type        = bool
   default     = null
 }
@@ -106,8 +106,8 @@ variable "apache_workers_threshold_critical" {
   default     = 90
 }
 
-variable "apache_workers_threshold_warning" {
-  description = "Warning threshold for apache_workers detector"
+variable "apache_workers_threshold_major" {
+  description = "Major threshold for apache_workers detector"
   type        = number
   default     = 80
 }

--- a/middleware/haproxy/detectors-haproxy.tf
+++ b/middleware/haproxy/detectors-haproxy.tf
@@ -62,7 +62,7 @@ resource "signalfx_detector" "session_limit" {
     B = data('haproxy_session_limit', filter=${module.filter-tags.filter_custom})${var.session_limit_aggregation_function}${var.session_limit_transformation_function}
     signal = (A/B).scale(100).publish('signal')
     detect(when(signal > ${var.session_limit_threshold_critical})).publish('CRIT')
-    detect(when(signal > ${var.session_limit_threshold_warning}) and when(signal <= ${var.session_limit_threshold_critical})).publish('WARN')
+    detect(when(signal > ${var.session_limit_threshold_major}) and when(signal <= ${var.session_limit_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -75,11 +75,11 @@ EOF
   }
 
   rule {
-    description           = "is approaching the limit > ${var.session_limit_threshold_warning}%"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.session_limit_disabled_warning, var.session_limit_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.session_limit_notifications, "warning", []), var.notifications.warning)
+    description           = "is approaching the limit > ${var.session_limit_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.session_limit_disabled_major, var.session_limit_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.session_limit_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -92,7 +92,7 @@ resource "signalfx_detector" "http_5xx_response" {
     B = data('haproxy_request_total', filter=${module.filter-tags.filter_custom}, rollup='delta')${var.http_5xx_response_aggregation_function}${var.http_5xx_response_transformation_function}
     signal = (A/B).scale(100).publish('signal')
     detect(when(signal > ${var.http_5xx_response_threshold_critical})).publish('CRIT')
-    detect(when(signal > ${var.http_5xx_response_threshold_warning}) and when(signal <= ${var.http_5xx_response_threshold_critical})).publish('WARN')
+    detect(when(signal > ${var.http_5xx_response_threshold_major}) and when(signal <= ${var.http_5xx_response_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -105,11 +105,11 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.http_5xx_response_threshold_warning}%"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.http_5xx_response_disabled_warning, var.http_5xx_response_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.http_5xx_response_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.http_5xx_response_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.http_5xx_response_disabled_major, var.http_5xx_response_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.http_5xx_response_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -122,7 +122,7 @@ resource "signalfx_detector" "http_4xx_response" {
     B = data('haproxy_request_total', filter=${module.filter-tags.filter_custom}, rollup='delta')${var.http_4xx_response_aggregation_function}${var.http_4xx_response_transformation_function}
     signal = (A/B).scale(100).publish('signal')
     detect(when(signal > ${var.http_4xx_response_threshold_critical})).publish('CRIT')
-    detect(when(signal > ${var.http_4xx_response_threshold_warning}) and when(signal <= ${var.http_4xx_response_threshold_critical})).publish('WARN')
+    detect(when(signal > ${var.http_4xx_response_threshold_major}) and when(signal <= ${var.http_4xx_response_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -135,11 +135,11 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.http_4xx_response_threshold_warning}%"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.http_4xx_response_disabled_warning, var.http_4xx_response_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.http_4xx_response_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.http_4xx_response_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.http_4xx_response_disabled_major, var.http_4xx_response_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.http_4xx_response_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/middleware/haproxy/variables.tf
+++ b/middleware/haproxy/variables.tf
@@ -128,8 +128,8 @@ variable "session_limit_disabled" {
   default     = null
 }
 
-variable "session_limit_disabled_warning" {
-  description = "Disable warning alerting rule for session limit detector"
+variable "session_limit_disabled_major" {
+  description = "Disable major alerting rule for session limit detector"
   type        = bool
   default     = null
 }
@@ -158,7 +158,7 @@ variable "session_limit_transformation_function" {
   default     = ".min(over='10m')"
 }
 
-variable "session_limit_threshold_warning" {
+variable "session_limit_threshold_major" {
   description = "Critical threshold for session limit detector"
   type        = number
   default     = 80
@@ -176,8 +176,8 @@ variable "http_5xx_response_disabled" {
   default     = null
 }
 
-variable "http_5xx_response_disabled_warning" {
-  description = "Disable warning alerting rule for http_5xx_response detector"
+variable "http_5xx_response_disabled_major" {
+  description = "Disable major alerting rule for http_5xx_response detector"
   type        = bool
   default     = null
 }
@@ -206,7 +206,7 @@ variable "http_5xx_response_transformation_function" {
   default     = ".min(over='10m')"
 }
 
-variable "http_5xx_response_threshold_warning" {
+variable "http_5xx_response_threshold_major" {
   description = "Critical threshold for http_5xx_response detector"
   type        = number
   default     = 50
@@ -224,8 +224,8 @@ variable "http_4xx_response_disabled" {
   default     = null
 }
 
-variable "http_4xx_response_disabled_warning" {
-  description = "Disable warning alerting rule for http_4xx_response detector"
+variable "http_4xx_response_disabled_major" {
+  description = "Disable major alerting rule for http_4xx_response detector"
   type        = bool
   default     = null
 }
@@ -254,7 +254,7 @@ variable "http_4xx_response_transformation_function" {
   default     = ".min(over='10m')"
 }
 
-variable "http_4xx_response_threshold_warning" {
+variable "http_4xx_response_threshold_major" {
   description = "Critical threshold for http_4xx_response detector"
   type        = number
   default     = 50

--- a/middleware/kong/detectors-kong.tf
+++ b/middleware/kong/detectors-kong.tf
@@ -26,7 +26,7 @@ resource "signalfx_detector" "treatment_limit" {
     B = data('kong_nginx_http_current_connections', filter=filter('state', 'accepted') and ${module.filter-tags.filter_custom})${var.treatment_limit_aggregation_function}${var.treatment_limit_transformation_function}
     signal = ((A-B)/A).scale(100).publish('signal')
     detect(when(signal > ${var.treatment_limit_threshold_critical})).publish('CRIT')
-    detect(when(signal > ${var.treatment_limit_threshold_warning}) and when(signal <= ${var.treatment_limit_threshold_critical})).publish('WARN')
+    detect(when(signal > ${var.treatment_limit_threshold_major}) and when(signal <= ${var.treatment_limit_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -39,11 +39,11 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.treatment_limit_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.treatment_limit_disabled_warning, var.treatment_limit_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.treatment_limit_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.treatment_limit_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.treatment_limit_disabled_major, var.treatment_limit_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.treatment_limit_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/middleware/kong/variables.tf
+++ b/middleware/kong/variables.tf
@@ -76,8 +76,8 @@ variable "treatment_limit_disabled_critical" {
   default     = null
 }
 
-variable "treatment_limit_disabled_warning" {
-  description = "Disable warning alerting rule for treatment limit detector"
+variable "treatment_limit_disabled_major" {
+  description = "Disable major alerting rule for treatment limit detector"
   type        = bool
   default     = null
 }
@@ -106,8 +106,8 @@ variable "treatment_limit_threshold_critical" {
   default     = 20
 }
 
-variable "treatment_limit_threshold_warning" {
-  description = "Warning threshold for treatment limit detector"
+variable "treatment_limit_threshold_major" {
+  description = "Major threshold for treatment limit detector"
   type        = number
   default     = 0
 }

--- a/middleware/nginx/detectors-nginx.tf
+++ b/middleware/nginx/detectors-nginx.tf
@@ -24,7 +24,7 @@ resource "signalfx_detector" "dropped_connections" {
   program_text = <<-EOF
     signal = data('connections.failed', filter=${module.filter-tags.filter_custom})${var.dropped_connections_aggregation_function}${var.dropped_connections_transformation_function}.publish('signal')
     detect(when(signal > ${var.dropped_connections_threshold_critical})).publish('CRIT')
-    detect(when(signal > ${var.dropped_connections_threshold_warning}) and when(signal <= ${var.dropped_connections_threshold_critical})).publish('WARN')
+    detect(when(signal > ${var.dropped_connections_threshold_major}) and when(signal <= ${var.dropped_connections_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -37,11 +37,11 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.dropped_connections_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.dropped_connections_disabled_warning, var.dropped_connections_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.dropped_connections_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.dropped_connections_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.dropped_connections_disabled_major, var.dropped_connections_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.dropped_connections_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/middleware/nginx/variables.tf
+++ b/middleware/nginx/variables.tf
@@ -74,8 +74,8 @@ variable "dropped_connections_disabled_critical" {
   default     = null
 }
 
-variable "dropped_connections_disabled_warning" {
-  description = "Disable warning alerting rule for dropped connections detector"
+variable "dropped_connections_disabled_major" {
+  description = "Disable major alerting rule for dropped connections detector"
   type        = bool
   default     = null
 }
@@ -104,8 +104,8 @@ variable "dropped_connections_threshold_critical" {
   default     = 1
 }
 
-variable "dropped_connections_threshold_warning" {
-  description = "Warning threshold for dropped connections detector"
+variable "dropped_connections_threshold_major" {
+  description = "Major threshold for dropped connections detector"
   type        = number
   default     = 0
 }

--- a/middleware/php-fpm/detectors-fpm.tf
+++ b/middleware/php-fpm/detectors-fpm.tf
@@ -26,7 +26,7 @@ resource "signalfx_detector" "php_fpm_connect_idle" {
     B = data('phpfpm_processes.idle', ${module.filter-tags.filter_custom})${var.php_fpm_connect_idle_aggregation_function}${var.php_fpm_connect_idle_transformation_function}
     signal = ((A / (A+B)).scale(100)).publish('signal')
     detect(when(signal > ${var.php_fpm_connect_idle_threshold_critical})).publish('CRIT')
-    detect(when(signal > ${var.php_fpm_connect_idle_threshold_warning}) and when(signal <= ${var.php_fpm_connect_idle_threshold_critical})).publish('WARN')
+    detect(when(signal > ${var.php_fpm_connect_idle_threshold_major}) and when(signal <= ${var.php_fpm_connect_idle_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -39,11 +39,11 @@ EOF
   }
 
   rule {
-    description           = "are too high > ${var.php_fpm_connect_idle_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.php_fpm_connect_idle_disabled_warning, var.php_fpm_connect_idle_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.php_fpm_connect_idle_notifications, "warning", []), var.notifications.warning)
+    description           = "are too high > ${var.php_fpm_connect_idle_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.php_fpm_connect_idle_disabled_major, var.php_fpm_connect_idle_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.php_fpm_connect_idle_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/middleware/php-fpm/variables.tf
+++ b/middleware/php-fpm/variables.tf
@@ -76,8 +76,8 @@ variable "php_fpm_connect_idle_disabled_critical" {
   default     = null
 }
 
-variable "php_fpm_connect_idle_disabled_warning" {
-  description = "Disable warning alerting rule for php_fpm_connect_idle detector"
+variable "php_fpm_connect_idle_disabled_major" {
+  description = "Disable major alerting rule for php_fpm_connect_idle detector"
   type        = bool
   default     = null
 }
@@ -106,8 +106,8 @@ variable "php_fpm_connect_idle_threshold_critical" {
   default     = 90
 }
 
-variable "php_fpm_connect_idle_threshold_warning" {
-  description = "Warning threshold for php_fpm_connect_idle detector"
+variable "php_fpm_connect_idle_threshold_major" {
+  description = "Major threshold for php_fpm_connect_idle detector"
   type        = number
   default     = 80
 }

--- a/middleware/rabbitmq/node/detectors-rabbitmq-node.tf
+++ b/middleware/rabbitmq/node/detectors-rabbitmq-node.tf
@@ -26,7 +26,7 @@ resource "signalfx_detector" "file_descriptors" {
     B = data('gauge.node.fd_total', filter=filter('plugin', 'rabbitmq') and ${module.filter-tags.filter_custom})${var.file_descriptors_aggregation_function}${var.file_descriptors_transformation_function}
     signal = (A/B).scale(100).publish('signal')
     detect(when(signal > ${var.file_descriptors_threshold_critical})).publish('CRIT')
-    detect(when(signal > ${var.file_descriptors_threshold_warning}) and when(signal <= ${var.file_descriptors_threshold_critical})).publish('WARN')
+    detect(when(signal > ${var.file_descriptors_threshold_major}) and when(signal <= ${var.file_descriptors_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -39,11 +39,11 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.file_descriptors_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.file_descriptors_disabled_warning, var.file_descriptors_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.file_descriptors_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.file_descriptors_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.file_descriptors_disabled_major, var.file_descriptors_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.file_descriptors_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -56,7 +56,7 @@ resource "signalfx_detector" "processes" {
     B = data('gauge.node.proc_total', filter=filter('plugin', 'rabbitmq') and ${module.filter-tags.filter_custom})${var.processes_aggregation_function}${var.processes_transformation_function}
     signal = (A/B).scale(100).publish('signal')
     detect(when(signal > ${var.processes_threshold_critical})).publish('CRIT')
-    detect(when(signal > ${var.processes_threshold_warning}) and when(signal <= ${var.processes_threshold_critical})).publish('WARN')
+    detect(when(signal > ${var.processes_threshold_major}) and when(signal <= ${var.processes_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -69,11 +69,11 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.processes_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.processes_disabled_warning, var.processes_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.processes_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.processes_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.processes_disabled_major, var.processes_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.processes_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -86,7 +86,7 @@ resource "signalfx_detector" "sockets" {
     B = data('gauge.node.sockets_total', filter=filter('plugin', 'rabbitmq') and ${module.filter-tags.filter_custom})${var.sockets_aggregation_function}${var.sockets_transformation_function}
     signal = (A/B).scale(100).publish('signal')
     detect(when(signal > ${var.sockets_threshold_critical})).publish('CRIT')
-    detect(when(signal > ${var.sockets_threshold_warning}) and when(signal < ${var.sockets_threshold_critical})).publish('WARN')
+    detect(when(signal > ${var.sockets_threshold_major}) and when(signal < ${var.sockets_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -99,11 +99,11 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.sockets_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.sockets_disabled_warning, var.sockets_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.sockets_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.sockets_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.sockets_disabled_major, var.sockets_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.sockets_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -116,7 +116,7 @@ resource "signalfx_detector" "vm_memory" {
     B = data('gauge.node.mem_limit', filter=filter('plugin', 'rabbitmq') and ${module.filter-tags.filter_custom})${var.vm_memory_aggregation_function}${var.vm_memory_transformation_function}
     signal = (A/B).scale(100).publish('signal')
     detect(when(signal > ${var.vm_memory_threshold_critical})).publish('CRIT')
-    detect(when(signal > ${var.vm_memory_threshold_warning}) and when(signal < ${var.vm_memory_threshold_critical})).publish('WARN')
+    detect(when(signal > ${var.vm_memory_threshold_major}) and when(signal < ${var.vm_memory_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -130,10 +130,10 @@ EOF
 
   rule {
     description           = "is approaching the limit"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.vm_memory_disabled_warning, var.vm_memory_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.vm_memory_notifications, "warning", []), var.notifications.warning)
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.vm_memory_disabled_major, var.vm_memory_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.vm_memory_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/middleware/rabbitmq/node/variables.tf
+++ b/middleware/rabbitmq/node/variables.tf
@@ -74,8 +74,8 @@ variable "file_descriptors_disabled_critical" {
   default     = null
 }
 
-variable "file_descriptors_disabled_warning" {
-  description = "Disable warning alerting rule for file descriptors detector"
+variable "file_descriptors_disabled_major" {
+  description = "Disable major alerting rule for file descriptors detector"
   type        = bool
   default     = null
 }
@@ -104,8 +104,8 @@ variable "file_descriptors_threshold_critical" {
   default     = 90
 }
 
-variable "file_descriptors_threshold_warning" {
-  description = "Warning threshold for file descriptors detector"
+variable "file_descriptors_threshold_major" {
+  description = "Major threshold for file descriptors detector"
   type        = number
   default     = 80
 }
@@ -122,8 +122,8 @@ variable "processes_disabled_critical" {
   default     = null
 }
 
-variable "processes_disabled_warning" {
-  description = "Disable warning alerting rule for processes detector"
+variable "processes_disabled_major" {
+  description = "Disable major alerting rule for processes detector"
   type        = bool
   default     = null
 }
@@ -152,8 +152,8 @@ variable "processes_threshold_critical" {
   default     = 90
 }
 
-variable "processes_threshold_warning" {
-  description = "Warning threshold for processes detector"
+variable "processes_threshold_major" {
+  description = "Major threshold for processes detector"
   type        = number
   default     = 80
 }
@@ -170,8 +170,8 @@ variable "sockets_disabled_critical" {
   default     = null
 }
 
-variable "sockets_disabled_warning" {
-  description = "Disable warning alerting rule for sockets detector"
+variable "sockets_disabled_major" {
+  description = "Disable major alerting rule for sockets detector"
   type        = bool
   default     = null
 }
@@ -200,8 +200,8 @@ variable "sockets_threshold_critical" {
   default     = 90
 }
 
-variable "sockets_threshold_warning" {
-  description = "Warning threshold for sockets detector"
+variable "sockets_threshold_major" {
+  description = "Major threshold for sockets detector"
   type        = number
   default     = 80
 }
@@ -218,8 +218,8 @@ variable "vm_memory_disabled_critical" {
   default     = null
 }
 
-variable "vm_memory_disabled_warning" {
-  description = "Disable warning alerting rule for vm_memory detector"
+variable "vm_memory_disabled_major" {
+  description = "Disable major alerting rule for vm_memory detector"
   type        = bool
   default     = null
 }
@@ -248,8 +248,8 @@ variable "vm_memory_threshold_critical" {
   default     = 90
 }
 
-variable "vm_memory_threshold_warning" {
-  description = "Warning threshold for vm_memory detector"
+variable "vm_memory_threshold_major" {
+  description = "Major threshold for vm_memory detector"
   type        = number
   default     = 80
 }

--- a/middleware/rabbitmq/queue/detectors-rabbitmq-queue.tf
+++ b/middleware/rabbitmq/queue/detectors-rabbitmq-queue.tf
@@ -4,7 +4,7 @@ resource "signalfx_detector" "messages_ready" {
   program_text = <<-EOF
     signal = data('gauge.queue.messages_ready', filter=filter('plugin', 'rabbitmq') and ${module.filter-tags.filter_custom})${var.messages_ready_aggregation_function}${var.messages_ready_transformation_function}.publish('signal')
     detect(when(signal > ${var.messages_ready_threshold_critical})).publish('CRIT')
-    detect(when(signal > ${var.messages_ready_threshold_warning}) and when(signal <= ${var.messages_ready_threshold_critical})).publish('WARN')
+    detect(when(signal > ${var.messages_ready_threshold_major}) and when(signal <= ${var.messages_ready_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -17,11 +17,11 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.messages_ready_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.messages_ready_disabled_warning, var.messages_ready_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.messages_ready_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.messages_ready_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.messages_ready_disabled_major, var.messages_ready_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.messages_ready_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -32,7 +32,7 @@ resource "signalfx_detector" "messages_unacknowledged" {
   program_text = <<-EOF
     signal = data('gauge.queue.messages_unacknowledged', filter=filter('plugin', 'rabbitmq') and ${module.filter-tags.filter_custom})${var.messages_unacknowledged_aggregation_function}${var.messages_unacknowledged_transformation_function}.publish('signal')
     detect(when(signal > ${var.messages_unacknowledged_threshold_critical})).publish('CRIT')
-    detect(when(signal > ${var.messages_unacknowledged_threshold_warning}) and when(signal <= ${var.messages_unacknowledged_threshold_critical})).publish('WARN')
+    detect(when(signal > ${var.messages_unacknowledged_threshold_major}) and when(signal <= ${var.messages_unacknowledged_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -46,10 +46,10 @@ EOF
 
   rule {
     description           = "is too high"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.messages_unacknowledged_disabled_warning, var.messages_unacknowledged_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.messages_unacknowledged_notifications, "warning", []), var.notifications.warning)
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.messages_unacknowledged_disabled_major, var.messages_unacknowledged_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.messages_unacknowledged_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -61,7 +61,7 @@ resource "signalfx_detector" "messages_ack_rate" {
     signal = data('counter.queue.message_stats.ack', filter=filter('plugin', 'rabbitmq') and ${module.filter-tags.filter_custom})${var.messages_ack_rate_aggregation_function}.publish('signal')
     msg = data('gauge.queue.messages', filter=filter('plugin', 'rabbitmq') and ${module.filter-tags.filter_custom})${var.messages_ack_rate_aggregation_function}
     detect((when((signal >= 0) and (signal <= threshold(${var.messages_ack_rate_threshold_critical}) and (msg > 0)), lasting='${var.messages_ack_rate_lasting_duration_seconds}s', at_least=${var.messages_ack_rate_at_least_percentage}))).publish('CRIT')
-    detect((when((signal >= ${var.messages_ack_rate_threshold_critical}) and (signal <= threshold(${var.messages_ack_rate_threshold_warning}) and (msg > 0)), lasting='${var.messages_ack_rate_lasting_duration_seconds}s', at_least=${var.messages_ack_rate_at_least_percentage}))).publish('WARN')
+    detect((when((signal >= ${var.messages_ack_rate_threshold_critical}) and (signal <= threshold(${var.messages_ack_rate_threshold_major}) and (msg > 0)), lasting='${var.messages_ack_rate_lasting_duration_seconds}s', at_least=${var.messages_ack_rate_at_least_percentage}))).publish('MAJOR')
 EOF
 
   rule {
@@ -74,11 +74,11 @@ EOF
   }
 
   rule {
-    description           = format("is too low < %s and there are ready or unack messages", var.messages_ack_rate_threshold_warning)
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.messages_ack_rate_disabled_warning, var.messages_ack_rate_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.messages_ack_rate_notifications, "warning", []), var.notifications.warning)
+    description           = format("is too low < %s and there are ready or unack messages", var.messages_ack_rate_threshold_major)
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.messages_ack_rate_disabled_major, var.messages_ack_rate_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.messages_ack_rate_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -90,7 +90,7 @@ resource "signalfx_detector" "consumer_use" {
     signal = data('gauge.queue.consumer_use', filter=filter('plugin', 'rabbitmq') and ${module.filter-tags.filter_custom})${var.consumer_use_aggregation_function}.publish('util')
     msg = data('gauge.queue.messages', filter=filter('plugin', 'rabbitmq') and ${module.filter-tags.filter_custom})${var.consumer_use_aggregation_function}
     detect((when((signal < threshold(${var.consumer_use_threshold_critical}) and (msg > 0)), lasting='${var.consumer_use_lasting_duration_seconds}s', at_least=${var.consumer_use_at_least_percentage}))).publish('CRIT')
-    detect((when((signal < threshold(${var.consumer_use_threshold_warning}) and (msg > 0)), lasting='${var.consumer_use_lasting_duration_seconds}s', at_least=${var.consumer_use_at_least_percentage}))).publish('WARN')
+    detect((when((signal < threshold(${var.consumer_use_threshold_major}) and (msg > 0)), lasting='${var.consumer_use_lasting_duration_seconds}s', at_least=${var.consumer_use_at_least_percentage}))).publish('MAJOR')
 EOF
 
   rule {
@@ -103,11 +103,11 @@ EOF
   }
 
   rule {
-    description           = format("is too low < %s, consumers seems too slow", var.consumer_use_threshold_warning)
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.consumer_use_disabled_warning, var.consumer_use_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.consumer_use_notifications, "warning", []), var.notifications.warning)
+    description           = format("is too low < %s, consumers seems too slow", var.consumer_use_threshold_major)
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.consumer_use_disabled_major, var.consumer_use_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.consumer_use_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/middleware/rabbitmq/queue/variables.tf
+++ b/middleware/rabbitmq/queue/variables.tf
@@ -56,8 +56,8 @@ variable "messages_ready_disabled_critical" {
   default     = null
 }
 
-variable "messages_ready_disabled_warning" {
-  description = "Disable warning alerting rule for messages_ready detector"
+variable "messages_ready_disabled_major" {
+  description = "Disable major alerting rule for messages_ready detector"
   type        = bool
   default     = null
 }
@@ -80,8 +80,8 @@ variable "messages_ready_transformation_function" {
   default     = ".min(over='20m')"
 }
 
-variable "messages_ready_threshold_warning" {
-  description = "Warning threshold for messages ready detector."
+variable "messages_ready_threshold_major" {
+  description = "Major threshold for messages ready detector."
   type        = number
   default     = 10000
 }
@@ -104,8 +104,8 @@ variable "messages_unacknowledged_disabled_critical" {
   default     = null
 }
 
-variable "messages_unacknowledged_disabled_warning" {
-  description = "Disable warning alerting rule for messages_unacknowledged detector"
+variable "messages_unacknowledged_disabled_major" {
+  description = "Disable major alerting rule for messages_unacknowledged detector"
   type        = bool
   default     = null
 }
@@ -128,8 +128,8 @@ variable "messages_unacknowledged_transformation_function" {
   default     = ".min(over='20m')"
 }
 
-variable "messages_unacknowledged_threshold_warning" {
-  description = "Warning threshold for messages unacknowledged detector."
+variable "messages_unacknowledged_threshold_major" {
+  description = "Major threshold for messages unacknowledged detector."
   type        = number
   default     = 10000
 }
@@ -152,8 +152,8 @@ variable "messages_ack_rate_disabled_critical" {
   default     = null
 }
 
-variable "messages_ack_rate_disabled_warning" {
-  description = "Disable warning alerting rule for messages_ack_rate detector"
+variable "messages_ack_rate_disabled_major" {
+  description = "Disable major alerting rule for messages_ack_rate detector"
   type        = bool
   default     = null
 }
@@ -182,8 +182,8 @@ variable "messages_ack_rate_at_least_percentage" {
   default     = 0.9
 }
 
-variable "messages_ack_rate_threshold_warning" {
-  description = "Warning threshold for messages ack rate detector. Specify it as a string with a rate, 2/60 means 2 ack per minute."
+variable "messages_ack_rate_threshold_major" {
+  description = "Major threshold for messages ack rate detector. Specify it as a string with a rate, 2/60 means 2 ack per minute."
   type        = string
   default     = "2/60"
 }
@@ -206,8 +206,8 @@ variable "consumer_use_disabled_critical" {
   default     = null
 }
 
-variable "consumer_use_disabled_warning" {
-  description = "Disable warning alerting rule for consumer_use detector"
+variable "consumer_use_disabled_major" {
+  description = "Disable major alerting rule for consumer_use detector"
   type        = bool
   default     = null
 }
@@ -236,8 +236,8 @@ variable "consumer_use_at_least_percentage" {
   default     = 0.9
 }
 
-variable "consumer_use_threshold_warning" {
-  description = "Warning threshold for consumer use detector."
+variable "consumer_use_threshold_major" {
+  description = "Major threshold for consumer use detector."
   type        = number
   default     = 1.0
 }

--- a/middleware/supervisor/detectors-supervisor.tf
+++ b/middleware/supervisor/detectors-supervisor.tf
@@ -24,7 +24,7 @@ resource "signalfx_detector" "process_state" {
   program_text = <<-EOF
     signal = data('supervisor.state', filter=${module.filter-tags.filter_custom})${var.process_state_aggregation_function}${var.process_state_transformation_function}.publish('signal')
     detect(when(signal > ${var.process_state_threshold_critical})).publish('CRIT')
-    detect(when(signal < ${var.process_state_threshold_warning})).publish('WARN')
+    detect(when(signal < ${var.process_state_threshold_major})).publish('MAJOR')
 EOF
 
   rule {
@@ -38,10 +38,10 @@ EOF
 
   rule {
     description           = "is stopped"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.process_state_disabled_warning, var.process_state_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.process_state_notifications, "warning", []), var.notifications.warning)
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.process_state_disabled_major, var.process_state_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.process_state_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/middleware/supervisor/variables.tf
+++ b/middleware/supervisor/variables.tf
@@ -74,8 +74,8 @@ variable "process_state_disabled_critical" {
   default     = null
 }
 
-variable "process_state_disabled_warning" {
-  description = "Disable warning alerting rule for process state detector"
+variable "process_state_disabled_major" {
+  description = "Disable major alerting rule for process state detector"
   type        = bool
   default     = null
 }
@@ -104,8 +104,8 @@ variable "process_state_threshold_critical" {
   default     = 20
 }
 
-variable "process_state_threshold_warning" {
-  description = "Warning threshold for process state detector (default to be less then 20 (process has been stopped manually or is starting), see http://supervisord.org/subprocess.html#process-states "
+variable "process_state_threshold_major" {
+  description = "Major threshold for process state detector (default to be less then 20 (process has been stopped manually or is starting), see http://supervisord.org/subprocess.html#process-states "
   type        = number
   default     = 20
 }

--- a/middleware/varnish/detectors-varnish.tf
+++ b/middleware/varnish/detectors-varnish.tf
@@ -63,24 +63,24 @@ resource "signalfx_detector" "varnish_cache_hit_rate" {
     A = data('varnish.cache_hit', filter=filter('plugin', 'telegraf/varnish') and ${module.filter-tags.filter_custom})${var.varnish_cache_hit_rate_aggregation_function}${var.varnish_cache_hit_rate_transformation_function}.publish('A')
     B = data('varnish.cache_miss', filter=filter('plugin', 'telegraf/varnish') and ${module.filter-tags.filter_custom})${var.varnish_cache_hit_rate_aggregation_function}${var.varnish_cache_hit_rate_transformation_function}.publish('B')
     signal = ((A/(A+B)).fill(0).scale(100)).publish('signal')
-    detect(when(signal < ${var.varnish_cache_hit_rate_threshold_major})).publish('MAJOR')
-    detect(when(signal < ${var.varnish_cache_hit_rate_threshold_warning}) and (signal > ${var.varnish_cache_hit_rate_threshold_major})).publish('WARN')
+    detect(when(signal < ${var.varnish_cache_hit_rate_threshold_minor})).publish('MINOR')
+    detect(when(signal < ${var.varnish_cache_hit_rate_threshold_major}) and (signal > ${var.varnish_cache_hit_rate_threshold_minor})).publish('MAJOR')
 EOF
 
-  rule {
-    description           = "is too low > ${var.varnish_cache_hit_rate_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.varnish_cache_hit_rate_disabled_warning, var.varnish_cache_hit_rate_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.varnish_cache_hit_rate_notifications, "warning", []), var.notifications.warning)
-    parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
-  }
   rule {
     description           = "is too low > ${var.varnish_cache_hit_rate_threshold_major}"
     severity              = "Major"
     detect_label          = "MAJOR"
     disabled              = coalesce(var.varnish_cache_hit_rate_disabled_major, var.varnish_cache_hit_rate_disabled, var.detectors_disabled)
     notifications         = coalescelist(lookup(var.varnish_cache_hit_rate_notifications, "major", []), var.notifications.major)
+    parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
+  }
+  rule {
+    description           = "is too low > ${var.varnish_cache_hit_rate_threshold_minor}"
+    severity              = "Minor"
+    detect_label          = "MINOR"
+    disabled              = coalesce(var.varnish_cache_hit_rate_disabled_minor, var.varnish_cache_hit_rate_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.varnish_cache_hit_rate_notifications, "minor", []), var.notifications.minor)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
 }
@@ -94,11 +94,11 @@ resource "signalfx_detector" "varnish_memory_usage" {
     B = data('varnish.s0.g_space', filter=filter('plugin', 'telegraf/varnish') and ${module.filter-tags.filter_custom})${var.varnish_memory_usage_aggregation_function}${var.varnish_memory_usage_transformation_function}
     signal = (A / (A+B)).scale(100).fill(0).publish('signal')
     detect(when(signal > ${var.varnish_memory_usage_threshold_critical})).publish('CRIT')
-    detect(when(signal > ${var.varnish_memory_usage_threshold_warning}) and (signal < ${var.varnish_memory_usage_threshold_critical})).publish('WARN')
+    detect(when(signal > ${var.varnish_memory_usage_threshold_major}) and (signal < ${var.varnish_memory_usage_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
-    description           = "is too low > ${var.varnish_memory_usage_threshold_warning}"
+    description           = "is too low > ${var.varnish_memory_usage_threshold_major}"
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.varnish_memory_usage_disabled_critical, var.varnish_memory_usage_disabled, var.detectors_disabled)
@@ -106,11 +106,11 @@ EOF
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
   rule {
-    description           = "is too low > ${var.varnish_memory_usage_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.varnish_memory_usage_disabled_warning, var.varnish_memory_usage_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.varnish_memory_usage_notifications, "warning", []), var.notifications.warning)
+    description           = "is too low > ${var.varnish_memory_usage_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.varnish_memory_usage_disabled_major, var.varnish_memory_usage_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.varnish_memory_usage_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
 }

--- a/middleware/varnish/variables.tf
+++ b/middleware/varnish/variables.tf
@@ -81,14 +81,14 @@ variable "varnish_cache_hit_rate_disabled" {
   default     = null
 }
 
-variable "varnish_cache_hit_rate_disabled_warning" {
-  description = "Disable warning alerting rule for cache_hit_rate detector"
+variable "varnish_cache_hit_rate_disabled_major" {
+  description = "Disable major alerting rule for cache_hit_rate detector"
   type        = bool
   default     = null
 }
 
-variable "varnish_cache_hit_rate_disabled_major" {
-  description = "Disable major alerting rule for cache_hit_rate detector"
+variable "varnish_cache_hit_rate_disabled_minor" {
+  description = "Disable minor alerting rule for cache_hit_rate detector"
   type        = bool
   default     = null
 }
@@ -111,8 +111,8 @@ variable "varnish_memory_usage_disabled_critical" {
   default     = null
 }
 
-variable "varnish_memory_usage_disabled_warning" {
-  description = "Disable warning alerting rule for memory_usage detector"
+variable "varnish_memory_usage_disabled_major" {
+  description = "Disable major alerting rule for memory_usage detector"
   type        = bool
   default     = null
 }
@@ -199,14 +199,14 @@ variable "varnish_session_dropped_threshold_critical" {
   default     = 0
 }
 
-variable "varnish_cache_hit_rate_threshold_major" {
-  description = "Varnish cache hit rate threshold major"
+variable "varnish_cache_hit_rate_threshold_minor" {
+  description = "Varnish cache hit rate threshold minor"
   type        = number
   default     = 90
 }
 
-variable "varnish_cache_hit_rate_threshold_warning" {
-  description = "Varnish cache hit rate threshold warning"
+variable "varnish_cache_hit_rate_threshold_major" {
+  description = "Varnish cache hit rate threshold major"
   type        = number
   default     = 80
 }
@@ -217,8 +217,8 @@ variable "varnish_threads_threshold_critical" {
   default     = 1
 }
 
-variable "varnish_memory_usage_threshold_warning" {
-  description = "Varnish memory usage threshold warning"
+variable "varnish_memory_usage_threshold_major" {
+  description = "Varnish memory usage threshold major"
   type        = number
   default     = 80
 }

--- a/network/dns/detectors-dns.tf
+++ b/network/dns/detectors-dns.tf
@@ -24,7 +24,7 @@ resource "signalfx_detector" "dns_query_time" {
   program_text = <<-EOF
     signal = data('dns.query_time_ms', filter=filter('plugin', 'telegraf/dns') and ${module.filter-tags.filter_custom})${var.dns_query_time_aggregation_function}${var.dns_query_time_transformation_function}.publish('signal')
     detect(when(signal > ${var.dns_query_time_threshold_critical})).publish('CRIT')
-    detect(when(signal > ${var.dns_query_time_threshold_warning}) and when(signal <= ${var.dns_query_time_threshold_critical})).publish('WARN')
+    detect(when(signal > ${var.dns_query_time_threshold_major}) and when(signal <= ${var.dns_query_time_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -37,11 +37,11 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.dns_query_time_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.dns_query_time_disabled_warning, var.dns_query_time_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.dns_query_time_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.dns_query_time_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.dns_query_time_disabled_major, var.dns_query_time_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.dns_query_time_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/network/dns/variables.tf
+++ b/network/dns/variables.tf
@@ -76,8 +76,8 @@ variable "dns_query_time_disabled_critical" {
   default     = null
 }
 
-variable "dns_query_time_disabled_warning" {
-  description = "Disable warning alerting rule for dns_query_time detector"
+variable "dns_query_time_disabled_major" {
+  description = "Disable major alerting rule for dns_query_time detector"
   type        = bool
   default     = null
 }
@@ -106,8 +106,8 @@ variable "dns_query_time_threshold_critical" {
   default     = 1000
 }
 
-variable "dns_query_time_threshold_warning" {
-  description = "Warning threshold for dns_query_time detector"
+variable "dns_query_time_threshold_major" {
+  description = "Major threshold for dns_query_time detector"
   type        = number
   default     = 500
 }

--- a/network/http/detectors-http.tf
+++ b/network/http/detectors-http.tf
@@ -62,7 +62,7 @@ resource "signalfx_detector" "http_response_time" {
   program_text = <<-EOF
     signal = data('http.response_time', ${module.filter-tags.filter_custom})${var.http_response_time_aggregation_function}${var.http_response_time_transformation_function}.publish('signal')
     detect(when(signal > ${var.http_response_time_threshold_critical})).publish('CRIT')
-    detect(when(signal > ${var.http_response_time_threshold_warning}) and when(signal <= ${var.http_response_time_threshold_critical})).publish('WARN')
+    detect(when(signal > ${var.http_response_time_threshold_major}) and when(signal <= ${var.http_response_time_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -75,11 +75,11 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.http_response_time_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.http_response_time_disabled_warning, var.http_response_time_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.http_response_time_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.http_response_time_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.http_response_time_disabled_major, var.http_response_time_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.http_response_time_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -89,15 +89,15 @@ resource "signalfx_detector" "http_content_length" {
 
   program_text = <<-EOF
     signal = data('http.content_length', ${module.filter-tags.filter_custom})${var.http_content_length_aggregation_function}${var.http_content_length_transformation_function}.publish('signal')
-    detect(when(signal < ${var.http_content_length_threshold_warning})).publish('WARN')
+    detect(when(signal < ${var.http_content_length_threshold_major})).publish('MAJOR')
 EOF
 
   rule {
-    description           = "is too low < ${var.http_content_length_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
+    description           = "is too low < ${var.http_content_length_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
     disabled              = coalesce(var.http_content_length_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.http_content_length_notifications, "warning", []), var.notifications.warning)
+    notifications         = coalescelist(lookup(var.http_content_length_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -109,7 +109,7 @@ resource "signalfx_detector" "certificate_expiration_date" {
     A = data('http.cert_expiry', ${module.filter-tags.filter_custom})${var.certificate_expiration_date_aggregation_function}${var.certificate_expiration_date_transformation_function}
     signal = (A/86400).publish('signal')
     detect(when(signal < ${var.certificate_expiration_date_threshold_critical})).publish('CRIT')
-    detect(when(signal < ${var.certificate_expiration_date_threshold_warning}) and when(signal >= ${var.certificate_expiration_date_threshold_critical})).publish('WARN')
+    detect(when(signal < ${var.certificate_expiration_date_threshold_major}) and when(signal >= ${var.certificate_expiration_date_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -122,11 +122,11 @@ EOF
   }
 
   rule {
-    description           = " < ${var.certificate_expiration_date_threshold_warning} days"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.certificate_expiration_date_disabled_warning, var.certificate_expiration_date_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.certificate_expiration_date_notifications, "warning", []), var.notifications.warning)
+    description           = " < ${var.certificate_expiration_date_threshold_major} days"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.certificate_expiration_date_disabled_major, var.certificate_expiration_date_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.certificate_expiration_date_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/network/http/variables.tf
+++ b/network/http/variables.tf
@@ -140,8 +140,8 @@ variable "http_response_time_disabled_critical" {
   default     = null
 }
 
-variable "http_response_time_disabled_warning" {
-  description = "Disable warning alerting rule for http_response_time detector"
+variable "http_response_time_disabled_major" {
+  description = "Disable major alerting rule for http_response_time detector"
   type        = bool
   default     = null
 }
@@ -170,8 +170,8 @@ variable "http_response_time_threshold_critical" {
   default     = 2
 }
 
-variable "http_response_time_threshold_warning" {
-  description = "Warning threshold for http_response_time detector"
+variable "http_response_time_threshold_major" {
+  description = "Major threshold for http_response_time detector"
   type        = number
   default     = 1
 }
@@ -202,7 +202,7 @@ variable "http_content_length_transformation_function" {
   default     = ".max(over='15m')"
 }
 
-variable "http_content_length_threshold_warning" {
+variable "http_content_length_threshold_major" {
   description = "Critical threshold for http_content_length detector"
   type        = number
   default     = 10
@@ -222,8 +222,8 @@ variable "certificate_expiration_date_disabled_critical" {
   default     = null
 }
 
-variable "certificate_expiration_date_disabled_warning" {
-  description = "Disable warning alerting rule for certificate_expiration_date detector"
+variable "certificate_expiration_date_disabled_major" {
+  description = "Disable major alerting rule for certificate_expiration_date detector"
   type        = bool
   default     = null
 }
@@ -252,8 +252,8 @@ variable "certificate_expiration_date_threshold_critical" {
   default     = 15
 }
 
-variable "certificate_expiration_date_threshold_warning" {
-  description = "Warning threshold for certificate_expiration_date detector"
+variable "certificate_expiration_date_threshold_major" {
+  description = "Major threshold for certificate_expiration_date detector"
   type        = number
   default     = 30
 }

--- a/organization/usage/detectors-usage.tf
+++ b/organization/usage/detectors-usage.tf
@@ -4,15 +4,15 @@ resource "signalfx_detector" "hosts_limit" {
   program_text = <<-EOF
     signal = data('${"sf.org.${var.is_parent ? "child." : ""}numResourcesMonitored"}', filter=filter('resourceType', 'host'))${local.aggregation_function}${var.hosts_limit_transformation_function}.publish('signal')
     limit = data('${"sf.org.${var.is_parent ? "child." : ""}subscription.hosts"}')${local.aggregation_function}${var.hosts_limit_transformation_function}
-    detect(when(signal > threshold(limit))).publish('WARN')
+    detect(when(signal > threshold(limit))).publish('MAJOR')
 EOF
 
   rule {
     description           = "is exceeded"
-    severity              = "Warning"
-    detect_label          = "WARN"
+    severity              = "Major"
+    detect_label          = "MAJOR"
     disabled              = coalesce(var.hosts_limit_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.hosts_limit_notifications, "warning", []), var.notifications.warning)
+    notifications         = coalescelist(lookup(var.hosts_limit_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}} > {{inputs.limit.value}}) on {{{dimensions}}}"
     parameterized_body    = local.parameterized_body
     runbook_url           = var.runbook_url
@@ -28,15 +28,15 @@ resource "signalfx_detector" "containers_limit" {
   program_text = <<-EOF
     signal = data('${"sf.org.${var.is_parent ? "child." : ""}numResourcesMonitored"}', filter=filter('resourceType', 'container'))${local.aggregation_function}${var.containers_limit_transformation_function}.publish('signal')
     limit = data('${"sf.org.${var.is_parent ? "child." : ""}subscription.containers"}')${local.aggregation_function}${var.containers_limit_transformation_function}
-    detect(when(signal > threshold(limit))).publish('WARN')
+    detect(when(signal > threshold(limit))).publish('MAJOR')
 EOF
 
   rule {
     description           = "is exceeded"
-    severity              = "Warning"
-    detect_label          = "WARN"
+    severity              = "Major"
+    detect_label          = "MAJOR"
     disabled              = coalesce(var.containers_limit_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.containers_limit_notifications, "warning", []), var.notifications.warning)
+    notifications         = coalescelist(lookup(var.containers_limit_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}} > {{inputs.limit.value}}) on {{{dimensions}}}"
     parameterized_body    = local.parameterized_body
     runbook_url           = var.runbook_url
@@ -52,15 +52,15 @@ resource "signalfx_detector" "custom_metrics_limit" {
   program_text = <<-EOF
     signal = data('${"sf.org.${var.is_parent ? "child." : ""}numCustomMetrics"}')${local.aggregation_function}${var.custom_metrics_limit_transformation_function}.publish('signal')
     limit = data('${"sf.org.${var.is_parent ? "child." : ""}subscription.customMetrics"}')${local.aggregation_function}${var.custom_metrics_limit_transformation_function}
-    detect(when(signal > threshold(limit))).publish('WARN')
+    detect(when(signal > threshold(limit))).publish('MAJOR')
 EOF
 
   rule {
     description           = "is exceeded"
-    severity              = "Warning"
-    detect_label          = "WARN"
+    severity              = "Major"
+    detect_label          = "MAJOR"
     disabled              = coalesce(var.custom_metrics_limit_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.custom_metrics_limit_notifications, "warning", []), var.notifications.warning)
+    notifications         = coalescelist(lookup(var.custom_metrics_limit_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}} > {{inputs.limit.value}}) on {{{dimensions}}}"
     parameterized_body    = local.parameterized_body
     runbook_url           = var.runbook_url
@@ -77,15 +77,15 @@ resource "signalfx_detector" "containers_ratio" {
     containers = data('${"sf.org.${var.is_parent ? "child." : ""}numResourcesMonitored"}', filter=filter('resourceType', 'container'))${local.aggregation_function}${var.containers_ratio_transformation_function}
     hosts = data('${"sf.org.${var.is_parent ? "child." : ""}numResourcesMonitored"}', filter=filter('resourceType', 'host'))${local.aggregation_function}${var.containers_ratio_transformation_function}
     signal = (containers / (hosts*${var.multiplier}0)).scale(100).fill(value=0).publish('signal')
-    detect(when(signal > threshold(${var.containers_ratio_threshold_warning}))).publish('WARN')
+    detect(when(signal > threshold(${var.containers_ratio_threshold_major}))).publish('MAJOR')
 EOF
 
   rule {
-    description           = "is exceeded > ${var.containers_ratio_threshold_warning}%"
-    severity              = "Warning"
-    detect_label          = "WARN"
+    description           = "is exceeded > ${var.containers_ratio_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
     disabled              = coalesce(var.containers_ratio_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.containers_ratio_notifications, "warning", []), var.notifications.warning)
+    notifications         = coalescelist(lookup(var.containers_ratio_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
     parameterized_body    = local.parameterized_body
     runbook_url           = var.runbook_url
@@ -104,15 +104,15 @@ resource "signalfx_detector" "custom_metrics_ratio" {
     custom_metrics = data('${"sf.org.${var.is_parent ? "child." : ""}numCustomMetrics"}')${local.aggregation_function}${var.custom_metrics_ratio_transformation_function}
     hosts = data('${"sf.org.${var.is_parent ? "child." : ""}numResourcesMonitored"}', filter=filter('resourceType', 'host'))${local.aggregation_function}${var.custom_metrics_ratio_transformation_function}
     signal = (custom_metrics / (hosts*${var.multiplier}00)).scale(100).fill(value=0).publish('signal')
-    detect(when(signal > threshold(${var.custom_metrics_ratio_threshold_warning}))).publish('WARN')
+    detect(when(signal > threshold(${var.custom_metrics_ratio_threshold_major}))).publish('MAJOR')
 EOF
 
   rule {
-    description           = "is exceeded > ${var.custom_metrics_ratio_threshold_warning}%"
-    severity              = "Warning"
-    detect_label          = "WARN"
+    description           = "is exceeded > ${var.custom_metrics_ratio_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
     disabled              = coalesce(var.custom_metrics_ratio_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.custom_metrics_ratio_notifications, "warning", []), var.notifications.warning)
+    notifications         = coalescelist(lookup(var.custom_metrics_ratio_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
     parameterized_body    = local.parameterized_body
     runbook_url           = var.runbook_url

--- a/organization/usage/variables.tf
+++ b/organization/usage/variables.tf
@@ -131,8 +131,8 @@ variable "containers_ratio_transformation_function" {
   default     = ".mean(over='4w')"
 }
 
-variable "containers_ratio_threshold_warning" {
-  description = "Warning threshold for containers_ratio detector"
+variable "containers_ratio_threshold_major" {
+  description = "Major threshold for containers_ratio detector"
   type        = number
   default     = 100
 }
@@ -157,8 +157,8 @@ variable "custom_metrics_ratio_transformation_function" {
   default     = ".mean(over='4w')"
 }
 
-variable "custom_metrics_ratio_threshold_warning" {
-  description = "Warning threshold for custom_metrics_ratio detector"
+variable "custom_metrics_ratio_threshold_major" {
+  description = "Major threshold for custom_metrics_ratio detector"
   type        = number
   default     = 100
 }

--- a/saas/new-relic/detectors-new-relic.tf
+++ b/saas/new-relic/detectors-new-relic.tf
@@ -4,15 +4,15 @@ resource "signalfx_detector" "heartbeat" {
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('Apdex/score/*', ${module.filter-tags.filter_custom}).publish('signal')
-    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}').publish('WARN')
+    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}').publish('MAJOR')
 EOF
 
   rule {
     description           = "has not reported in ${var.heartbeat_timeframe}"
-    severity              = "Warning"
-    detect_label          = "WARN"
+    severity              = "Major"
+    detect_label          = "MAJOR"
     disabled              = coalesce(var.heartbeat_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.heartbeat_notifications, "warning", []), var.notifications.warning)
+    notifications         = coalescelist(lookup(var.heartbeat_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
 }
@@ -23,7 +23,7 @@ resource "signalfx_detector" "error_rate" {
   program_text = <<-EOF
     signal = data('Errors/all/errors_per_minute/*', ${module.filter-tags.filter_custom})${var.error_rate_aggregation_function}${var.error_rate_transformation_function}.publish('signal')
     detect(when(signal > ${var.error_rate_threshold_critical})).publish('CRIT')
-    detect(when(signal > ${var.error_rate_threshold_warning}) and when(signal <= ${var.error_rate_threshold_critical})).publish('WARN')
+    detect(when(signal > ${var.error_rate_threshold_major}) and when(signal <= ${var.error_rate_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -36,11 +36,11 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.error_rate_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.error_rate_disabled_warning, var.error_rate_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.error_rate_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.error_rate_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.error_rate_disabled_major, var.error_rate_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.error_rate_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 
@@ -52,7 +52,7 @@ resource "signalfx_detector" "apdex" {
   program_text = <<-EOF
     signal = data('Apdex/score/*', ${module.filter-tags.filter_custom})${var.apdex_aggregation_function}${var.apdex_transformation_function}.publish('signal')
     detect(when(signal < ${var.apdex_threshold_critical})).publish('CRIT')
-    detect(when(signal < ${var.apdex_threshold_warning}) and when(signal >= ${var.apdex_threshold_critical})).publish('WARN')
+    detect(when(signal < ${var.apdex_threshold_major}) and when(signal >= ${var.apdex_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -65,11 +65,11 @@ EOF
   }
 
   rule {
-    description           = "is below nominal capacity < ${var.apdex_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.apdex_disabled_warning, var.apdex_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.apdex_notifications, "warning", []), var.notifications.warning)
+    description           = "is below nominal capacity < ${var.apdex_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.apdex_disabled_major, var.apdex_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.apdex_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/saas/new-relic/variables.tf
+++ b/saas/new-relic/variables.tf
@@ -76,8 +76,8 @@ variable "error_rate_disabled_critical" {
   default     = null
 }
 
-variable "error_rate_disabled_warning" {
-  description = "Disable warning alerting rule for error_rate detector"
+variable "error_rate_disabled_major" {
+  description = "Disable major alerting rule for error_rate detector"
   type        = bool
   default     = null
 }
@@ -106,8 +106,8 @@ variable "error_rate_threshold_critical" {
   default     = 5
 }
 
-variable "error_rate_threshold_warning" {
-  description = "Warning threshold for error_rate detector"
+variable "error_rate_threshold_major" {
+  description = "Major threshold for error_rate detector"
   type        = number
   default     = 1
 }
@@ -126,8 +126,8 @@ variable "apdex_disabled_critical" {
   default     = null
 }
 
-variable "apdex_disabled_warning" {
-  description = "Disable warning alerting rule for apdex detector"
+variable "apdex_disabled_major" {
+  description = "Disable major alerting rule for apdex detector"
   type        = bool
   default     = null
 }
@@ -156,8 +156,8 @@ variable "apdex_threshold_critical" {
   default     = 0.25
 }
 
-variable "apdex_threshold_warning" {
-  description = "Warning threshold for apdex detector"
+variable "apdex_threshold_major" {
+  description = "Major threshold for apdex detector"
   type        = number
   default     = 0.5
 }

--- a/system/generic/detectors-system.tf
+++ b/system/generic/detectors-system.tf
@@ -24,7 +24,7 @@ resource "signalfx_detector" "cpu" {
   program_text = <<-EOF
     signal = data('cpu.utilization', filter=${module.filter-tags.filter_custom}, extrapolation='zero')${var.cpu_aggregation_function}${var.cpu_transformation_function}.publish('signal')
     detect(when(signal > ${var.cpu_threshold_critical})).publish('CRIT')
-    detect(when(signal > ${var.cpu_threshold_warning}) and when(signal <= ${var.cpu_threshold_critical})).publish('WARN')
+    detect(when(signal > ${var.cpu_threshold_major}) and when(signal <= ${var.cpu_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -37,11 +37,11 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.cpu_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.cpu_disabled_warning, var.cpu_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.cpu_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.cpu_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.cpu_disabled_major, var.cpu_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.cpu_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -52,7 +52,7 @@ resource "signalfx_detector" "load" {
   program_text = <<-EOF
     signal = data('load.midterm', filter=${module.filter-tags.filter_custom})${var.load_aggregation_function}${var.load_transformation_function}.publish('signal')
     detect(when(signal > ${var.load_threshold_critical})).publish('CRIT')
-    detect(when(signal > ${var.load_threshold_warning}) and when(signal <= ${var.load_threshold_critical})).publish('WARN')
+    detect(when(signal > ${var.load_threshold_major}) and when(signal <= ${var.load_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -65,11 +65,11 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.load_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.load_disabled_warning, var.load_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.load_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.load_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.load_disabled_major, var.load_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.load_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -80,7 +80,7 @@ resource "signalfx_detector" "disk_space" {
   program_text = <<-EOF
     signal = data('disk.utilization', filter=${module.filter-tags.filter_custom})${var.disk_space_aggregation_function}${var.disk_space_transformation_function}.publish('signal')
     detect(when(signal > ${var.disk_space_threshold_critical})).publish('CRIT')
-    detect(when(signal > ${var.disk_space_threshold_warning}) and when(signal <= ${var.disk_space_threshold_critical})).publish('WARN')
+    detect(when(signal > ${var.disk_space_threshold_major}) and when(signal <= ${var.disk_space_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -93,11 +93,11 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.disk_space_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.disk_space_disabled_warning, var.disk_space_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.disk_space_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.disk_space_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.disk_space_disabled_major, var.disk_space_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.disk_space_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -108,7 +108,7 @@ resource "signalfx_detector" "disk_inodes" {
   program_text = <<-EOF
     signal = data('percent_inodes.used', filter=${module.filter-tags.filter_custom})${var.disk_inodes_aggregation_function}${var.disk_inodes_transformation_function}.publish('signal')
     detect(when(signal > ${var.disk_inodes_threshold_critical})).publish('CRIT')
-    detect(when(signal > ${var.disk_inodes_threshold_warning}) and when(signal <= ${var.disk_inodes_threshold_critical})).publish('WARN')
+    detect(when(signal > ${var.disk_inodes_threshold_major}) and when(signal <= ${var.disk_inodes_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -121,11 +121,11 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.disk_inodes_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.disk_inodes_disabled_warning, var.disk_inodes_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.disk_inodes_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.disk_inodes_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.disk_inodes_disabled_major, var.disk_inodes_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.disk_inodes_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }
@@ -136,15 +136,15 @@ resource "signalfx_detector" "disk_running_out" {
   program_text = <<-EOF
     from signalfx.detectors.countdown import countdown
     signal = data('disk.utilization', filter=${module.filter-tags.filter_custom}).publish('signal')
-    countdown.hours_left_stream_incr_detector(stream=signal, maximum_capacity=${var.disk_running_out_maximum_capacity}, lower_threshold=${var.disk_running_out_hours_till_full}, fire_lasting=lasting('${var.disk_running_out_fire_lasting_time}', ${var.disk_running_out_fire_lasting_time_percent}), clear_threshold=${var.disk_running_out_clear_hours_remaining}, clear_lasting=lasting('${var.disk_running_out_clear_lasting_time}', ${var.disk_running_out_clear_lasting_time_percent}), use_double_ewma=${var.disk_running_out_use_ewma}).publish('WARN')
+    countdown.hours_left_stream_incr_detector(stream=signal, maximum_capacity=${var.disk_running_out_maximum_capacity}, lower_threshold=${var.disk_running_out_hours_till_full}, fire_lasting=lasting('${var.disk_running_out_fire_lasting_time}', ${var.disk_running_out_fire_lasting_time_percent}), clear_threshold=${var.disk_running_out_clear_hours_remaining}, clear_lasting=lasting('${var.disk_running_out_clear_lasting_time}', ${var.disk_running_out_clear_lasting_time_percent}), use_double_ewma=${var.disk_running_out_use_ewma}).publish('MAJOR')
 EOF
 
   rule {
     description           = "in ${var.disk_running_out_hours_till_full}"
-    severity              = "Warning"
-    detect_label          = "WARN"
+    severity              = "Major"
+    detect_label          = "MAJOR"
     disabled              = coalesce(var.disk_running_out_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.disk_running_out_notifications, "warning", []), var.notifications.warning)
+    notifications         = coalescelist(lookup(var.disk_running_out_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} on {{{dimensions}}}"
   }
 }
@@ -155,7 +155,7 @@ resource "signalfx_detector" "memory" {
   program_text = <<-EOF
     signal = data('memory.utilization', filter=${module.filter-tags.filter_custom})${var.memory_aggregation_function}${var.memory_transformation_function}.publish('signal')
     detect(when(signal > ${var.memory_threshold_critical})).publish('CRIT')
-    detect(when(signal > ${var.memory_threshold_warning}) and when(signal <= ${var.memory_threshold_critical})).publish('WARN')
+    detect(when(signal > ${var.memory_threshold_major}) and when(signal <= ${var.memory_threshold_critical})).publish('MAJOR')
 EOF
 
   rule {
@@ -168,11 +168,11 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.memory_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.memory_disabled_warning, var.memory_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.memory_notifications, "warning", []), var.notifications.warning)
+    description           = "is too high > ${var.memory_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.memory_disabled_major, var.memory_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.memory_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/system/generic/variables.tf
+++ b/system/generic/variables.tf
@@ -76,8 +76,8 @@ variable "cpu_disabled_critical" {
   default     = null
 }
 
-variable "cpu_disabled_warning" {
-  description = "Disable warning alerting rule for cpu detector"
+variable "cpu_disabled_major" {
+  description = "Disable major alerting rule for cpu detector"
   type        = bool
   default     = null
 }
@@ -106,8 +106,8 @@ variable "cpu_threshold_critical" {
   default     = 90
 }
 
-variable "cpu_threshold_warning" {
-  description = "Warning threshold for cpu detector"
+variable "cpu_threshold_major" {
+  description = "Major threshold for cpu detector"
   type        = number
   default     = 85
 }
@@ -126,8 +126,8 @@ variable "load_disabled_critical" {
   default     = null
 }
 
-variable "load_disabled_warning" {
-  description = "Disable warning alerting rule for load detector"
+variable "load_disabled_major" {
+  description = "Disable major alerting rule for load detector"
   type        = bool
   default     = null
 }
@@ -156,8 +156,8 @@ variable "load_threshold_critical" {
   default     = 2.5
 }
 
-variable "load_threshold_warning" {
-  description = "Warning threshold for load detector"
+variable "load_threshold_major" {
+  description = "Major threshold for load detector"
   type        = number
   default     = 2
 }
@@ -176,8 +176,8 @@ variable "disk_space_disabled_critical" {
   default     = null
 }
 
-variable "disk_space_disabled_warning" {
-  description = "Disable warning alerting rule for disk space detector"
+variable "disk_space_disabled_major" {
+  description = "Disable major alerting rule for disk space detector"
   type        = bool
   default     = null
 }
@@ -206,8 +206,8 @@ variable "disk_space_threshold_critical" {
   default     = 90
 }
 
-variable "disk_space_threshold_warning" {
-  description = "Warning threshold for disk space detector"
+variable "disk_space_threshold_major" {
+  description = "Major threshold for disk space detector"
   type        = number
   default     = 80
 }
@@ -226,8 +226,8 @@ variable "disk_inodes_disabled_critical" {
   default     = null
 }
 
-variable "disk_inodes_disabled_warning" {
-  description = "Disable warning alerting rule for dsik_inodes detector"
+variable "disk_inodes_disabled_major" {
+  description = "Disable major alerting rule for dsik_inodes detector"
   type        = bool
   default     = null
 }
@@ -256,8 +256,8 @@ variable "disk_inodes_threshold_critical" {
   default     = 95
 }
 
-variable "disk_inodes_threshold_warning" {
-  description = "Warning threshold for disk inodes detector"
+variable "disk_inodes_threshold_major" {
+  description = "Major threshold for disk inodes detector"
   type        = number
   default     = 90
 }
@@ -338,8 +338,8 @@ variable "memory_disabled_critical" {
   default     = null
 }
 
-variable "memory_disabled_warning" {
-  description = "Disable warning alerting rule for memory detector"
+variable "memory_disabled_major" {
+  description = "Disable major alerting rule for memory detector"
   type        = bool
   default     = null
 }
@@ -368,8 +368,8 @@ variable "memory_threshold_critical" {
   default     = 95
 }
 
-variable "memory_threshold_warning" {
-  description = "Warning threshold for memory detector"
+variable "memory_threshold_major" {
+  description = "Major threshold for memory detector"
   type        = number
   default     = 90
 }

--- a/system/nagios-status-check/variables.tf
+++ b/system/nagios-status-check/variables.tf
@@ -11,9 +11,9 @@ variable "notifications" {
   description = "Default notification recipients list per severity"
   type = object({
     critical = list(string)
+    warning  = list(string)
     major    = list(string)
     minor    = list(string)
-    warning  = list(string)
     info     = list(string)
   })
 }

--- a/system/ntp/detectors-ntp.tf
+++ b/system/ntp/detectors-ntp.tf
@@ -23,15 +23,15 @@ resource "signalfx_detector" "ntp" {
 
   program_text = <<-EOF
         signal = data('ntp.offset_seconds', filter=${module.filter-tags.filter_custom})${var.ntp_aggregation_function}${var.ntp_transformation_function}.publish('signal')
-        detect(when(signal > ${var.ntp_threshold_warning})).publish('WARN')
+        detect(when(signal > ${var.ntp_threshold_major})).publish('MAJOR')
 EOF
 
   rule {
-    description           = "is too high > ${var.ntp_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
+    description           = "is too high > ${var.ntp_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
     disabled              = coalesce(var.ntp_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.ntp_notifications, "warning", []), var.notifications.warning)
+    notifications         = coalescelist(lookup(var.ntp_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/system/ntp/variables.tf
+++ b/system/ntp/variables.tf
@@ -88,8 +88,8 @@ variable "ntp_transformation_function" {
   default     = ".min(over='5m')"
 }
 
-variable "ntp_threshold_warning" {
-  description = "Warning threshold for ntp detector"
+variable "ntp_threshold_major" {
+  description = "Major threshold for ntp detector"
   type        = number
   default     = 1500
 }

--- a/system/processes/detectors-processes.tf
+++ b/system/processes/detectors-processes.tf
@@ -4,7 +4,7 @@ resource "signalfx_detector" "processes" {
   program_text = <<-EOF
         signal = data('ps_count.processes', filter=${module.filter-tags.filter_custom})${var.processes_aggregation_function}${var.processes_transformation_function}.publish('signal')
         detect(when(signal < 1)).publish('CRIT')
-        detect(when(signal < ${var.processes_threshold_warning}) and when (signal >= 1)).publish('WARN')
+        detect(when(signal < ${var.processes_threshold_major}) and when (signal >= 1)).publish('MAJOR')
 EOF
 
   rule {
@@ -17,11 +17,11 @@ EOF
   }
 
   rule {
-    description           = "count is too low < ${var.processes_threshold_warning}"
-    severity              = "Warning"
-    detect_label          = "WARN"
-    disabled              = coalesce(var.processes_disabled_warning, var.processes_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.processes_notifications, "warning", []), var.notifications.warning)
+    description           = "count is too low < ${var.processes_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.processes_disabled_major, var.processes_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.processes_notifications, "major", []), var.notifications.major)
     parameterized_subject = "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}}) on {{{dimensions}}}"
   }
 }

--- a/system/processes/variables.tf
+++ b/system/processes/variables.tf
@@ -56,8 +56,8 @@ variable "processes_disabled_critical" {
   default     = null
 }
 
-variable "processes_disabled_warning" {
-  description = "Disable warning alerting rule for processes detector"
+variable "processes_disabled_major" {
+  description = "Disable major alerting rule for processes detector"
   type        = bool
   default     = true
 }
@@ -80,8 +80,8 @@ variable "processes_transformation_function" {
   default     = ".min(over='15m')"
 }
 
-variable "processes_threshold_warning" {
-  description = "Warning threshold for processes detector"
+variable "processes_threshold_major" {
+  description = "Major threshold for processes detector"
   type        = number
   default     = 2
 }


### PR DESCRIPTION
replaces:
- warning by major
- major by minor
- minor by warning

the goal is to enjoy the multiple severity levels provided by signalfx compared to original datadog monitors.

we should probably decrease the severity of lot of legacy detectors because orginally we were forced to assign a critical/alert level for datadog but now we can define any level on signalfx.

this could be done little by little in future, this PR only aims to reorder severities and keep them as they are.