### PR TITLE
#156 various improvements for generator

### DIFF
--- a/.github/workflows/generator.yml
+++ b/.github/workflows/generator.yml
@@ -40,9 +40,14 @@ jobs:
     - name: Setup env
       run: |
         ./scripts/gen_module.sh ${TF_VAR_environment} module
-        echo -e "module \"generated\" {\nsource=\"../modules/${TF_VAR_environment}-module\"\n$(cat common/modules-args.txt)\n}" >> test/generated.tf
-        cat test/generated.tf
+        for config in scripts/templates/threshold/*.yaml; do 
+          j2 <(cat scripts/templates/detector_vars.tf.j2 scripts/templates/detector_res.tf.j2) $config >> modules/${TF_VAR_environment}-module/gen.tf
+        done
+        echo -e "module \"generated\" {\nsource=\"../modules/${TF_VAR_environment}-module\"\n$(cat common/modules-args.txt)\n}" >> test/gen.tf
     
+    - name: Terraform fmt
+      run: terraform fmt -write=false -diff -check modules/${TF_VAR_environment}-module
+
     - name: Terraform init
       run: terraform init test
 

--- a/scripts/templates/detector_res.tf.j2
+++ b/scripts/templates/detector_res.tf.j2
@@ -1,9 +1,15 @@
-{%- set id = name | replace(' ', '_') | lower -%}
+{%- if id is defined and id -%}
+  {%- set id = id | lower -%}
+{%- else -%}
+  {%- set id = name | replace(' ', '_') | lower -%}
+{% endif -%}
 {%- if name | lower == 'heartbeat' -%}
   {%- set type = 'heartbeat' -%}
+  {%- set arg_format = '     ' -%}
 {%- else -%}
   {%- set type = 'threshold' -%}
 {%- endif -%}
+{%- set filtering_variable = 'base_filtering' -%}
 
 {%- for key, signal in signals.items() -%}
   {%- if loop.last -%}
@@ -11,7 +17,7 @@
   {%- endif %}
 {%- endfor -%}
 resource "signalfx_detector" "{{ id }}" {
-  name = format("%s %s", local.detector_name_prefix, "{{ module | capitalize }} {{ name }}")
+  name{{ arg_format | default('') }} = format("%s %s", local.detector_name_prefix, "{{ module[0]|upper}}{{module[1:] }} {{ name | lower }}")
   {%- if type == 'heartbeat' %}
   max_delay = 900
   {%- endif %}
@@ -20,10 +26,13 @@ resource "signalfx_detector" "{{ id }}" {
     {%- if type == 'heartbeat' %}
     from signalfx.detectors.not_reporting import not_reporting
     {%- endif %}
+    {%- if filtering is defined and filtering %}
+    {{ filtering_variable }} = {{ filtering }}
+    {%- endif %}
 
     {%- for key, signal in signals.items() -%}
       {%- if 'metric' in signal %}
-    {{ key }} = data('{{ signal.metric }}', filter=${module.filter-tags.filter_custom})
+    {{ key }} = data('{{ signal.metric }}', filter={%- if filtering is defined and filtering -%}{{ filtering_variable }} and {% endif -%}${module.filter-tags.filter_custom})
         {%- if aggregation | default(true) %}${var.{{ id }}_aggregation_function}{%- endif %}
         {%- if transformation | default(true)%}${var.{{ id }}_transformation_function}{%- endif %}
       {%- endif -%}
@@ -54,7 +63,7 @@ resource "signalfx_detector" "{{ id }}" {
         {%- else %}
           {%- set negative_comparator = reverse_comparator ~ '=' %}
         {%- endif %}
-    detect(when(signal > ${var.{{ id }}_threshold_{{ severity }}})
+    detect(when(signal {{ rule.comparator }} ${var.{{ id }}_threshold_{{ severity }}})
         {%- if 'dependency' in rule %} and when(signal {{ negative_comparator }} ${var.{{ id }}_threshold_{{ rule.dependency }}}){%- endif -%})
       {%- endif -%}
     .publish('{{ severity_label }}')

--- a/scripts/templates/detector_vars.tf.j2
+++ b/scripts/templates/detector_vars.tf.j2
@@ -1,4 +1,8 @@
-{%- set id = name | replace(' ', '_') -%}
+{%- if id is defined and id -%}
+  {%- set id = id | lower -%}
+{%- else -%}
+  {%- set id = name | replace(' ', '_') | lower -%}
+{% endif -%}
 {%- if name | lower == 'heartbeat' -%}
   {%- set type = 'heartbeat' -%}
 {%- else -%}
@@ -47,7 +51,7 @@ variable "{{ id }}_disabled_{{ severity }}" {
   default     = null
 }
 
-  {% endfor -%}
+{% endfor -%}
 {% endif -%}
 
 {% if type == 'heartbeat' -%}
@@ -63,10 +67,10 @@ variable "{{ id }}_timeframe" {
 variable "{{ id }}_threshold_{{ severity }}" {
   description = "{{ severity | capitalize }} threshold for {{ id }} detector"
   type        = number
-    {%- if (rule.threshold is defined and rule.threshold | int) %}
+    {%- if rule.threshold is number %}
   default     = {{ rule.threshold }}
     {%- endif %}
 }
 
-  {% endfor -%}
+{% endfor -%}
 {% endif -%}

--- a/scripts/templates/values.yaml
+++ b/scripts/templates/values.yaml
@@ -13,6 +13,18 @@
 #
 module: 
 
+## @param id - string - optional
+## Detector id (shorter canonical name).
+## Used as prefix for terraform variables, resources and outputs names.
+#
+## If not defined it will result in lower {{name}} with spaces replaced by `_`.
+## This is why this is highly recommended to explicitly set {{id}} if 
+## {{name}} is too long or use special chars like `()`.
+#
+## Aims to be passed from env var by script or cli.
+#
+id: 
+
 ## @param name - string - mandatory
 ## Detector entire readable name (what it checks).
 ## Used after {{module}} for alert subject and as prefix for variables.
@@ -48,6 +60,18 @@ aggregation: true
 #
 #transformation: ".mean(over='5m')"
 transformation: true
+
+## @param filtering - string - optional
+## Determine base filtering added only to {{rules.severity}} with 
+## {{metric}} defined (not used for {{formula}}).
+## It will define a `base_filtering` variable at start of signalflow 
+## programm then use it in `filter` parameter of `data()` function.
+#
+## Should be a valid `filter` object, see:
+## https://dev.splunk.com/observability/docs/signalflow/functions/filter_function/
+#
+#filtering: "filter('primary_aggregation_type', 'true')"
+filtering:
 
 ## @param signals - object - mandatory
 ## List of signals of the detector. Attribute key is the {{signal_label}} 


### PR DESCRIPTION
improve #156 preserving terraform fmt for variables (trim ending whitespace) and avoid capitalize which lower every chars except the first one (MongoDB -> Mongodb)

EDIT: adding threshold detectors to ci tests showed another problem with `name` format when `max_delay` is set (for heartbeat only).

- trim "for" based starting variables declaration:
(`# xyz detector` -> `# xyz detector`)

- do not lower module name (but keep upper for first char)

- terraform format for `name` when `max_delay` is defined (heartbeat)

- fix hardcoded comparator in main detect condition

- fix threshold to 0 is considered as not defined

- ability to override id for long name or containing special chars

- add base filtering support