### PR TITLE
Readme, templating, wiki and contribution

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,0 +1,27 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Documentation
+
+on:
+  push:
+    paths:
+    - '**.md'
+    - '.github/workflows/doc.yml'
+
+jobs:
+  toc:
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: TOC Generator
+      uses: technote-space/toc-generator@v2.6.1
+      with:
+        TARGET_PATHS: '*.md'
+        TOC_TITLE: ':link: **Contents**'
+        MAX_HEADER_LEVEL: 3
+

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,5 +1,18 @@
 # Contributor Covenant Code of Conduct
 
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+:link: **Contents**
+
+- [Our Pledge](#our-pledge)
+- [Our Standards](#our-standards)
+- [Our Responsibilities](#our-responsibilities)
+- [Scope](#scope)
+- [Enforcement](#enforcement)
+- [Attribution](#attribution)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 ## Our Pledge
 
 In the interest of fostering an open and welcoming environment, we as

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,27 @@
 # Contributing
 
-All contributions and pull requests are welcome!
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+:link: **Contents**
 
-## Workflow
+- [General](#general)
+- [Detectors](#detectors)
+- [Scope](#scope)
+- [Example](#example)
+- [Limits](#limits)
+- [Criteria](#criteria)
+- [Templating tips and rules](#templating-tips-and-rules)
+  - [Modules structure](#modules-structure)
+  - [Variables](#variables)
+  - [Default values](#default-values)
+  - [Filtering](#filtering)
+  - [Severity](#severity)
+  - [No data](#no-data)
+  - [Documentation](#documentation)
 
-### General
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## General
 
 * to propose change, simply submit a pull request (no issue required).
 * if you are not sure, create it as draft this will allow code owners 
@@ -14,7 +31,7 @@ discuss.
 * there are several issue templates available for common needs, please 
 select it appropriately.
 
-# Detectors
+## Detectors
 
 * to update existing detectors do the change directly in code.
 * to add new detectors in existing modules use [the jinja 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,256 +1,245 @@
 # Contributing
 
+__Thanks for wanting to contribute. The Claranet Team will be pleased to guide you and review 
+your proposals as quickly as possible. Keep in mind that all communication are 
+subject to our [CODE_OF_CONDUCT.md](/CODE_OF_CONDUCT.md).__
+
+To record a bug report, enhancement proposal, or give any other product feedback, please [open 
+a new Github issue](https://github.com/claranet/terraform-signalfx-detectors/issues/new/choose) 
+using the most appropriate issue template. Please, try to provide as much details, context and 
+examples as possible. Information requested by issue templates should help but feel free to 
+adapt. The goal is to maximize chance to act relevantly to your feedback.
+
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 :link: **Contents**
 
-- [General](#general)
-- [Detectors](#detectors)
-- [Scope](#scope)
-- [Example](#example)
-- [Limits](#limits)
-- [Criteria](#criteria)
-- [Templating tips and rules](#templating-tips-and-rules)
-  - [Modules structure](#modules-structure)
-  - [Variables](#variables)
-  - [Default values](#default-values)
-  - [Filtering](#filtering)
-  - [Severity](#severity)
-  - [No data](#no-data)
+- [Proposing a change](#proposing-a-change)
   - [Documentation](#documentation)
+  - [Detectors](#detectors)
+  - [Templating](#templating)
+  - [Continous Integration](#continous-integration)
+- [Workflow](#workflow)
+  - [Issue](#issue)
+  - [Pull Request](#pull-request)
+  - [Speed up review and merge](#speed-up-review-and-merge)
+  - [PR Checks](#pr-checks)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-## General
+## Proposing a change 
 
-* to propose change, simply submit a pull request (no issue required).
-* if you are not sure, create it as draft this will allow code owners 
-to help you.
-* to ask for changes or for larger feature please open an issue to 
-discuss.
-* there are several issue templates available for common needs, please 
-select it appropriately.
+In general, we prefer to discuss in Github issues prior to implementation. That will allow us to 
+give some clues and recommendations on the design and may be provide existing work or thoughts 
+from our experience.
 
-## Detectors
+First, search for existing issue related to your change and start a discussion about what you 
+wish to implement. This could be useful to prevent tenious conflicts, notice eventual 
+implications or mutualize implementation of dependent or similar features.
 
-* to update existing detectors do the change directly in code.
-* to add new detectors in existing modules use [the jinja 
-generator](./scripts/templates/README.md).
-* to add new module use [the gen_module.sh 
-script](./scripts/gen_module.sh).
+If you did not find an existing one, please [open a new Github
+issue](https://github.com/claranet/terraform-signalfx-detectors/issues/new/choose) 
+before invest significant development time.
 
-## Scope
+The general workflow is the same for any contribution but there are different considerations to 
+know depending on what you want to change or, more specifically, on what could be impacted by 
+your change.
 
-The generic purpose goal of detectors in this repository will always 
-limit the scope and the capabilities of these modules and also the 
-approval criteria for changes.
+### Documentation
 
-It does not aim to cover too specific usage, setup or implementation 
-because they will not be reusable.
+__Label__: 
+[documentation](https://github.com/claranet/terraform-signalfx-detectors/labels/documentation)
 
-It is a good start for a new project, to detect known anomalies and 
-usual problems, in common situations. Each module is focused on 
-monitor one target from its own internal view.
+__Issue__: Not required, go ahead and open a Pull Request.
 
-## Example
+Changes of documentation are riskless but here are some considerations:
 
-The metric collection is good to understand this:
+* The modules readmes are auto generated so you must edit the underlying configuration.
+* Table of contents of every readmes are auto generarated by the CI, there is no need to update 
+them yourself.
+* Pull request is not possible on Github `wiki` so you can create an issue for that. For more 
+complex changes you can create a new empty repository on your Github, clone this wiki: 
+`git clone git@github.com:claranet/terraform-signalfx-detectors.wiki.git`, change its remote to 
+your new repository, push your change then provide the change url of your Github repository in 
+an issue here.
 
-* using highly complex formulas on multiple metrics from the same 
-source is not a problem while it remains easy to setup and could be 
-used in common situations.
-* but a very simple detector using only two metrics from different 
-sources could be too dificult to setup or require dependencies not 
-available for most of the people.
+### Detectors
 
-For example, correlate a simple CPU usage of an host (fully generic) 
-with the latency of his own application (collected by a custom metric or apm metric): the detector is simple, easy to deploy but requirements 
-cannot be generic by design.
+__Label__: 
+[detectors](https://github.com/claranet/terraform-signalfx-detectors/labels/detectors)
 
-## Limits
+__Issue__: Not required but recommended.
 
-Given that this scope and because we want to preserve homogeneity 
-and maintainability every propositions could not be accepted. Also, 
-the behavior which corresponds to the most of the people will always 
-be favored compared to a better or more accurate approach which will 
-only work in few situations.
+Changes on detectors are the most common but you first have to understand the current goal of 
+this repository explained in the [wiki](https://github.com/claranet/terraform-signalfx-detectors/wiki).
+Indeed, this repository aims to provide "generic enough" detectors and this limits the scope of changes we 
+can accept. 
 
-This is also why we always recommend to create his own detectors, 
-specifc to his use case, data sources and situations. They will be 
-a good complement to get a global monitoring coverage.
+* To update existing detectors, simply edit the `*.tf` code in the related module and update the 
+variables default values, the signalflow programm or any other changes specific to detectors 
+behaviors you want to do. For basic change, a simple description in Pull Request is enough and do 
+not require an issue.
 
-## Criteria
+* To add new detectors in existing modules use [the jinja 
+generator](./scripts/templates/README.md) for detector. This should help you to quickly build new 
+detectors for common use cases which respect every of our templating rules. For more complex or 
+unusual use cases, you will have to do it manually either from sratch, from an existing detectors 
+on the repository or applying specific changes on generator output.
 
-Modules should be as much "plug and play" as possible, that means:
+* To add a new module use [the gen_module.sh 
+script](./scripts/gen_module.sh) which will bootstrap a new module directory with common structure 
+and a sample "heartbeat" detector generated inside. One heartbeat per module is often used but not 
+mandatory, you can remove it and/or use the previous mentionned generator to add new ones.
+
+* To delete an existing detector, first think if lower the severity and changing thresholds or 
+functions could not improve enough it. If still not relevant or generate too many alerts in some 
+scenarios but remain useful in others may be disabling it by default is a good idea. Finally, when 
+removing do not forget to remove its related variables and outputs.
+
+Globally, we want modules to be as much "plug and play" as possible, that means:
 
 * be easy to configure and deploy
 * works in most of the situations
 * do not generate undersirable and predictable false alerts
-* how to collect the metrics used in detectors should be 
-provided, documented and available.
-* should limit dependencies complexity as using too many or 
-too different sources of metrics.
+* how to collect the metrics used in detectors should be provided, documented and available.
+* should limit dependencies complexity as using too many or too different sources of metrics.
 
-In short, the implementation could be complex but the usage must 
-remain simple and useful for the community.
+In short, the implementation could be complex but the usage must remain simple and useful for the 
+community. To make it possible we provide a common module 
+[structure](https://github.com/claranet/terraform-signalfx-detectors/wiki/Structure) which make 
+the experience similar for every modules.
 
-Sadly, full ready detectors which work everywhere by default is 
-almost never possible. This is why templating tips and rules have 
-been defined to help to customize their behavior at deployment 
-to meet these criterias.
+Sadly, full ready and generic detectors which work everywhere by default is almost never possible. 
+This is why we have also have use 
+[templating](https://github.com/claranet/terraform-signalfx-detectors/wiki/Structure) thanks to 
+terraform to make it possible to customize their configuration and adapt their behavior at deployment.
 
-## Templating tips and rules
-
-Terraform is rich of capabilities and allow to provide flexibility 
-in configuration at deployment level.
-
-A generic implementation customizable from user inputs with a 
-good thinked structure and rich documentation could help to cover 
-different specific situations and make it more generic.
-
-Here are some templating rules and tips used to achieve this goal.
-Some are required and others optional, more information 
-in [the wiki](https://github.com/claranet/terraform-signalfx-detectors/wiki) 
-for more details.
-
-### Modules structure
-
-Split your detectors into as much different modules as it could 
-exist different predictable situations.
-
-Having big modules with lot of detectors is not a problem itself 
-but it increase the risk to not meet requirements.
-Proposing atomic module will allow users to pick up only what they 
-want without to disable some detectors.
-
-Some examples:
-* there is a `common` kubernetes module which should work in any 
-cases. The `volume` detectors should be useful for everybody but 
-has its own module while it requires additional agent configuration.
-Every other `kubernetes` modules depend on the situation like
-`ingress-nginx` useful only if Nginx Ingress Controller is used.
-* GCP `cloud-sql` module is broken down into `common` (for all 
-cloudsql instances) and engine specific module (for MySQL, 
-PostgreSQL) and `failover` because it will raise false alert if 
-deployed on master.
-
-### Variables
-
-Providing variables is the key to allow user adapt the behavior to 
-meet their requirement keeping an uniq code base.
-
-Some variables, considered as often useful at customization, are 
-mandatory and so, represent a templating rule like:
-
-* `*_aggregation_function` allows to set groups because dimensions
-could change depending on the environment (vm or containers based 
-infrastructure) or the configuration (`extraDimensions`, 
-`disableHostDimensions`, ..)
-* `*_transformation_function` could help to adapt sensitivity of 
-alerting rules depending on the situation. For example, choosing 
-`min` function with bigger timeframe and `>` threshold condition 
-comparison will make the detector more tolerant.
-* `filter_custom_*` to change included and / or excluded dimensions. 
-This will allow user limit the alerting scope to part of its resources. 
-It is possible to use multiple times the same module with different 
-filters for different configuration (thresholds, ...)
-* `*_threshold[_severity]` obviously give ability to change thresholds.
-* `*_disabled[_severity]` make it possible to disable alerting rule(s).
-
-### Default values
-
-Providing (or not) default values for variables could help (or force) 
-users to configure properly his monitoring.
-
-* define default value as recommendation for everybody.
-* do not define default value to make something specific obvious to user.
-For example, if it is not possible to advice a good generic threshold, so 
-do not set it will ask to user to define their own adapted to his use case.
-* if alerting rule is too dangerous or tricky to deploy it by default, it 
-is possible to disabled it by default to avoid to many false alerts and let 
-advanced users to configure it even so.
-
-### Filtering
-
-Default filtering follows a convention to make it possible to:
-
-* identify and separate the environment (i.e. `env` or `aws_tag_env` ..) 
-because if we should monitor same things for every environments we also 
-often want to define different recipients for example.
-* define and delimit the scope of alerting on specific resources (i.e. apply 
-detectors only on resources tagged with `sfx_monitored:true`
-* both `env` and `sfx_monitored` represent the general convention but it 
-could change depending on multiple factors. For example, GCP managed 
-services labels are not synced as dimensions into SignalFx which make 
-impossible to use `gcp_label_env` as we did for `aws_tag_env` and so 
-we use the `project_id` dimension instead.
-
-Custom filtering is always possible to use if user do not want or cannot 
-follow this convention. One or both of `filter_custom_includes` and 
-`filter_custom_excludes` could be used for that.
-
-### Severity
-
-Playing with [severities](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity) 
-will help to judge the criticity, the purpose and the scope of an alert. 
-Here are the binding followed:
-
-1. `Critical` for high priority alert waking up on call agent 24/7. 
-Notification is sent to alerting tool like Pagerduty. Often related to 
-availability or saturation of a resource.
-2. `Major` is similar to `Critical` but for incident which could wait to be 
-resolved during business hours. Also sent to alerting tool but with lower 
-priority to alert avoid notification during graceful period (i.e. the night).
-3. `Minor` will also generate notification but not disruptive this time like 
-Slack or email. The alert should and will be treated when agent is available. 
-Often related to performance degradation or proactive alerts.
-4. `Warning` should not notify at all but log the alert in a low priority 
-aggregator like a dashboard for proactive treatment or to help providing 
-troubleshooting inputs in case of more important problem.
-5. `Info` must not notify at all. Often used for debugging purpose or to 
-notice not incident events.
-
-__Note__: the `[*_]notifications` variables is a map/object which bind 
-each severity on its own list of recipients.
-
-### No data
-
-Think to no data and handle it. Indeed, often we create detectors on 
-real situations. It is good, but it is also important to think at how 
-they behave in no or few, irregular data presence.
-
-Take a load balancer 5xx errors percentage as example:
-
-* In most of the cases, load balancer will continually receive, at least, 
-few requests but not always. 
-* But for testing environment, we could expect to receive irregular traffic 
-depending on developpers tests.
-
-Imagine load balancer receive only one request resulting in 5xx error and 
-no more traffic after that during 24h: 
-
-* The percentage of errors will be considered as high (100%)
-* but not persisted enough time to want to raise alert
-* however, witohut traffic, no more data and this is the last dapatoint 
-which will determine the evaluation
-* given that this last datapoint is in error so the detector will raise 
-an alert which seem not relevant.
-
-To avoid this kind of undesired behavior we encourage to use [extrapolation 
-policy](https://docs.signalfx.com/en/latest/charts/chart-builder.html#extrapolation-policy-and-max-extrapolations-missing-datapoints) 
-or [fill](https://developers.signalfx.com/signalflow_analytics/methods/fill_stream_method.html) signalflow method.
+This is why all modules must provide, at least, these Terraform  
+[variables](https://github.com/claranet/terraform-signalfx-detectors/wiki/Variables) to enjoy this 
+templating and provide to the user common cutomization capabilities.
 
 
-### Documentation
+### Templating
 
-Adding a `README.md` at the root of the module providing:
+__Label__: 
+[templating](https://github.com/claranet/terraform-signalfx-detectors/labels/templating)
 
-* general documentation on the purpose of this module, its scope...
-* requirements listing
-* metrics collection how to (i.e. agent configuration sample)
-* usage example
-* notes about specificities or behavior
+__Issue__: Mandatory
 
-will help the users to understand and customize module to satisfy 
-their own constaints.
+This project respect some rules to create the modules and their detectors. It is constraining and 
+will eventually limit the usage in some cases but this allows to preserve homogeneity in 
+implementation, parity in features and it brings a common, repeatable and opinionated way to deploy, 
+configure and manage detectors.
 
+We want this template evolves from internal usage and community feedbacks to cover a larger scope of 
+usage and provide more flexibility in implementation. However, monitoring is a critical component for 
+most of the people and it is crucial for us to preserve the reliability of the underlying detectors.
+
+Too many customizations mechanisms fatally involve more complexity and make the code more difficult 
+to understand, review, maintain, test and to contribute to it. Sometimes we will prefer to abandon a 
+feature to keep it simple if it concerns to few users or implies too tricky or dangerous consequences.
+
+Every single and tiny change in these templating rules should be spread to the entire repository on 
+every detectors. This could be difficult to automate, source of mistakes and have undersired side 
+effects.
+
+That said, please open an issue to discuss, this could help us to notice and priorize some popular 
+features. And if you want to try to implement it yourself this could be the place to provide you help 
+and resources.
+
+At this time, we do not have a formal process for reviewing proposals that significantly change this 
+project, its primary usage patterns, and its defined template. Additionally, some seemingly simple 
+proposals can be difficult or time consuming to spread over every modules given that we want to keep 
+homogeinity as much as possible.
+
+### Continous Integration
+
+__Label__: 
+[CI](https://github.com/claranet/terraform-signalfx-detectors/labels/CI)
+
+__Issue__: Highly recommended because it could have deep implications but not required for simple 
+changes.
+
+CI related changes will generally be done by Claranet Team but if you try to implement an important 
+templating change as mentionned just above there is good chance you will need to update existing 
+tests or add new ones for your feature.
+
+Please ask to help and advices about this because the workflow could be not obvious.
+
+## Workflow
+
+### Issue
+
+Depending of the scope and the size of your change open an issue. If you feel enough confident, do 
+know well the code base, and do not need help feel free to go to the next step direclty.
+
+### Pull Request
+
+1. You are welcome to submit a [draft pull 
+request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) 
+for commentary or review before it is fully completed. It's also a good idea to include specific 
+questions or items you'd like feedback on.
+2. Once you believe your pull request is ready to be merged you can create your pull request.
+3. When time permits Claranet Team members will look over your contribution and either merge, or 
+provide comments letting you know if there is anything left to do. It may take some time for us 
+to respond. We may also have questions that we need answered about the code, either because 
+something doesn't make sense to us or because we want to understand your thought process. 
+4. If we have requested changes, you can either make those changes or, if you disagree with 
+the suggested changes, we can have a conversation about our reasoning and agree on a path 
+forward. This may be a multi-step process. Our view is that pull requests are a chance to 
+collaborate, and we welcome conversations about how to do things better. It is the contributor's 
+responsibility to address any changes requested. While reviewers are happy to give guidance, 
+it is unsustainable for us to perform the coding work necessary to get a PR into a mergeable state.
+5. Once all outstanding comments and checklist items have been addressed, your contribution will 
+be merged and should be included in the next release!
+6. In some cases, we might decide that a PR should be closed without merging. We'll make sure to 
+provide clear reasoning when this happens. Following the recommended process above is one of the 
+ways to ensure you don't spend time on a PR we can't or won't merge.
+
+### Speed up review and merge
+
+It is much easier to review pull requests that are:
+
+1. Well-documented: Try to explain in the pull request comments what your change does, why you have 
+made the change, and provide instructions for how to produce the new behavior introduced in the pull 
+request. If you can, provide screen captures or terminal output to show what the changes look like. 
+This helps the reviewers understand and test the change. This peace could belongs in existing Github 
+issue. In this case, add `fix #ISSUE_ID` in the Pull Request description. You can also add the 
+`#ISSUE_ID` in your commits.
+2. Small: Try to only make one change per pull request. If you found two bugs and want to fix them 
+both, that's *awesome*, but it's still best to submit the fixes as separate pull requests. This 
+makes it much easier for reviewers to keep in their heads all of the implications of individual 
+code changes, and that means the PR takes less effort and energy to merge. In general, the smaller 
+the pull request, the sooner reviewers will be able to make time to review it.
+3. Passing Tests: Based on how much time we have, we may not review pull requests which aren't 
+passing our tests (look below for advice on how to run unit tests). If you need help figuring out 
+why tests are failing, please feel free to ask, but while we're happy to give guidance it is 
+generally your responsibility to make sure that tests are passing.
+
+If we request changes, try to make those changes in a timely manner. Otherwise, PRs can go stale 
+and be a lot more work for all of us to merge in the future.
+
+Even with everyone making their best effort to be responsive, it can be time-consuming to get a 
+PR merged. It can be frustrating to deal with the back-and-forth as we make sure that we understand 
+the changes fully. Please bear with us, and please know that we appreciate the time and energy you 
+put into the project.
+
+### PR Checks
+
+The CI is broken down into 3 workflow:
+
+* the main workflow is dedicated to detectors. It will test the terraform code: fmt, deployment, 
+compliance, generated outputs ..
+
+* the generator workflow will test the jinja generator used to create new detectors deploying 
+sample detectors.
+
+* the documentation workflow will take care of generate and update documentation files and their 
+table of contents.
+
+Each workflow will run depending on files you modify but every executed workflow are mandatory 
+and must succeed.
+
+In case of errors, please check the Github actions logs to fix them. There are scripts available 
+to automate redundant tasks like [gen_outputs.sh](./scripts/gen_outputs) to update terraform 
+outputs for detectors.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -230,10 +230,8 @@ The CI is broken down into 3 workflow:
 
 * the main workflow is dedicated to detectors. It will test the terraform code: fmt, deployment, 
 compliance, generated outputs ..
-
 * the generator workflow will test the jinja generator used to create new detectors deploying 
 sample detectors.
-
 * the documentation workflow will take care of generate and update documentation files and their 
 table of contents.
 

--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@
 ## :loudspeaker: Goal
 
 This project aims to speed up alerting deployment and apply infrastructure as code 
-process to monitoring. It could also be a place to collect, share and improve 
-alerting rules on popular tools and environments through SignalFx and Terraform.
+process to your monitoring. It could also be a place to collect, share and improve 
+alerting rules on popular services and environments through SignalFx and Terraform.
 
 __Note__: These templates implementation is opinionated and enforce best practices 
-which ensure homogeneity but will also restrict the usage and capabilities even if 
-it tries to provide as much flexibility as possible.
+which ensure homogeneity but it will also restrict the usage and capabilities even 
+if it tries to provide as much flexibility as possible.
 
 ## :bell: Modules
 
@@ -41,7 +41,7 @@ Each module is fully independent and it is dedicated to monitor one service
 thanks to the metrics and information it provides. It contains:
 
 - Terraform source code to be use as module
-- Readme file containing instructions and notes specific to work with the module.
+- Readme file containing instructions and specific notes to work with the module.
 - Source, dependencies and sample configuration for metrics collection.
 
 ## :running: Usage
@@ -56,7 +56,7 @@ at deployment thanks to Terraform.
 
 ## :handshake: Contributing
 
-Contributions from community are most welcome!
+Contributions from the community are most welcome!
 
 There are many ways to contribute: writing code, add or improve detectors, 
 documentation, reporting issues, discussing better error tracking...

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SignalFx Detectors
+# Terraform SignalFx Detectors
 [![Maintainer](https://img.shields.io/badge/maintained%20by-claranet-red?style=flat-square)](https://www.claranet.fr/)
 [![License](https://img.shields.io/github/license/claranet/terraform-signalfx-detectors?style=flat-square)](LICENSE)
 [![Release](https://img.shields.io/github/v/release/claranet/terraform-signalfx-detectors?style=flat-square)](https://github.com/claranet/terraform-signalfx-detectors/releases)
@@ -6,23 +6,23 @@
 [![Terraform version](https://img.shields.io/badge/terraform-%3E%3D0.12.26-623CE4.svg?style=flat-square&logo=terraform)](https://github.com/hashicorp/terraform)
 [![Terraform registry](https://img.shields.io/badge/terraform-registry-623CE4.svg?style=flat-square&logo=terraform)](https://registry.terraform.io/modules/claranet/detectors/signalfx)
 
-> Most alerting rules are common to every users. Here is a place to "rule" them all! :gift: :rotating_light: :metal:
+> Many detectors alert could be common. Here is a place to "rule" them all! 🤘
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 :link: **Contents**
 
-- [:loudspeaker: Goal](#loudspeaker-goal)
-- [:bell: Modules](#bell-modules)
-- [:running: Usage](#running-usage)
-- [:handshake: Contributing](#handshake-contributing)
-- [:construction: Roadmap](#construction-roadmap)
-- [:warning: Changelog](#warning-changelog)
-- [:memo: License](#memo-license)
+- [🥅 Goal](#-goal)
+- [📦 Modules](#-modules)
+- [🚀 Usage](#-usage)
+- [🤝 Contributing](#-contributing)
+- [🚧 Roadmap](#-roadmap)
+- [🚨 Changelog](#-changelog)
+- [📝 License](#-license)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-## :loudspeaker: Goal
+## 🥅 Goal
 
 This project aims to speed up alerting deployment and apply infrastructure as code 
 process to your monitoring. It could also be a place to collect, share and improve 
@@ -32,7 +32,7 @@ __Note__: These templates implementation is opinionated and enforce best practic
 which ensure homogeneity but it will also restrict the usage and capabilities even 
 if it tries to provide as much flexibility as possible.
 
-## :bell: Modules
+## 📦 Modules
 
 This repository consists in a collection of generic pre-built detectors for SignalFx 
 broken down into multiple terraform modules in [modules](./modules/README.md) directory.
@@ -44,7 +44,7 @@ thanks to the metrics and information it provides. It contains:
 - Readme file containing instructions and specific notes to work with the module.
 - Source, dependencies and sample configuration for metrics collection.
 
-## :running: Usage
+## 🚀 Usage
 
 A module is a collection of [detectors 
 resource](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector) 
@@ -54,7 +54,7 @@ at deployment thanks to Terraform.
 
 [Instructions in Wiki](https://github.com/claranet/terraform-signalfx-detectors/wiki).
 
-## :handshake: Contributing
+## 🤝 Contributing
 
 Contributions from the community are most welcome!
 
@@ -63,19 +63,19 @@ documentation, reporting issues, discussing better error tracking...
 
 [Instructions in CONTRUBITING.md](CONTRIBUTING.md).
 
-## :construction: Roadmap
+## 🚧 Roadmap
 
 You can go to [github 
 milestones](https://github.com/claranet/terraform-signalfx-detectors/milestones) 
 to know what is planned in future versions browsing [available 
 issues](https://github.com/claranet/terraform-signalfx-detectors/issues).
 
-## :warning: Changelog
+## 🚨 Changelog
 
 Read carefully release notes of each [github 
 release](https://github.com/claranet/terraform-signalfx-detectors/releases) 
 before upgrading to a new version.
 
-## :memo: License
+## 📝 License
 
 [Mozilla Public License](https://www.mozilla.org/en-US/MPL/)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,81 @@
+# SignalFx Detectors
+[![Maintainer](https://img.shields.io/badge/maintained%20by-claranet-red?style=flat-square)](https://www.claranet.fr/)
+[![License](https://img.shields.io/github/license/claranet/terraform-signalfx-detectors?style=flat-square)](LICENSE)
+[![Release](https://img.shields.io/github/v/release/claranet/terraform-signalfx-detectors?style=flat-square)](https://github.com/claranet/terraform-signalfx-detectors/releases)
+[![Status](https://img.shields.io/github/workflow/status/claranet/terraform-signalfx-detectors/Detectors?style=flat-square&label=tests)](https://github.com/claranet/terraform-signalfx-detectors/actions?query=workflow%3ADetectors)
+[![Terraform version](https://img.shields.io/badge/terraform-%3E%3D0.12.26-623CE4.svg?style=flat-square&logo=terraform)](https://github.com/hashicorp/terraform)
+[![Terraform registry](https://img.shields.io/badge/terraform-registry-623CE4.svg?style=flat-square&logo=terraform)](https://registry.terraform.io/modules/claranet/detectors/signalfx)
+
+> Most alerting rules are common to every users. Here is a place to "rule" them all! :gift: :rotating_light: :metal:
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+:link: **Contents**
+
+- [:loudspeaker: Goal](#loudspeaker-goal)
+- [:bell: Modules](#bell-modules)
+- [:running: Usage](#running-usage)
+- [:handshake: Contributing](#handshake-contributing)
+- [:construction: Roadmap](#construction-roadmap)
+- [:warning: Changelog](#warning-changelog)
+- [:memo: License](#memo-license)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## :loudspeaker: Goal
+
+This project aims to speed up alerting deployment and apply infrastructure as code 
+process to monitoring. It could also be a place to collect, share and improve 
+alerting rules on popular tools and environments through SignalFx and Terraform.
+
+__Note__: These templates implementation is opinionated and enforce best practices 
+which ensure homogeneity but will also restrict the usage and capabilities even if 
+it tries to provide as much flexibility as possible.
+
+## :bell: Modules
+
+This repository consists in a collection of generic pre-built detectors for SignalFx 
+broken down into multiple terraform modules in [modules](./modules/README.md) directory.
+
+Each module is fully independent and it is dedicated to monitor one service 
+thanks to the metrics and information it provides. It contains:
+
+- Terraform source code to be use as module
+- Readme file containing instructions and notes specific to work with the module.
+- Source, dependencies and sample configuration for metrics collection.
+
+## :running: Usage
+
+A module is a collection of [detectors 
+resource](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector) 
+with global and per-detector variables available to adapt the default alerting 
+behavior to suit your requirements changing the underlying detectors configuration 
+at deployment thanks to Terraform.
+
+[Instructions in Wiki](https://github.com/claranet/terraform-signalfx-detectors/wiki).
+
+## :handshake: Contributing
+
+Contributions from community are most welcome!
+
+There are many ways to contribute: writing code, add or improve detectors, 
+documentation, reporting issues, discussing better error tracking...
+
+[Instructions in CONTRUBITING.md](CONTRIBUTING.md).
+
+## :construction: Roadmap
+
+You can go to [github 
+milestones](https://github.com/claranet/terraform-signalfx-detectors/milestones) 
+to know what is planned in future versions browsing [available 
+issues](https://github.com/claranet/terraform-signalfx-detectors/issues).
+
+## :warning: Changelog
+
+Read carefully release notes of each [github 
+release](https://github.com/claranet/terraform-signalfx-detectors/releases) 
+before upgrading to a new version.
+
+## :memo: License
+
+[Mozilla Public License](https://www.mozilla.org/en-US/MPL/)


### PR DESCRIPTION
close #96

Much documentation are now available on the github wiki https://github.com/claranet/terraform-signalfx-detectors/wiki

also related to: 
- #109 because it add automatic TOC gen from the CI
- #160 because it moves part of the contributing information into the wiki