### PR TITLE
#203 bunch of makefile improvements

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -34,8 +34,8 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Generate modules readmes
-      run: make readmes
+    - name: Generate modules doc
+      run: make doc
 
     - name: Check for changes
       run: git diff --exit-code

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SUPPORTED_COMMANDS := module
+SUPPORTED_COMMANDS := module modules doc gen detectors outputs
 SUPPORTS_MAKE_ARGS := $(findstring $(firstword $(MAKECMDGOALS)), $(SUPPORTED_COMMANDS))
 ifneq "$(SUPPORTS_MAKE_ARGS)" ""
   COMMAND_ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
@@ -14,6 +14,12 @@ else
 	REV := $(TAG)
 endif
 
+ifeq ($(COMMAND_ARGS),)
+	export FILTER := *
+else
+	export FILTER := $(COMMAND_ARGS)
+endif
+
 .PHONY: dev
 dev:
 	docker exec -ti terraform-signalfx-detectors bash -i || \
@@ -26,12 +32,12 @@ clean:
 	git checkout -- examples/stack/detectors.tf
 	git clean -df modules/
 
-.PHONY: doc
-doc: readmes toc
+.PHONY: modules
+modules: gen doc
 
-.PHONY: readmes
-readmes: 
-	./scripts/module/loop_wrapper.sh ./scripts/module/gen_doc.sh
+.PHONY: doc
+doc: 
+	CI=true	./scripts/module/loop_wrapper.sh ./scripts/module/gen_doc.sh
 
 .PHONY: toc
 toc: 
@@ -45,7 +51,7 @@ lint:
 	./scripts/module/loop_wrapper.sh ./scripts/module/lint.sh
 
 .PHONY: gen
-gen: outputs detectors
+gen: detectors outputs
 
 .PHONY: outputs
 outputs: 

