### PR TITLE
#146 network/http add lasting for code check

### DIFF
--- a/network/http/detectors-http.tf
+++ b/network/http/detectors-http.tf
@@ -24,7 +24,7 @@ resource "signalfx_detector" "http_code_matched" {
 
   program_text = <<-EOF
     signal = data('http.code_matched', ${module.filter-tags.filter_custom})${var.http_code_matched_aggregation_function}${var.http_code_matched_transformation_function}.publish('signal')
-    detect(when(signal < 1)).publish('CRIT')
+    detect(when(signal < 1, lasting('${var.http_code_matched_lasting_duration}'))).publish('CRIT')
 EOF
 
   rule {
@@ -44,7 +44,7 @@ resource "signalfx_detector" "http_regex_matched" {
 
   program_text = <<-EOF
     signal = data('http.regex_matched', ${module.filter-tags.filter_custom})${var.http_regex_matched_aggregation_function}${var.http_regex_matched_transformation_function}.publish('signal')
-    detect(when(signal < 1)).publish('CRIT')
+    detect(when(signal < 1, lasting('${var.http_regex_matched_lasting_duration}'))).publish('CRIT')
 EOF
 
   rule {

--- a/network/http/variables.tf
+++ b/network/http/variables.tf
@@ -58,6 +58,12 @@ variable "http_code_matched_transformation_function" {
   default     = ".max(over='1m')"
 }
 
+variable "http_code_matched_lasting_duration" {
+  description = "Duration that indicates how long we wait before triggering the http_code_matched alert. Specified as s, m, h, d"
+  type        = string
+  default     = "1s"
+}
+
 # Http_regex_matched detector
 
 variable "http_regex_matched_disabled" {
@@ -88,6 +94,12 @@ variable "http_regex_matched_transformation_function" {
   description = "Transformation function for http_regex_matched detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ".max(over='5m')"
+}
+
+variable "http_regex_matched_lasting_duration" {
+  description = "Duration that indicates how long we wait before triggering the http_regex_matched alert. Specified as s, m, h, d"
+  type        = string
+  default     = "1s"
 }
 
 # Http_response_time detector


### PR DESCRIPTION
Allow to retard the alert trigger by adding lasting() in the signal detector.
Default value to 1s to not break existing code.

fix #146 