### PR TITLE
haproxy: do not alert on backend limit by default

### DIFF
--- a/middleware/haproxy/detectors-haproxy.tf
+++ b/middleware/haproxy/detectors-haproxy.tf
@@ -61,7 +61,7 @@ resource "signalfx_detector" "session_limit" {
   name = format("%s %s", local.detector_name_prefix, "Haproxy session")
 
   program_text = <<-EOF
-    A = data('haproxy_session_current', filter=${module.filter-tags.filter_custom})${var.session_limit_aggregation_function}${var.session_limit_transformation_function}
+    A = data('haproxy_session_current', filter=filter('type', '0', '2') and ${module.filter-tags.filter_custom})${var.session_limit_aggregation_function}${var.session_limit_transformation_function}
     B = data('haproxy_session_limit', filter=${module.filter-tags.filter_custom})${var.session_limit_aggregation_function}${var.session_limit_transformation_function}
     signal = (A/B).scale(100).publish('signal')
     detect(when(signal > ${var.session_limit_threshold_critical})).publish('CRIT')


### PR DESCRIPTION
There are no real limits on the backend in Haproxy but there are on the `server` and `frontend` components.

The limit parameter on the `backend` is useful only if there is a `minconn` parameter on the server (see https://www.mail-archive.com/haproxy@formilux.org/msg26566.html). 

I think it is better to filter only on `server` and `frontend` by default to avoid unnecessary alerts.