--- a/docs/development.md
+++ b/docs/development.md
@@ -21,6 +21,7 @@ rules and templates homogeneous to all modules.
 - [Requirements](#requirements)
 - [Scripts](#scripts)
 - [Change types](#change-types)
+  - [TLDR](#tldr)
   - [Documentation](#documentation)
   - [Detectors](#detectors)
   - [Templating](#templating)
@@ -41,9 +42,39 @@ dependencies available to run useful commands detailed below.
 Now you have a ready dev env you can run `make` commands or directly use the underlying 
 [scripts](./scripts.md) or even some tools available in the container like `doctoc` or `j2`.
 
+Here are useful `make` commands for development purpose:
+
+- `dev`: the default and optional target run the container ready to run other commands
+- `clean` to clean directory and git diff related to `/modules`
+- `doc`: generate modules readmes
+- `detectors`: generate variables and resources terraform code for detectors
+- `outputs`: generate outputs terraform code for detectors
+- `module`: bootstrap a new, fresh, empty module directory where add detectors
+- `lint`: run `tflint` command
+
+Some alias exist to run multiple commands in once:
+
+- `gen`: `detectors` && `output`
+- `modules`: `gen` && `doc`
+- `check`: `lint` (for now)
+
+Most of the them can accept an argument:
+
+- `module`: the name of the new, fresh, empty module directory to bootstrap.
+- `modules`, `doc`, `gen`, `detectors`, `outputs`: the filter to target changes on a subset of module(s).
+
+For example you can run `make modules *system*` to update doc, detectors and outputs for all modules 
+matching `*system*` wildcard filter like `smart-agent_system-common`.
+
 ## Change types
 
 There are different automation tasks to perform depending on the change done in this repository.
+
+### TLDR
+
+Documentation below will guide you to understand what command to run depending on your change to 
+pass the related CI checks. If you prefer, you can run the `make modules` command which should 
+cover any common contribution types.
 
 ### Documentation
 
@@ -58,11 +89,9 @@ __Check__:
 also run `doctoc --github --title ':link: **Contents**' --maxlevel 3` on a specific module.
 
 * To update readme(s) of detectors modules you have to edit its underlying configuration 
-available in `conf/readme.yaml` of the module directory. Then you must run `make readmes` 
+available in `conf/readme.yaml` of the module directory. Then you must run `make doc` 
 to regenerate readmes. It uses the module [gen_doc.sh](../scripts/module/gen_doc.sh) script 
 under the hood so you also use it to update only one module provided as parameter.
-
-You can use `make doc` command which is equivalent to `make readmes && make toc`.
 
 ### Detectors
 
@@ -177,8 +206,6 @@ in markdown files.
 
 * __dead-links__: uses [markdown-link-check](https://github.com/marketplace/actions/markdown-link-check) 
 to find any broken links in markdown files.
-
-Both of these jobs consist of the `make doc` command.
 
 ### Generator
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -30,6 +30,11 @@ dependencies available to run useful commands detailed below.
 Now you have a ready dev env you can run `make` commands or directly use the underlying 
 [scripts](./scripts.md) or even some tools available in the container like `doctoc` or `j2`.
 
+Here are useful `make` commands for development purpose:
+
+- `stack` to generate a usable stack with all detectors imported in `examples/stack`.
+- `clean` to clean directory and git diff related to `make stack`.
+
 ## Stack
 
 To bootstrap a new stack usable for your project with all modules pre-imported and configured,

--- a/scripts/module/bootstrap.sh
+++ b/scripts/module/bootstrap.sh
@@ -25,10 +25,15 @@ if [[ -d "${TARGET}" ]]; then
 fi
 
 echo "Bootstrap module code in \"${TARGET}\""
-mkdir -p "${TARGET}"
+mkdir -p "${TARGET}/conf"
 for tf in common/module/*.tf; do 
     ln -s ../../${tf} ${TARGET}/common-${tf#"common/module/"}
 done
+cat <<EOF > "${TARGET}/conf/readme.yaml"
+documentations:
+
+source_doc:
+EOF
 
 #echo "Generate variables from template"
 #j2 ${TEMPLATES}/detector_vars.tf.j2 ${TEMPLATES}/examples/heartbeat-simple.yaml > ${TARGET}/variables.tf

--- a/scripts/module/gen_doc.sh
+++ b/scripts/module/gen_doc.sh
@@ -15,7 +15,10 @@ if [[ ${source_type} == "integration" ]]; then
 fi
 module=$(echo ${MODULE} | cut -d'_' -f 2)
 tf="$(./scripts/stack/gen_module.sh ${TARGET})"
-detectors="$(sed -n 's/^.*name.*=.*detector_name_prefix.*"\(.*\)")$/* \1/p' ${TARGET}/detectors-*.tf | sort -fdbiu)"
+detectors=""
+if compgen -G "${TARGET}/detectors-*.tf" > /dev/null; then 
+    detectors="$(sed -n 's/^.*name.*=.*detector_name_prefix.*"\(.*\)")$/* \1/p' ${TARGET}/detectors-*.tf | sort -fdbiu)"
+fi
 vars=
 if [ -f ${TARGET}/variables.tf ]; then
     vars="${vars},variables.tf"

--- a/scripts/module/loop_wrapper.sh
+++ b/scripts/module/loop_wrapper.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 set -ue -o pipefail
+if ! [ -v FILTER ]; then
+    FILTER="*"
+fi
 
 if [ $# -eq 0 ]; then
     echo "Needs to provide a script to run for each module as parameter"
@@ -15,6 +18,10 @@ MODULES=modules
 SCRIPT=$1
 shift
 
-for module in ${MODULES}/*/; do
+shopt -s nullglob
+for module in ${MODULES}/${FILTER}/; do
+    if ! [ -d "${module}" ]; then
+        continue
+    fi
     $SCRIPT ${module%"/"} $@
 done

--- a/scripts/templates/README.md
+++ b/scripts/templates/README.md
@@ -153,6 +153,5 @@ The modules readmes are generated from their yaml configuration located inside
 the module in `conf` directory.
 
 This template is used internally and it does not aims to be run manually.
-If you want to update modules readmes please use `make readmes` or 
-`make doc` if you want to also generate table of contents.
+If you want to update modules readmes please use `make doc`.
 

--- a/scripts/templates/readme.md.j2
+++ b/scripts/templates/readme.md.j2
@@ -92,7 +92,7 @@ organization](https://docs.signalfx.com/en/latest/integrations/integrations-refe
 There are always available and do not need any configuration to work.
 {%- endif %}
 
-{% if source_doc is defined -%}
+{% if source_doc is defined and source_doc is not none -%}
 {{ source_doc }}
 {%- endif %}
 
@@ -106,7 +106,7 @@ There are always available and do not need any configuration to work.
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-{% if documentations is defined -%}
+{% if documentations is defined and documentations is not none -%}
 {% for documentation in documentations -%}
 * [{{ documentation.name}}]({{ documentation.url }})
 {% endfor %}


### PR DESCRIPTION
close #203 

- toc is now a full separate target to use only when we want to check the entire repo
- so readmes target is simply dropped and doc becomes the target to gen modules readmes/doc
- all modules related target can now accept an argument which is a filter to limit the scope of execution. If no arg is provided the filter is "*" which correspond to all directories in `/modules`, else it will use it as filter for bash files expansion (so you can use either a full directory name like `make detectors smart-agent_system-common` or a wildcard based pattern like `make detectors *system*`).
- outputs target is now run AFTER detectors target to ensure outputs is always up to date and avoid to run it again
- new modules target allows to run all modules related targets in once to ease contribution (detectors, outputs, doc)
- the module target used to bootstrap a new module now also create the conf directory along with a its empty/minimal readme yaml config
- ci has been updated to support these changes
- We will wait the issuer approval @Shr3ps before to update related documentations (in repo and wiki)
