### PR TITLE
add tomcat detectors

### DIFF
--- a/database/cassandra/README.md
+++ b/database/cassandra/README.md
@@ -18,3 +18,5 @@ Requires SignalFx Agent >= `5.5.5` and enable the following extra metrics:
       - "gauge.cassandra.ClientRequest.CASWrite.Latency.99thPercentile"
 ```
 
+You can use [genericjmx](../../middleware/genericjmx/README.md) as complement 
+to this module to monitor generic JMX metrics.

--- a/middleware/tomcat/README.md
+++ b/middleware/tomcat/README.md
@@ -1,0 +1,15 @@
+## Notes
+
+This module uses the [collectd/tomcat](https://docs.signalfx.com/en/latest/integrations/agent/monitors/collectd-tomcat.html)
+monitor to collect metrics which require agent version `>= 5.5.5`.
+
+There is not any specific configuration:
+
+```yaml
+  - type: collectd/tomcat
+    host: 127.0.0.1
+    port: 8050
+```
+
+You can use [genericjmx](../genericjmx/README.md) as complement 
+to this module to monitor generic JMX metrics.

--- a/middleware/tomcat/common-locals.tf
+++ b/middleware/tomcat/common-locals.tf
@@ -1,0 +1,1 @@
+../../common/locals.tf

--- a/middleware/tomcat/common-modules.tf
+++ b/middleware/tomcat/common-modules.tf
@@ -1,0 +1,1 @@
+../../common/modules.tf

--- a/middleware/tomcat/common-variables.tf
+++ b/middleware/tomcat/common-variables.tf
@@ -1,0 +1,1 @@
+../../common/variables.tf

--- a/middleware/tomcat/common-versions.tf
+++ b/middleware/tomcat/common-versions.tf
@@ -1,0 +1,1 @@
+../../common/versions.tf

--- a/middleware/tomcat/detectors-tomcat.tf
+++ b/middleware/tomcat/detectors-tomcat.tf
@@ -1,0 +1,86 @@
+resource "signalfx_detector" "heartbeat" {
+  name      = format("%s %s", local.detector_name_prefix, "Tomcat heartbeat")
+  max_delay = 900
+
+  program_text = <<-EOF
+    from signalfx.detectors.not_reporting import not_reporting
+    signal = data(' gauge.tomcat.ThreadPool.maxThreads ', filter=${module.filter-tags.filter_custom})${var.heartbeat_aggregation_function}.publish('signal')
+    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}').publish('CRIT')
+EOF
+
+  rule {
+    description           = "has not reported in ${var.heartbeat_timeframe}"
+    severity              = "Critical"
+    detect_label          = "CRIT"
+    disabled              = coalesce(var.heartbeat_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.heartbeat_notifications, "critical", []), var.notifications.critical)
+    parameterized_subject = local.rule_subject
+    parameterized_body    = local.rule_body
+  }
+}
+
+resource "signalfx_detector" "average_processing_time" {
+  name = format("%s %s", local.detector_name_prefix, "Tomcat average processing time")
+
+  program_text = <<-EOF
+    A = data('counter.tomcat.GlobalRequestProcessor.processingTime', filter=${module.filter-tags.filter_custom}, rollup='delta')${var.average_processing_time_aggregation_function}${var.average_processing_time_transformation_function}
+    B = data('counter.tomcat.GlobalRequestProcessor.requestCount', filter=${module.filter-tags.filter_custom}, rollup='delta')${var.average_processing_time_aggregation_function}${var.average_processing_time_transformation_function}
+    signal = (A/B).fill(0).publish('signal')
+    detect(when(signal > ${var.average_processing_time_threshold_critical})).publish('CRIT')
+    detect(when(signal > ${var.average_processing_time_threshold_major}) and when(signal <= ${var.average_processing_time_threshold_critical})).publish('MAJOR')
+EOF
+
+  rule {
+    description           = "is too high > ${var.average_processing_time_threshold_critical} ms"
+    severity              = "Critical"
+    detect_label          = "CRIT"
+    disabled              = coalesce(var.average_processing_time_disabled_critical, var.average_processing_time_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.average_processing_time_notifications, "critical", []), var.notifications.critical)
+    parameterized_subject = local.rule_subject
+    parameterized_body    = local.rule_body
+  }
+
+  rule {
+    description           = "is too high > ${var.average_processing_time_threshold_major} ms"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.average_processing_time_disabled_major, var.average_processing_time_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.average_processing_time_notifications, "major", []), var.notifications.major)
+    parameterized_subject = local.rule_subject
+    parameterized_body    = local.rule_body
+  }
+}
+
+
+resource "signalfx_detector" "busy_threads_percentage" {
+  name = format("%s %s", local.detector_name_prefix, "Tomcat busy threads percentage")
+
+  program_text = <<-EOF
+    A = data('gauge.tomcat.ThreadPool.currentThreadsBusy', filter=${module.filter-tags.filter_custom})${var.busy_threads_percentage_aggregation_function}${var.busy_threads_percentage_transformation_function}
+    B = data('gauge.tomcat.ThreadPool.maxThreads', filter=${module.filter-tags.filter_custom})${var.busy_threads_percentage_aggregation_function}${var.busy_threads_percentage_transformation_function}
+    signal = (A/B).scale(100).fill(0).publish('signal')
+    detect(when(signal > ${var.busy_threads_percentage_threshold_critical})).publish('CRIT')
+    detect(when(signal > ${var.busy_threads_percentage_threshold_major}) and when(signal <= ${var.busy_threads_percentage_threshold_critical})).publish('MAJOR')
+EOF
+
+  rule {
+    description           = "is too high > ${var.busy_threads_percentage_threshold_critical}"
+    severity              = "Critical"
+    detect_label          = "CRIT"
+    disabled              = coalesce(var.busy_threads_percentage_disabled_critical, var.busy_threads_percentage_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.busy_threads_percentage_notifications, "critical", []), var.notifications.critical)
+    parameterized_subject = local.rule_subject
+    parameterized_body    = local.rule_body
+  }
+
+  rule {
+    description           = "is too high > ${var.busy_threads_percentage_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.busy_threads_percentage_disabled_major, var.busy_threads_percentage_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.busy_threads_percentage_notifications, "major", []), var.notifications.major)
+    parameterized_subject = local.rule_subject
+    parameterized_body    = local.rule_body
+  }
+}
+

--- a/middleware/tomcat/outputs.tf
+++ b/middleware/tomcat/outputs.tf
@@ -1,0 +1,15 @@
+output "average_processing_time" {
+  description = "Detector resource for average_processing_time"
+  value       = signalfx_detector.average_processing_time
+}
+
+output "busy_threads_percentage" {
+  description = "Detector resource for busy_threads_percentage"
+  value       = signalfx_detector.busy_threads_percentage
+}
+
+output "heartbeat" {
+  description = "Detector resource for heartbeat"
+  value       = signalfx_detector.heartbeat
+}
+

--- a/middleware/tomcat/variables.tf
+++ b/middleware/tomcat/variables.tf
@@ -1,0 +1,126 @@
+# heartbeat detector
+
+variable "heartbeat_notifications" {
+  description = "Notification recipients list per severity overridden for heartbeat detector"
+  type        = map(list(string))
+  default     = {}
+}
+
+variable "heartbeat_aggregation_function" {
+  description = "Aggregation function and group by for heartbeat detector (i.e. \".mean(by=['host'])\")"
+  type        = string
+  default     = ""
+}
+
+variable "heartbeat_disabled" {
+  description = "Disable all alerting rules for heartbeat detector"
+  type        = bool
+  default     = null
+}
+
+variable "heartbeat_timeframe" {
+  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  type        = string
+  default     = "20m"
+}
+
+# average_processing_time detector
+
+variable "average_processing_time_notifications" {
+  description = "Notification recipients list per severity overridden for average_processing_time detector"
+  type        = map(list(string))
+  default     = {}
+}
+
+variable "average_processing_time_aggregation_function" {
+  description = "Aggregation function and group by for average_processing_time detector (i.e. \".mean(by=['host'])\")"
+  type        = string
+  default     = ""
+}
+
+variable "average_processing_time_transformation_function" {
+  description = "Transformation function for average_processing_time detector (i.e. \".mean(over='5m')\")"
+  type        = string
+  default     = ".min(over='10m')"
+}
+
+variable "average_processing_time_disabled" {
+  description = "Disable all alerting rules for average_processing_time detector"
+  type        = bool
+  default     = null
+}
+
+variable "average_processing_time_disabled_critical" {
+  description = "Disable critical alerting rule for average_processing_time detector"
+  type        = bool
+  default     = null
+}
+
+variable "average_processing_time_disabled_major" {
+  description = "Disable major alerting rule for average_processing_time detector"
+  type        = bool
+  default     = null
+}
+
+variable "average_processing_time_threshold_critical" {
+  description = "Critical threshold for average_processing_time detector in ms"
+  type        = number
+  default     = 1500
+}
+
+variable "average_processing_time_threshold_major" {
+  description = "Major threshold for average_processing_time detector in ms"
+  type        = number
+  default     = 750
+}
+
+# busy_threads_percentage detector
+
+variable "busy_threads_percentage_notifications" {
+  description = "Notification recipients list per severity overridden for busy_threads_percentage detector"
+  type        = map(list(string))
+  default     = {}
+}
+
+variable "busy_threads_percentage_aggregation_function" {
+  description = "Aggregation function and group by for busy_threads_percentage detector (i.e. \".mean(by=['host'])\")"
+  type        = string
+  default     = ""
+}
+
+variable "busy_threads_percentage_transformation_function" {
+  description = "Transformation function for busy_threads_percentage detector (i.e. \".mean(over='5m')\")"
+  type        = string
+  default     = ".min(over='5m')"
+}
+
+variable "busy_threads_percentage_disabled" {
+  description = "Disable all alerting rules for busy_threads_percentage detector"
+  type        = bool
+  default     = null
+}
+
+variable "busy_threads_percentage_disabled_critical" {
+  description = "Disable critical alerting rule for busy_threads_percentage detector"
+  type        = bool
+  default     = null
+}
+
+variable "busy_threads_percentage_disabled_major" {
+  description = "Disable major alerting rule for busy_threads_percentage detector"
+  type        = bool
+  default     = null
+}
+
+variable "busy_threads_percentage_threshold_critical" {
+  description = "Critical threshold for busy_threads_percentage detector"
+  type        = number
+  default     = 95
+}
+
+variable "busy_threads_percentage_threshold_major" {
+  description = "Major threshold for busy_threads_percentage detector"
+  type        = number
+  default     = 80
+}
+


### PR DESCRIPTION
First module created from https://github.com/claranet/terraform-signalfx-detectors/pull/161, the ci will be ok when this one will be merged (will need to run gen_outputs.sh script after).