### PR TITLE
Azure: Add global Storage Accounts detectors

### DIFF
--- a/modules/integration_azure-storage-account/README.md
+++ b/modules/integration_azure-storage-account/README.md
@@ -1,0 +1,114 @@
+# AZURE-STORAGE-ACCOUNT SignalFx detectors
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+:link: **Contents**
+
+- [How to use this module?](#how-to-use-this-module)
+- [What are the available detectors in this module?](#what-are-the-available-detectors-in-this-module)
+- [How to collect required metrics?](#how-to-collect-required-metrics)
+  - [Metrics](#metrics)
+- [Notes](#notes)
+- [Related documentation](#related-documentation)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## How to use this module?
+
+This directory defines a [Terraform](https://www.terraform.io/) 
+[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a 
+`module` configuration and setting its `source` parameter to URL of this folder:
+
+```hcl
+module "signalfx-detectors-integration-azure-storage-account" {
+  source = "github.com/claranet/terraform-signalfx-detectors.git//modules/integration_azure-storage-account?ref={revision}"
+
+  environment   = var.environment
+  notifications = local.notifications
+}
+```
+
+Note the following parameters:
+
+* `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required. 
+  Terraform uses it to specify subfolders within a Git repo (see [module
+  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch 
+  like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform 
+  [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source 
+  instead of `git` which is more flexible but less future-proof.
+
+* `environment`: Use this parameter to specify the 
+  [environment](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#environment) used by this 
+  instance of the module.
+  Its value will be added to the `prefixes` list at the start of the [detector 
+  name](https://github.com/claranet/terraform-signalfx-detectors/wiki/Templating#example).
+  In general, it will also be used in `filter-tags` sub-module to apply a
+  [filtering](https://github.com/claranet/terraform-signalfx-detectors/wiki/Guidance#filtering) based on our default 
+  [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
+
+* `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists 
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an 
+  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity) 
+  and its value is a list of recipients. Every recipients must respect the [detector notification 
+  format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
+  Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding) 
+  documentation to understand the recommended role of each severity.
+
+These 3 parameters alongs with all variables defined in [common-variables.tf](common-variables.tf) are common to all 
+[modules](../) in this repository. Other variables, specific to this module, are available in 
+[variables-gen.tf](variables-gen.tf).
+In general, the default configuration "works" but all of these Terraform 
+[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to 
+customize the detectors behavior to better fit your needs.
+
+Most of them represent usual tips and rules detailled in the 
+[guidance](https://github.com/claranet/terraform-signalfx-detectors/wiki/Guidance) documentation and listed in the 
+common [variables](https://github.com/claranet/terraform-signalfx-detectors/wiki/Variables) dedicated documentation.
+
+Feel free to explore the [wiki](https://github.com/claranet/terraform-signalfx-detectors/wiki) for more information about 
+general usage of this repository.
+
+## What are the available detectors in this module?
+
+This module creates the following SignalFx detectors which could contain one or multiple alerting rules:
+
+* Azure Storage Account capacity
+* Azure Storage Account count
+* Azure Storage Account egress
+* Azure Storage Account ingress
+* Azure Storage Account requests rate
+
+## How to collect required metrics?
+
+This module uses metrics available from 
+the [Azure integration](https://docs.signalfx.com/en/latest/integrations/azure-info.html) configurable 
+with this Terraform [module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/azure).
+
+
+
+
+### Metrics
+
+
+Here is the list of required metrics for detectors in this module.
+
+* `Egress`
+* `Ingress`
+* `Transactions`
+* `UsedCapacity`
+
+
+## Notes
+
+* Ingress default threshold value is set for US and Europe regions
+* Egress default threshold value is set for general-purpose v2 and Blob storage accounts
+
+
+## Related documentation
+
+* [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
+* [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
+* [Azure Monitor metrics for Storage Accounts](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftstoragestorageaccounts)
+* [Azure Storage Account limits](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/azure-subscription-service-limits#storage-limits)

--- a/modules/integration_azure-storage-account/common-locals.tf
+++ b/modules/integration_azure-storage-account/common-locals.tf
@@ -1,0 +1,1 @@
+../../common/module/locals.tf

--- a/modules/integration_azure-storage-account/common-modules.tf
+++ b/modules/integration_azure-storage-account/common-modules.tf
@@ -1,0 +1,7 @@
+module "filter-tags" {
+  source = "github.com/claranet/terraform-signalfx-detectors.git//common/filter-tags"
+
+  filter_defaults        = "filter('azure_tag_env', '${var.environment}') and filter('azure_tag_sfx_monitored', 'true')"
+  filter_custom_includes = var.filter_custom_includes
+  filter_custom_excludes = var.filter_custom_excludes
+}

--- a/modules/integration_azure-storage-account/common-variables.tf
+++ b/modules/integration_azure-storage-account/common-variables.tf
@@ -1,0 +1,1 @@
+../../common/module/variables.tf

--- a/modules/integration_azure-storage-account/common-versions.tf
+++ b/modules/integration_azure-storage-account/common-versions.tf
@@ -1,0 +1,1 @@
+../../common/module/versions.tf

--- a/modules/integration_azure-storage-account/conf/01-count.yaml
+++ b/modules/integration_azure-storage-account/conf/01-count.yaml
@@ -1,0 +1,19 @@
+module: "Azure Storage Account"
+name: "count"
+filtering: "filter('resource_type', 'Microsoft.Storage/storageAccounts') and filter('primary_aggregation_type', 'true')"
+aggregation: ".count(by=['subscription_id'])"
+transformation: ".min(over='1d')"
+signals:
+  capacity:
+    metric: "UsedCapacity"
+  signal:
+    formula:
+      capacity.fill(None, duration='1d')
+rules:
+  critical:
+    threshold: 245
+    comparator: ">"
+  major:
+    threshold: 240
+    comparator: ">"
+    dependency: critical

--- a/modules/integration_azure-storage-account/conf/02-capacity.yaml
+++ b/modules/integration_azure-storage-account/conf/02-capacity.yaml
@@ -1,0 +1,20 @@
+module: "Azure Storage Account"
+name: "capacity"
+filtering: "filter('resource_type', 'Microsoft.Storage/storageAccounts') and filter('primary_aggregation_type', 'true')"
+aggregation: ".fill(None, duration='1d').sum(by=['azure_resource_name', 'azure_resource_group_name', 'azure_region'])"
+transformation: ".min(over='1d')"
+value_unit: PiB
+signals:
+  capacity:
+    metric: "UsedCapacity"
+  signal:
+    formula:
+      capacity.scale(0.0000000000000008881784197001252) # Scale to PiB unit
+rules:
+  critical:
+    threshold: 4.8
+    comparator: ">"
+  major:
+    threshold: 4.5
+    comparator: ">"
+    dependency: critical

--- a/modules/integration_azure-storage-account/conf/03-ingress.yaml
+++ b/modules/integration_azure-storage-account/conf/03-ingress.yaml
@@ -1,0 +1,21 @@
+module: "Azure Storage Account"
+name: "ingress"
+filtering: "filter('resource_type', 'Microsoft.Storage/storageAccounts') and filter('primary_aggregation_type', 'true')"
+aggregation: ".sum(by=['azure_resource_name', 'azure_resource_group_name', 'azure_region'])"
+transformation: ".min(over='15m')"
+value_unit: "Gbps"
+signals:
+  ingress:
+    metric: "Ingress"
+    rollup: rate
+  signal:
+    formula:
+      ingress.scale(0.000000008) # Scale to Gb unit
+rules:
+  critical:
+    threshold: 9
+    comparator: ">"
+  major:
+    threshold: 8
+    comparator: ">"
+    dependency: critical

--- a/modules/integration_azure-storage-account/conf/04-egress.yaml
+++ b/modules/integration_azure-storage-account/conf/04-egress.yaml
@@ -1,0 +1,21 @@
+module: "Azure Storage Account"
+name: "egress"
+filtering: "filter('resource_type', 'Microsoft.Storage/storageAccounts') and filter('primary_aggregation_type', 'true')"
+aggregation: ".sum(by=['azure_resource_name', 'azure_resource_group_name', 'azure_region'])"
+transformation: ".min(over='15m')"
+value_unit: "Gbps"
+signals:
+  egress:
+    metric: "Egress"
+    rollup: rate
+  signal:
+    formula:
+      egress.scale(0.000000008) # Scale to Gb unit
+rules:
+  critical:
+    threshold: 48
+    comparator: ">"
+  major:
+    threshold: 45
+    comparator: ">"
+    dependency: critical

--- a/modules/integration_azure-storage-account/conf/05-requests-rate.yaml
+++ b/modules/integration_azure-storage-account/conf/05-requests-rate.yaml
@@ -1,0 +1,17 @@
+module: "Azure Storage Account"
+name: "requests rate"
+filtering: "filter('resource_type', 'Microsoft.Storage/storageAccounts') and filter('primary_aggregation_type', 'true')"
+aggregation: ".sum(by=['azure_resource_name', 'azure_resource_group_name', 'azure_region'])"
+transformation: ".min(over='15m')"
+signals:
+  signal:
+    metric: "Transactions"
+    rollup: rate
+rules:
+  critical:
+    threshold: 19000
+    comparator: ">"
+  major:
+    threshold: 18000
+    comparator: ">"
+    dependency: critical

--- a/modules/integration_azure-storage-account/conf/readme.yaml
+++ b/modules/integration_azure-storage-account/conf/readme.yaml
@@ -1,0 +1,9 @@
+notes: |
+  * Ingress default threshold value is set for US and Europe regions
+  * Egress default threshold value is set for general-purpose v2 and Blob storage accounts
+
+documentations:
+  - name: Azure Monitor metrics for Storage Accounts
+    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftstoragestorageaccounts'
+  - name: Azure Storage Account limits
+    url: 'https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/azure-subscription-service-limits#storage-limits'

--- a/modules/integration_azure-storage-account/detectors-gen.tf
+++ b/modules/integration_azure-storage-account/detectors-gen.tf
@@ -1,0 +1,204 @@
+resource "signalfx_detector" "count" {
+  name = format("%s %s", local.detector_name_prefix, "Azure Storage Account count")
+
+  authorized_writer_teams = var.authorized_writer_teams
+
+  program_text = <<-EOF
+    base_filtering = filter('resource_type', 'Microsoft.Storage/storageAccounts') and filter('primary_aggregation_type', 'true')
+    capacity = data('UsedCapacity', filter=base_filtering and ${module.filter-tags.filter_custom})${var.count_aggregation_function}${var.count_transformation_function}
+    signal = capacity.fill(None, duration='1d').publish('signal')
+    detect(when(signal > ${var.count_threshold_critical})).publish('CRIT')
+    detect(when(signal > ${var.count_threshold_major}) and when(signal <= ${var.count_threshold_critical})).publish('MAJOR')
+EOF
+
+  rule {
+    description           = "is too high > ${var.count_threshold_critical}"
+    severity              = "Critical"
+    detect_label          = "CRIT"
+    disabled              = coalesce(var.count_disabled_critical, var.count_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.count_notifications, "critical", []), var.notifications.critical)
+    runbook_url           = try(coalesce(var.count_runbook_url, var.runbook_url), "")
+    tip                   = var.count_tip
+    parameterized_subject = local.rule_subject
+    parameterized_body    = local.rule_body
+  }
+
+  rule {
+    description           = "is too high > ${var.count_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.count_disabled_major, var.count_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.count_notifications, "major", []), var.notifications.major)
+    runbook_url           = try(coalesce(var.count_runbook_url, var.runbook_url), "")
+    tip                   = var.count_tip
+    parameterized_subject = local.rule_subject
+    parameterized_body    = local.rule_body
+  }
+}
+
+resource "signalfx_detector" "capacity" {
+  name = format("%s %s", local.detector_name_prefix, "Azure Storage Account capacity")
+
+  authorized_writer_teams = var.authorized_writer_teams
+
+  viz_options {
+    label        = "signal"
+    value_suffix = "PiB"
+  }
+
+  program_text = <<-EOF
+    base_filtering = filter('resource_type', 'Microsoft.Storage/storageAccounts') and filter('primary_aggregation_type', 'true')
+    capacity = data('UsedCapacity', filter=base_filtering and ${module.filter-tags.filter_custom})${var.capacity_aggregation_function}${var.capacity_transformation_function}
+    signal = capacity.scale(0.0000000000000008881784197001252).publish('signal')
+    detect(when(signal > ${var.capacity_threshold_critical})).publish('CRIT')
+    detect(when(signal > ${var.capacity_threshold_major}) and when(signal <= ${var.capacity_threshold_critical})).publish('MAJOR')
+EOF
+
+  rule {
+    description           = "is too high > ${var.capacity_threshold_critical}PiB"
+    severity              = "Critical"
+    detect_label          = "CRIT"
+    disabled              = coalesce(var.capacity_disabled_critical, var.capacity_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.capacity_notifications, "critical", []), var.notifications.critical)
+    runbook_url           = try(coalesce(var.capacity_runbook_url, var.runbook_url), "")
+    tip                   = var.capacity_tip
+    parameterized_subject = local.rule_subject
+    parameterized_body    = local.rule_body
+  }
+
+  rule {
+    description           = "is too high > ${var.capacity_threshold_major}PiB"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.capacity_disabled_major, var.capacity_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.capacity_notifications, "major", []), var.notifications.major)
+    runbook_url           = try(coalesce(var.capacity_runbook_url, var.runbook_url), "")
+    tip                   = var.capacity_tip
+    parameterized_subject = local.rule_subject
+    parameterized_body    = local.rule_body
+  }
+}
+
+resource "signalfx_detector" "ingress" {
+  name = format("%s %s", local.detector_name_prefix, "Azure Storage Account ingress")
+
+  authorized_writer_teams = var.authorized_writer_teams
+
+  viz_options {
+    label        = "signal"
+    value_suffix = "Gbps"
+  }
+
+  program_text = <<-EOF
+    base_filtering = filter('resource_type', 'Microsoft.Storage/storageAccounts') and filter('primary_aggregation_type', 'true')
+    ingress = data('Ingress', filter=base_filtering and ${module.filter-tags.filter_custom}, rollup='rate')${var.ingress_aggregation_function}${var.ingress_transformation_function}
+    signal = ingress.scale(0.000000008).publish('signal')
+    detect(when(signal > ${var.ingress_threshold_critical})).publish('CRIT')
+    detect(when(signal > ${var.ingress_threshold_major}) and when(signal <= ${var.ingress_threshold_critical})).publish('MAJOR')
+EOF
+
+  rule {
+    description           = "is too high > ${var.ingress_threshold_critical}Gbps"
+    severity              = "Critical"
+    detect_label          = "CRIT"
+    disabled              = coalesce(var.ingress_disabled_critical, var.ingress_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.ingress_notifications, "critical", []), var.notifications.critical)
+    runbook_url           = try(coalesce(var.ingress_runbook_url, var.runbook_url), "")
+    tip                   = var.ingress_tip
+    parameterized_subject = local.rule_subject
+    parameterized_body    = local.rule_body
+  }
+
+  rule {
+    description           = "is too high > ${var.ingress_threshold_major}Gbps"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.ingress_disabled_major, var.ingress_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.ingress_notifications, "major", []), var.notifications.major)
+    runbook_url           = try(coalesce(var.ingress_runbook_url, var.runbook_url), "")
+    tip                   = var.ingress_tip
+    parameterized_subject = local.rule_subject
+    parameterized_body    = local.rule_body
+  }
+}
+
+resource "signalfx_detector" "egress" {
+  name = format("%s %s", local.detector_name_prefix, "Azure Storage Account egress")
+
+  authorized_writer_teams = var.authorized_writer_teams
+
+  viz_options {
+    label        = "signal"
+    value_suffix = "Gbps"
+  }
+
+  program_text = <<-EOF
+    base_filtering = filter('resource_type', 'Microsoft.Storage/storageAccounts') and filter('primary_aggregation_type', 'true')
+    egress = data('Egress', filter=base_filtering and ${module.filter-tags.filter_custom}, rollup='rate')${var.egress_aggregation_function}${var.egress_transformation_function}
+    signal = egress.scale(0.000000008).publish('signal')
+    detect(when(signal > ${var.egress_threshold_critical})).publish('CRIT')
+    detect(when(signal > ${var.egress_threshold_major}) and when(signal <= ${var.egress_threshold_critical})).publish('MAJOR')
+EOF
+
+  rule {
+    description           = "is too high > ${var.egress_threshold_critical}Gbps"
+    severity              = "Critical"
+    detect_label          = "CRIT"
+    disabled              = coalesce(var.egress_disabled_critical, var.egress_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.egress_notifications, "critical", []), var.notifications.critical)
+    runbook_url           = try(coalesce(var.egress_runbook_url, var.runbook_url), "")
+    tip                   = var.egress_tip
+    parameterized_subject = local.rule_subject
+    parameterized_body    = local.rule_body
+  }
+
+  rule {
+    description           = "is too high > ${var.egress_threshold_major}Gbps"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.egress_disabled_major, var.egress_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.egress_notifications, "major", []), var.notifications.major)
+    runbook_url           = try(coalesce(var.egress_runbook_url, var.runbook_url), "")
+    tip                   = var.egress_tip
+    parameterized_subject = local.rule_subject
+    parameterized_body    = local.rule_body
+  }
+}
+
+resource "signalfx_detector" "requests_rate" {
+  name = format("%s %s", local.detector_name_prefix, "Azure Storage Account requests rate")
+
+  authorized_writer_teams = var.authorized_writer_teams
+
+  program_text = <<-EOF
+    base_filtering = filter('resource_type', 'Microsoft.Storage/storageAccounts') and filter('primary_aggregation_type', 'true')
+    signal = data('Transactions', filter=base_filtering and ${module.filter-tags.filter_custom}, rollup='rate')${var.requests_rate_aggregation_function}${var.requests_rate_transformation_function}.publish('signal')
+    detect(when(signal > ${var.requests_rate_threshold_critical})).publish('CRIT')
+    detect(when(signal > ${var.requests_rate_threshold_major}) and when(signal <= ${var.requests_rate_threshold_critical})).publish('MAJOR')
+EOF
+
+  rule {
+    description           = "is too high > ${var.requests_rate_threshold_critical}"
+    severity              = "Critical"
+    detect_label          = "CRIT"
+    disabled              = coalesce(var.requests_rate_disabled_critical, var.requests_rate_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.requests_rate_notifications, "critical", []), var.notifications.critical)
+    runbook_url           = try(coalesce(var.requests_rate_runbook_url, var.runbook_url), "")
+    tip                   = var.requests_rate_tip
+    parameterized_subject = local.rule_subject
+    parameterized_body    = local.rule_body
+  }
+
+  rule {
+    description           = "is too high > ${var.requests_rate_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.requests_rate_disabled_major, var.requests_rate_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.requests_rate_notifications, "major", []), var.notifications.major)
+    runbook_url           = try(coalesce(var.requests_rate_runbook_url, var.runbook_url), "")
+    tip                   = var.requests_rate_tip
+    parameterized_subject = local.rule_subject
+    parameterized_body    = local.rule_body
+  }
+}
+

--- a/modules/integration_azure-storage-account/outputs.tf
+++ b/modules/integration_azure-storage-account/outputs.tf
@@ -1,0 +1,25 @@
+output "capacity" {
+  description = "Detector resource for capacity"
+  value       = signalfx_detector.capacity
+}
+
+output "count" {
+  description = "Detector resource for count"
+  value       = signalfx_detector.count
+}
+
+output "egress" {
+  description = "Detector resource for egress"
+  value       = signalfx_detector.egress
+}
+
+output "ingress" {
+  description = "Detector resource for ingress"
+  value       = signalfx_detector.ingress
+}
+
+output "requests_rate" {
+  description = "Detector resource for requests_rate"
+  value       = signalfx_detector.requests_rate
+}
+

--- a/modules/integration_azure-storage-account/variables-gen.tf
+++ b/modules/integration_azure-storage-account/variables-gen.tf
@@ -1,0 +1,310 @@
+# count detector
+
+variable "count_notifications" {
+  description = "Notification recipients list per severity overridden for count detector"
+  type        = map(list(string))
+  default     = {}
+}
+
+variable "count_aggregation_function" {
+  description = "Aggregation function and group by for count detector (i.e. \".mean(by=['host'])\")"
+  type        = string
+  default     = ".count(by=['subscription_id'])"
+}
+
+variable "count_transformation_function" {
+  description = "Transformation function for count detector (i.e. \".mean(over='5m')\")"
+  type        = string
+  default     = ".min(over='1d')"
+}
+
+variable "count_tip" {
+  description = "Suggested first course of action or any note useful for incident handling"
+  type        = string
+  default     = ""
+}
+
+variable "count_runbook_url" {
+  description = "URL like SignalFx dashboard or wiki page which can help to troubleshoot the incident cause"
+  type        = string
+  default     = ""
+}
+
+variable "count_disabled" {
+  description = "Disable all alerting rules for count detector"
+  type        = bool
+  default     = null
+}
+
+variable "count_disabled_critical" {
+  description = "Disable critical alerting rule for count detector"
+  type        = bool
+  default     = null
+}
+
+variable "count_disabled_major" {
+  description = "Disable major alerting rule for count detector"
+  type        = bool
+  default     = null
+}
+
+variable "count_threshold_critical" {
+  description = "Critical threshold for count detector"
+  type        = number
+  default     = 245
+}
+
+variable "count_threshold_major" {
+  description = "Major threshold for count detector"
+  type        = number
+  default     = 240
+}
+
+# capacity detector
+
+variable "capacity_notifications" {
+  description = "Notification recipients list per severity overridden for capacity detector"
+  type        = map(list(string))
+  default     = {}
+}
+
+variable "capacity_aggregation_function" {
+  description = "Aggregation function and group by for capacity detector (i.e. \".mean(by=['host'])\")"
+  type        = string
+  default     = ".fill(None, duration='1d').sum(by=['azure_resource_name', 'azure_resource_group_name', 'azure_region'])"
+}
+
+variable "capacity_transformation_function" {
+  description = "Transformation function for capacity detector (i.e. \".mean(over='5m')\")"
+  type        = string
+  default     = ".min(over='1d')"
+}
+
+variable "capacity_tip" {
+  description = "Suggested first course of action or any note useful for incident handling"
+  type        = string
+  default     = ""
+}
+
+variable "capacity_runbook_url" {
+  description = "URL like SignalFx dashboard or wiki page which can help to troubleshoot the incident cause"
+  type        = string
+  default     = ""
+}
+
+variable "capacity_disabled" {
+  description = "Disable all alerting rules for capacity detector"
+  type        = bool
+  default     = null
+}
+
+variable "capacity_disabled_critical" {
+  description = "Disable critical alerting rule for capacity detector"
+  type        = bool
+  default     = null
+}
+
+variable "capacity_disabled_major" {
+  description = "Disable major alerting rule for capacity detector"
+  type        = bool
+  default     = null
+}
+
+variable "capacity_threshold_critical" {
+  description = "Critical threshold for capacity detector in PiB"
+  type        = number
+  default     = 4.8
+}
+
+variable "capacity_threshold_major" {
+  description = "Major threshold for capacity detector in PiB"
+  type        = number
+  default     = 4.5
+}
+
+# ingress detector
+
+variable "ingress_notifications" {
+  description = "Notification recipients list per severity overridden for ingress detector"
+  type        = map(list(string))
+  default     = {}
+}
+
+variable "ingress_aggregation_function" {
+  description = "Aggregation function and group by for ingress detector (i.e. \".mean(by=['host'])\")"
+  type        = string
+  default     = ".sum(by=['azure_resource_name', 'azure_resource_group_name', 'azure_region'])"
+}
+
+variable "ingress_transformation_function" {
+  description = "Transformation function for ingress detector (i.e. \".mean(over='5m')\")"
+  type        = string
+  default     = ".min(over='15m')"
+}
+
+variable "ingress_tip" {
+  description = "Suggested first course of action or any note useful for incident handling"
+  type        = string
+  default     = ""
+}
+
+variable "ingress_runbook_url" {
+  description = "URL like SignalFx dashboard or wiki page which can help to troubleshoot the incident cause"
+  type        = string
+  default     = ""
+}
+
+variable "ingress_disabled" {
+  description = "Disable all alerting rules for ingress detector"
+  type        = bool
+  default     = null
+}
+
+variable "ingress_disabled_critical" {
+  description = "Disable critical alerting rule for ingress detector"
+  type        = bool
+  default     = null
+}
+
+variable "ingress_disabled_major" {
+  description = "Disable major alerting rule for ingress detector"
+  type        = bool
+  default     = null
+}
+
+variable "ingress_threshold_critical" {
+  description = "Critical threshold for ingress detector in Gbps"
+  type        = number
+  default     = 9
+}
+
+variable "ingress_threshold_major" {
+  description = "Major threshold for ingress detector in Gbps"
+  type        = number
+  default     = 8
+}
+
+# egress detector
+
+variable "egress_notifications" {
+  description = "Notification recipients list per severity overridden for egress detector"
+  type        = map(list(string))
+  default     = {}
+}
+
+variable "egress_aggregation_function" {
+  description = "Aggregation function and group by for egress detector (i.e. \".mean(by=['host'])\")"
+  type        = string
+  default     = ".sum(by=['azure_resource_name', 'azure_resource_group_name', 'azure_region'])"
+}
+
+variable "egress_transformation_function" {
+  description = "Transformation function for egress detector (i.e. \".mean(over='5m')\")"
+  type        = string
+  default     = ".min(over='15m')"
+}
+
+variable "egress_tip" {
+  description = "Suggested first course of action or any note useful for incident handling"
+  type        = string
+  default     = ""
+}
+
+variable "egress_runbook_url" {
+  description = "URL like SignalFx dashboard or wiki page which can help to troubleshoot the incident cause"
+  type        = string
+  default     = ""
+}
+
+variable "egress_disabled" {
+  description = "Disable all alerting rules for egress detector"
+  type        = bool
+  default     = null
+}
+
+variable "egress_disabled_critical" {
+  description = "Disable critical alerting rule for egress detector"
+  type        = bool
+  default     = null
+}
+
+variable "egress_disabled_major" {
+  description = "Disable major alerting rule for egress detector"
+  type        = bool
+  default     = null
+}
+
+variable "egress_threshold_critical" {
+  description = "Critical threshold for egress detector in Gbps"
+  type        = number
+  default     = 48
+}
+
+variable "egress_threshold_major" {
+  description = "Major threshold for egress detector in Gbps"
+  type        = number
+  default     = 45
+}
+
+# requests_rate detector
+
+variable "requests_rate_notifications" {
+  description = "Notification recipients list per severity overridden for requests_rate detector"
+  type        = map(list(string))
+  default     = {}
+}
+
+variable "requests_rate_aggregation_function" {
+  description = "Aggregation function and group by for requests_rate detector (i.e. \".mean(by=['host'])\")"
+  type        = string
+  default     = ".sum(by=['azure_resource_name', 'azure_resource_group_name', 'azure_region'])"
+}
+
+variable "requests_rate_transformation_function" {
+  description = "Transformation function for requests_rate detector (i.e. \".mean(over='5m')\")"
+  type        = string
+  default     = ".min(over='15m')"
+}
+
+variable "requests_rate_tip" {
+  description = "Suggested first course of action or any note useful for incident handling"
+  type        = string
+  default     = ""
+}
+
+variable "requests_rate_runbook_url" {
+  description = "URL like SignalFx dashboard or wiki page which can help to troubleshoot the incident cause"
+  type        = string
+  default     = ""
+}
+
+variable "requests_rate_disabled" {
+  description = "Disable all alerting rules for requests_rate detector"
+  type        = bool
+  default     = null
+}
+
+variable "requests_rate_disabled_critical" {
+  description = "Disable critical alerting rule for requests_rate detector"
+  type        = bool
+  default     = null
+}
+
+variable "requests_rate_disabled_major" {
+  description = "Disable major alerting rule for requests_rate detector"
+  type        = bool
+  default     = null
+}
+
+variable "requests_rate_threshold_critical" {
+  description = "Critical threshold for requests_rate detector"
+  type        = number
+  default     = 19000
+}
+
+variable "requests_rate_threshold_major" {
+  description = "Major threshold for requests_rate detector"
+  type        = number
+  default     = 18000
+}
+


### PR DESCRIPTION
Adding global storage account detector. 
Checks:
* overall capacity limit
* resources count limit
* ingress limit
* egress limit
* transactions rate limit

fixes #206 