### PR TITLE
#109 filter ci workflow using paths

### DIFF
--- a/.github/workflows/generator.yml
+++ b/.github/workflows/generator.yml
@@ -4,6 +4,10 @@ name: Generator
 
 on:
   push:
+    paths:
+    - 'scripts/templates/**'
+    - 'scripts/gen_module.sh'
+    - '.github/workflows/generator.yml'
 
 jobs:
   test:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,10 @@ name: Detectors
 # events but only for the master branch
 on:
   push:
+    paths:
+    - '**.tf'
+    - 'scripts/*'
+    - '.github/workflows/main.yml'
 #    branches: [ master ]
 #  pull_request:
 #    branches: [ master ]


### PR DESCRIPTION
fix #109 

limit ci to paths, especially to avoid terraform apply for unrelated changes like README update
