### PR TITLE
Switch detector to nagios plugin

### DIFF
--- a/modules/smart-agent_nagios-status-check/README.md
+++ b/modules/smart-agent_nagios-status-check/README.md
@@ -86,40 +86,36 @@ Agent](https://github.com/signalfx/signalfx-agent). Check the "Related documenta
 information including the official documentation of this monitor.
 
 
-There is no SignalFx official integration for `Nagios` but there is still a 
-[monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/telegraf-exec.html) to use.
 
 ### Monitors
 
-You have to configure your existing Nagios script into the `telegraf/exec` monitor.
+This monitor is only available for agent `>= 5.7.1`. For prior versions, it is possible to use the 
+`telegraf/exec` monitor with `nagios` parser but you will not get the script result in event.
 
 You can configure as many monitors as you have nagios checks to reuse but you have to define for each 
-one at least:
-
-* the `dataFormat: nagios` in `telegrafParser` parameter to parse status from script exit code.
-* at least one dimension like `script` in `extraDimensions` to identify your check. If you do not 
-define `aggregation_function` and let empty as by default it will work for all dimensions you choose.
-
-Also it could be useful to adapt the `intervalSeconds` for each script.
+it could be useful to adapt the `intervalSeconds` for each script.
 
 ### Examples
 
 ```yaml
-- type: telegraf/exec
-  intervalSeconds: 180
-  command: /usr/local/bin/scripts/check-ipmitool.pl
-  extraDimensions:
-    script: check_ipmitool
-  telegrafParser:
-    dataFormat: nagios
-- type: telegraf/exec
-  intervalSeconds: 900  
-  command: /usr/local/bin/scripts/check-megaraidsas
-  extraDimensions:
-    script: check_megaraidsas
-  telegrafParser:
-    dataFormat: nagios
+globalDimensions:
+  sfx_monitored: true
+
+- type: nagios
+intervalSeconds: 180
+command: /usr/lib/nagios/plugins/check_ntp_time -H pool.ntp.typhon.net -w 0.5 -c 1
+service: NTP_TIME
+extraDimensions:
+  sfx_monitored: false
+
+- type: nagios
+intervalSeconds: 180
+command: /usr/lib/nagios/plugins/check_http -I google.fr -f sticky -H google.fr -s http -u / -p 80
+service: HTTP_google
 ```
+
+In this example, the first NTP check will not trigger any alert using default filtering convention but 
+the metric and its value will be available.
 
 
 ## Notes
@@ -130,15 +126,12 @@ respectively triggering `WARNING`, `CRITICAL` and `UNKNOWN` alert.
 
 While SignalFx does not provide `Unknown` severity this module uses the `Major` severity for unknown alerts.
 
-The metric is named `nagios_state.state`, you need to add an `extraDimensions` to your monitor in order to be 
-able to differantiate multiple script states.
+The metric is named `nagios.state`.
 
 
 ## Related documentation
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [Smart Agent monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/telegraf-exec.html)
+* [Smart Agent monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/nagios.html)
 * [Nagios checks guidelines](https://nagios-plugins.org/doc/guidelines.html#AEN78)
-* [Telegraf plugin exec](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/exec)
-* [Telegraf parser nagios](https://github.com/influxdata/telegraf/tree/master/plugins/parsers/nagios)

--- a/modules/smart-agent_nagios-status-check/conf/readme.yaml
+++ b/modules/smart-agent_nagios-status-check/conf/readme.yaml
@@ -8,8 +8,8 @@ source_doc: |
 
   ### Monitors
 
-  You have to configure your existing Nagios script into the `nagios` monitor.
-  This will require agent >= [5.7.1](https://github.com/signalfx/signalfx-agent/releases/tag/v5.7.1)
+  This monitor is only available for agent `>= 5.7.1`. For prior versions, it is possible to use the 
+  `telegraf/exec` monitor with `nagios` parser but you will not get the script result in event.
   
   You can configure as many monitors as you have nagios checks to reuse but you have to define for each 
   it could be useful to adapt the `intervalSeconds` for each script.
@@ -17,21 +17,24 @@ source_doc: |
   ### Examples
 
   ```yaml
+  globalDimensions:
+    sfx_monitored: true
+
   - type: nagios
   intervalSeconds: 180
   command: /usr/lib/nagios/plugins/check_ntp_time -H pool.ntp.typhon.net -w 0.5 -c 1
   service: NTP_TIME
   extraDimensions:
-    sfx_monitored: true
+    sfx_monitored: false
 
   - type: nagios
   intervalSeconds: 180
   command: /usr/lib/nagios/plugins/check_http -I google.fr -f sticky -H google.fr -s http -u / -p 80
-  service: HTT_google
-  extraDimensions:
-    sfx_monitored: true
-
+  service: HTTP_google
   ```
+  
+  In this example, the first NTP check will not trigger any alert using default filtering convention but 
+  the metric and its value will be available.
 
 notes: |
   This module has been designed to alert with the same behavior as 

--- a/modules/smart-agent_nagios-status-check/conf/readme.yaml
+++ b/modules/smart-agent_nagios-status-check/conf/readme.yaml
@@ -1,47 +1,36 @@
 documentations:
   - name: Smart Agent monitor
-    url: 'https://docs.signalfx.com/en/latest/integrations/agent/monitors/telegraf-exec.html'
+    url: 'https://docs.signalfx.com/en/latest/integrations/agent/monitors/nagios.html'
   - name: Nagios checks guidelines
     url: 'https://nagios-plugins.org/doc/guidelines.html#AEN78'
-  - name: Telegraf plugin exec
-    url: 'https://github.com/influxdata/telegraf/tree/master/plugins/inputs/exec'
-  - name: Telegraf parser nagios
-    url: 'https://github.com/influxdata/telegraf/tree/master/plugins/parsers/nagios'
 
 source_doc: |
-  There is no SignalFx official integration for `Nagios` but there is still a 
-  [monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/telegraf-exec.html) to use.
 
   ### Monitors
 
-  You have to configure your existing Nagios script into the `telegraf/exec` monitor.
+  You have to configure your existing Nagios script into the `nagios` monitor.
+  This will require agent >= [5.7.1](https://github.com/signalfx/signalfx-agent/releases/tag/v5.7.1)
   
   You can configure as many monitors as you have nagios checks to reuse but you have to define for each 
-  one at least:
-
-  * the `dataFormat: nagios` in `telegrafParser` parameter to parse status from script exit code.
-  * at least one dimension like `script` in `extraDimensions` to identify your check. If you do not 
-  define `aggregation_function` and let empty as by default it will work for all dimensions you choose.
-
-  Also it could be useful to adapt the `intervalSeconds` for each script.
+  it could be useful to adapt the `intervalSeconds` for each script.
 
   ### Examples
 
   ```yaml
-  - type: telegraf/exec
-    intervalSeconds: 180
-    command: /usr/local/bin/scripts/check-ipmitool.pl
-    extraDimensions:
-      script: check_ipmitool
-    telegrafParser:
-      dataFormat: nagios
-  - type: telegraf/exec
-    intervalSeconds: 900  
-    command: /usr/local/bin/scripts/check-megaraidsas
-    extraDimensions:
-      script: check_megaraidsas
-    telegrafParser:
-      dataFormat: nagios
+  - type: nagios
+  intervalSeconds: 180
+  command: /usr/lib/nagios/plugins/check_ntp_time -H pool.ntp.typhon.net -w 0.5 -c 1
+  service: NTP_TIME
+  extraDimensions:
+    sfx_monitored: true
+
+  - type: nagios
+  intervalSeconds: 180
+  command: /usr/lib/nagios/plugins/check_http -I google.fr -f sticky -H google.fr -s http -u / -p 80
+  service: HTT_google
+  extraDimensions:
+    sfx_monitored: true
+
   ```
 
 notes: |
@@ -51,5 +40,4 @@ notes: |
 
   While SignalFx does not provide `Unknown` severity this module uses the `Major` severity for unknown alerts.
 
-  The metric is named `nagios_state.state`, you need to add an `extraDimensions` to your monitor in order to be 
-  able to differantiate multiple script states.
+  The metric is named `nagios.state`.

--- a/modules/smart-agent_nagios-status-check/detectors-nagios-status-check.tf
+++ b/modules/smart-agent_nagios-status-check/detectors-nagios-status-check.tf
@@ -4,7 +4,7 @@ resource "signalfx_detector" "status_check" {
   authorized_writer_teams = var.authorized_writer_teams
 
   program_text = <<-EOF
-        signal = data('nagios_state.state', filter=${module.filter-tags.filter_custom})${var.status_check_aggregation_function}${var.status_check_transformation_function}.publish('signal')
+        signal = data('nagios.state', filter=${module.filter-tags.filter_custom})${var.status_check_aggregation_function}${var.status_check_transformation_function}.publish('signal')
         detect(when(signal == 1, lasting='${var.status_check_lasting_duration_seconds}s')).publish('WARN')
         detect(when(signal == 2, lasting='${var.status_check_lasting_duration_seconds}s')).publish('CRIT')
         detect(when(signal == 3, lasting='${var.status_check_lasting_duration_seconds}s')).publish('MAJOR')

--- a/modules/smart-agent_nagios-status-check/variables.tf
+++ b/modules/smart-agent_nagios-status-check/variables.tf
@@ -61,4 +61,3 @@ variable "status_check_lasting_duration_seconds" {
   type        = string
   default     = "900"
 }
-


### PR DESCRIPTION
Switch the detector to nagios.state instead of nagios_state.state.

This will work with the new monitor nagios activated on v5.7.0 of the agent : https://docs.signalfx.com/en/latest/integrations/agent/monitors/nagios.html

Also, enable runbook_url and tip for this detector.