### PR TITLE
Add nodetool check detector

### DIFF
--- a/modules/smart-agent_cassandra-nodetool/README.md
+++ b/modules/smart-agent_cassandra-nodetool/README.md
@@ -1,4 +1,4 @@
-# CASSANDRA SignalFx detectors
+# CASSANDRA-NODETOOL SignalFx detectors
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
@@ -7,9 +7,7 @@
 - [How to use this module?](#how-to-use-this-module)
 - [What are the available detectors in this module?](#what-are-the-available-detectors-in-this-module)
 - [How to collect required metrics?](#how-to-collect-required-metrics)
-  - [Agent](#agent)
-  - [Monitors](#monitors)
-  - [JMX](#jmx)
+  - [Monitor configuration example:](#monitor-configuration-example)
   - [Metrics](#metrics)
 - [Notes](#notes)
 - [Related documentation](#related-documentation)
@@ -24,8 +22,8 @@ existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/G
 `module` configuration and setting its `source` parameter to URL of this folder:
 
 ```hcl
-module "signalfx-detectors-smart-agent-cassandra" {
-  source = "github.com/claranet/terraform-signalfx-detectors.git//modules/smart-agent_cassandra?ref={revision}"
+module "signalfx-detectors-smart-agent-cassandra-nodetool" {
+  source = "github.com/claranet/terraform-signalfx-detectors.git//modules/smart-agent_cassandra-nodetool?ref={revision}"
 
   environment   = var.environment
   notifications = local.notifications
@@ -61,7 +59,7 @@ Note the following parameters:
 
 These 3 parameters alongs with all variables defined in [common-variables.tf](common-variables.tf) are common to all 
 [modules](../) in this repository. Other variables, specific to this module, are available in 
-[variables.tf](variables.tf).
+[variables-gen.tf](variables-gen.tf).
 In general, the default configuration "works" but all of these Terraform 
 [variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to 
 customize the detectors behavior to better fit your needs.
@@ -77,16 +75,8 @@ general usage of this repository.
 
 This module creates the following SignalFx detectors which could contain one or multiple alerting rules:
 
-* Cassandra heartbeat
-* Cassandra read latency 99th percentile
-* Cassandra read latency real time
-* Cassandra storage exceptions count
-* Cassandra transactional read latency 99th percentile
-* Cassandra transactional read latency real time
-* Cassandra transactional write latency 99th percentile
-* Cassandra transactional write latency real time
-* Cassandra write latency 99th percentile
-* Cassandra write latency real time
+* Cassandra nodetool node state
+* Cassandra nodetool node status
 
 ## How to collect required metrics?
 
@@ -97,40 +87,31 @@ Agent](https://github.com/signalfx/signalfx-agent). Check the "Related documenta
 information including the official documentation of this monitor.
 
 
-Check the [integration 
-documentation](https://docs.signalfx.com/en/latest/integrations/integrations-reference/integrations.cassandra.html) 
-in addition to the monitor one which it uses.
 
-### Agent
+This detectors requires a groovy script to get the metrics `cassandra.status` and `cassandra.state`. The script can be found in the `scripts` folder of this module.
+`cassandra.status` and `cassandra.state` are metrics that track the state of the node in the cluster. The nodetool status command returns the equivalent information.
 
-The agent requires to [Java 
-plugin](https://docs.signalfx.com/en/latest/integrations/integrations-reference/integrations.java.html) 
-for Collectd which is already installed in the [SignalFx Smart 
-Agent](https://github.com/signalfx/signalfx-agent/).
+For example:
+```
+nodetool status mykeyspace
 
-### Monitors
+Datacenter: datacenter1
+=======================
+Status=Up/Down
+|/ State=Normal/Leaving/Joining/Moving
+--  Address    Load       Tokens  Owns    Host ID                               Rack
+UN  127.0.0.1  47.66 KB   1       33.3%   aaa1b7c1-6049-4a08-ad3e-3697a0e30e10  rack1
+UN  127.0.0.2  47.67 KB   1       33.3%   1848c369-4306-4874-afdf-5c1e95b8732e  rack1
+UN  127.0.0.3  47.67 KB   1       33.3%   49578bf1-728f-438d-b1c1-d8dd644b6f7f  rack1
+```
 
-You have to enable the following `extraMetrics` in your monitor configuration:
-
-* `counter.cassandra.Storage.Exceptions.Count`
-* `counter.cassandra.ClientRequest.Read.TotalLatency.Count`
-* `counter.cassandra.ClientRequest.Write.TotalLatency.Count`
-* `counter.cassandra.ClientRequest.CASRead.Latency.Count`
-* `counter.cassandra.ClientRequest.CASRead.TotalLatency.Count`
-* `counter.cassandra.ClientRequest.CASWrite.Latency.Count`
-* `counter.cassandra.ClientRequest.CASWrite.TotalLatency.Count`
-* `gauge.cassandra.ClientRequest.CASRead.Latency.99thPercentile`
-* `gauge.cassandra.ClientRequest.CASWrite.Latency.99thPercentile`
-
-Some of them are only available since agent version `v5.5.5` like `CASWrite` and `CAWRead`.
-
-### JMX
-
-This module uses the common Java runtime metrics for every JVM based applications.
-
-You must [enable JMX 
-Remote](https://docs.datastax.com/en/cassandra-oss/2.1/cassandra/security/secureJmxAuthentication.html) 
-on your `cassandra` servers.
+### Monitor configuration example:
+```
+- type: jmx
+  host: localhost
+  port: 7199
+  groovyScript: {"#from": "/etc/signalfx/cassandra.groovy", raw: true}
+```
 
 
 ### Metrics
@@ -144,34 +125,19 @@ the corresponding monitor configuration:
     datapointsToExclude:
       - metricNames:
         - '*'
-        - '!counter.cassandra.ClientRequest.CASRead.Latency.Count'
-        - '!counter.cassandra.ClientRequest.CASRead.TotalLatency.Count'
-        - '!counter.cassandra.ClientRequest.CASWrite.Latency.Count'
-        - '!counter.cassandra.ClientRequest.CASWrite.TotalLatency.Count'
-        - '!counter.cassandra.ClientRequest.Read.Latency.Count'
-        - '!counter.cassandra.ClientRequest.Read.TotalLatency.Count'
-        - '!counter.cassandra.ClientRequest.Write.Latency.Count'
-        - '!counter.cassandra.ClientRequest.Write.TotalLatency.Count'
-        - '!counter.cassandra.Storage.Exceptions.Count'
-        - '!counter.cassandra.Storage.Load.Count'
-        - '!gauge.cassandra.ClientRequest.CASRead.Latency.99thPercentile'
-        - '!gauge.cassandra.ClientRequest.CASWrite.Latency.99thPercentile'
-        - '!gauge.cassandra.ClientRequest.Read.Latency.99thPercentile'
-        - '!gauge.cassandra.ClientRequest.Write.Latency.99thPercentile'
+        - '!cassandra.state'
+        - '!cassandra.status'
 
 ```
 
 ## Notes
 
-You can collect more metrics than used in this module defining `mBeanDefinitions` parameter on your monitor 
-configuration for metrology or troubleshooting purposes.
-
-You can use `genericjmx` module as complement to this one to monitor generic JMX metrics.
+- cassandra.status: 1 == Live, 0 == Dead, -1 == Unknown
+- cassandra.state: 1 == Normal, 2 == Leave, 3 == Join
 
 
 ## Related documentation
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [Smart Agent monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/collectd-cassandra.html)
-* [Collectd plugin](https://collectd.org/wiki/index.php/Plugin:GenericJMX)
+* [Smart Agent monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/jmx.html)

--- a/modules/smart-agent_cassandra-nodetool/README.md
+++ b/modules/smart-agent_cassandra-nodetool/README.md
@@ -7,7 +7,8 @@
 - [How to use this module?](#how-to-use-this-module)
 - [What are the available detectors in this module?](#what-are-the-available-detectors-in-this-module)
 - [How to collect required metrics?](#how-to-collect-required-metrics)
-  - [Monitor configuration example:](#monitor-configuration-example)
+  - [Monitors](#monitors)
+  - [JMX](#jmx)
   - [Metrics](#metrics)
 - [Notes](#notes)
 - [Related documentation](#related-documentation)
@@ -88,10 +89,15 @@ information including the official documentation of this monitor.
 
 
 
-This detectors requires a groovy script to get the metrics `cassandra.status` and `cassandra.state`. The script can be found in the `scripts` folder of this module.
-`cassandra.status` and `cassandra.state` are metrics that track the state of the node in the cluster. The nodetool status command returns the equivalent information.
+This module leverages the powerful `JMX` monitor to retrieve equivalent information 
+from the output of [Cassandra 
+Nodetool](https://cassandra.apache.org/doc/latest/tools/nodetool/nodetool.html) like 
+the `status` and the `state` of a node and push them as metrics.
 
-For example:
+The advantage of this method is we do not need to make the agent able to run `nodetool` 
+command on Cassandra nodes (i.e. by configuring `sudo`) and rely on an unsafe output 
+parsing:
+
 ```
 nodetool status mykeyspace
 
@@ -105,13 +111,27 @@ UN  127.0.0.2  47.67 KB   1       33.3%   1848c369-4306-4874-afdf-5c1e95b8732e  
 UN  127.0.0.3  47.67 KB   1       33.3%   49578bf1-728f-438d-b1c1-d8dd644b6f7f  rack1
 ```
 
-### Monitor configuration example:
-```
+### Monitors
+
+You will need to put the [groovy script](./scripts/cassandra.groovy) in all your 
+cassandra nodes into `/etc/signalfx` directory then configure the `jmx` 
+monitor like the following:
+
+```yaml
 - type: jmx
   host: localhost
   port: 7199
   groovyScript: {"#from": "/etc/signalfx/cassandra.groovy", raw: true}
 ```
+
+### JMX
+
+This module uses the [Cassandra](https://cassandra.apache.org/doc/latest/operating/metrics.html) 
+specific metrics.
+
+You must [enable JMX 
+Remote](https://docs.datastax.com/en/cassandra-oss/2.1/cassandra/security/secureJmxAuthentication.html) 
+on your `cassandra` servers.
 
 
 ### Metrics
@@ -132,8 +152,10 @@ the corresponding monitor configuration:
 
 ## Notes
 
-- cassandra.status: 1 == Live, 0 == Dead, -1 == Unknown
-- cassandra.state: 1 == Normal, 2 == Leave, 3 == Join
+- this module could be a good addition to the main [cassandra](../smart-agent_cassandra/) 
+module.
+- `cassandra.status` possible values are `1 == Live`, `0 == Dead`, `-1 == Unknown`
+- `cassandra.state` possible values are `1 == Normal`, `2 == Leave`, `3 == Join`
 
 
 ## Related documentation

--- a/modules/smart-agent_cassandra-nodetool/common-locals.tf
+++ b/modules/smart-agent_cassandra-nodetool/common-locals.tf
@@ -1,0 +1,1 @@
+../../common/module/locals.tf

--- a/modules/smart-agent_cassandra-nodetool/common-modules.tf
+++ b/modules/smart-agent_cassandra-nodetool/common-modules.tf
@@ -1,0 +1,1 @@
+../../common/module/modules.tf

--- a/modules/smart-agent_cassandra-nodetool/common-variables.tf
+++ b/modules/smart-agent_cassandra-nodetool/common-variables.tf
@@ -1,0 +1,1 @@
+../../common/module/variables.tf

--- a/modules/smart-agent_cassandra-nodetool/common-versions.tf
+++ b/modules/smart-agent_cassandra-nodetool/common-versions.tf
@@ -1,0 +1,1 @@
+../../common/module/versions.tf

--- a/modules/smart-agent_cassandra-nodetool/conf/00-status.yaml
+++ b/modules/smart-agent_cassandra-nodetool/conf/00-status.yaml
@@ -1,0 +1,16 @@
+module: cassandra nodetool
+name: "Node status"
+transformation: ".min(over='10m')"
+aggregation: true
+signals:
+  signal:
+    metric: "cassandra.status"
+rules:
+  critical:
+    threshold: 0
+    comparator: "=="
+    description: "is dead"
+  minor:
+    threshold: 0
+    comparator: "<"
+    description: "is unknown"

--- a/modules/smart-agent_cassandra-nodetool/conf/01-state.yaml
+++ b/modules/smart-agent_cassandra-nodetool/conf/01-state.yaml
@@ -1,0 +1,13 @@
+module: cassandra nodetool
+name: "Node state"
+transformation: ".min(over='1h')"
+aggregation: true
+signals:
+  signal:
+    metric: "cassandra.state"
+rules:
+  critical:
+    threshold: 1
+    comparator: ">"
+    description: "is not normal"
+tip: "The node state may be in leaving/joining for too long. Check the nodetool status result"

--- a/modules/smart-agent_cassandra-nodetool/conf/readme.yaml
+++ b/modules/smart-agent_cassandra-nodetool/conf/readme.yaml
@@ -4,10 +4,15 @@ documentations:
 
 source_doc: |
 
-  This detectors requires a groovy script to get the metrics `cassandra.status` and `cassandra.state`. The script can be found in the `scripts` folder of this module.
-  `cassandra.status` and `cassandra.state` are metrics that track the state of the node in the cluster. The nodetool status command returns the equivalent information.
+  This module leverages the powerful `JMX` monitor to retrieve equivalent information 
+  from the output of [Cassandra 
+  Nodetool](https://cassandra.apache.org/doc/latest/tools/nodetool/nodetool.html) like 
+  the `status` and the `state` of a node and push them as metrics.
 
-  For example:
+  The advantage of this method is we do not need to make the agent able to run `nodetool` 
+  command on Cassandra nodes (i.e. by configuring `sudo`) and rely on an unsafe output 
+  parsing:
+
   ```
   nodetool status mykeyspace
 
@@ -21,14 +26,30 @@ source_doc: |
   UN  127.0.0.3  47.67 KB   1       33.3%   49578bf1-728f-438d-b1c1-d8dd644b6f7f  rack1
   ```
 
-  ### Monitor configuration example:
-  ```
+  ### Monitors
+
+  You will need to put the [groovy script](./scripts/cassandra.groovy) in all your 
+  cassandra nodes into `/etc/signalfx` directory then configure the `jmx` 
+  monitor like the following:
+
+  ```yaml
   - type: jmx
     host: localhost
     port: 7199
     groovyScript: {"#from": "/etc/signalfx/cassandra.groovy", raw: true}
   ```
 
+  ### JMX
+
+  This module uses the [Cassandra](https://cassandra.apache.org/doc/latest/operating/metrics.html) 
+  specific metrics.
+
+  You must [enable JMX 
+  Remote](https://docs.datastax.com/en/cassandra-oss/2.1/cassandra/security/secureJmxAuthentication.html) 
+  on your `cassandra` servers.
+
 notes : |
-  - cassandra.status: 1 == Live, 0 == Dead, -1 == Unknown
-  - cassandra.state: 1 == Normal, 2 == Leave, 3 == Join
+  - this module could be a good addition to the main [cassandra](../smart-agent_cassandra/) 
+  module.
+  - `cassandra.status` possible values are `1 == Live`, `0 == Dead`, `-1 == Unknown`
+  - `cassandra.state` possible values are `1 == Normal`, `2 == Leave`, `3 == Join`

--- a/modules/smart-agent_cassandra-nodetool/conf/readme.yaml
+++ b/modules/smart-agent_cassandra-nodetool/conf/readme.yaml
@@ -1,0 +1,34 @@
+documentations:
+  - name: Smart Agent monitor
+    url: 'https://docs.signalfx.com/en/latest/integrations/agent/monitors/jmx.html'
+
+source_doc: |
+
+  This detectors requires a groovy script to get the metrics `cassandra.status` and `cassandra.state`. The script can be found in the `scripts` folder of this module.
+  `cassandra.status` and `cassandra.state` are metrics that track the state of the node in the cluster. The nodetool status command returns the equivalent information.
+
+  For example:
+  ```
+  nodetool status mykeyspace
+
+  Datacenter: datacenter1
+  =======================
+  Status=Up/Down
+  |/ State=Normal/Leaving/Joining/Moving
+  --  Address    Load       Tokens  Owns    Host ID                               Rack
+  UN  127.0.0.1  47.66 KB   1       33.3%   aaa1b7c1-6049-4a08-ad3e-3697a0e30e10  rack1
+  UN  127.0.0.2  47.67 KB   1       33.3%   1848c369-4306-4874-afdf-5c1e95b8732e  rack1
+  UN  127.0.0.3  47.67 KB   1       33.3%   49578bf1-728f-438d-b1c1-d8dd644b6f7f  rack1
+  ```
+
+  ### Monitor configuration example:
+  ```
+  - type: jmx
+    host: localhost
+    port: 7199
+    groovyScript: {"#from": "/etc/signalfx/cassandra.groovy", raw: true}
+  ```
+
+notes : |
+  - cassandra.status: 1 == Live, 0 == Dead, -1 == Unknown
+  - cassandra.state: 1 == Normal, 2 == Leave, 3 == Join

--- a/modules/smart-agent_cassandra-nodetool/detectors-gen.tf
+++ b/modules/smart-agent_cassandra-nodetool/detectors-gen.tf
@@ -1,0 +1,59 @@
+resource "signalfx_detector" "node_status" {
+  name = format("%s %s", local.detector_name_prefix, "Cassandra nodetool node status")
+
+  authorized_writer_teams = var.authorized_writer_teams
+
+  program_text = <<-EOF
+    signal = data('cassandra.status', filter=${module.filter-tags.filter_custom})${var.node_status_aggregation_function}${var.node_status_transformation_function}.publish('signal')
+    detect(when(signal == ${var.node_status_threshold_critical})).publish('CRIT')
+    detect(when(signal < ${var.node_status_threshold_minor})).publish('MINOR')
+EOF
+
+  rule {
+    description           = "is dead == ${var.node_status_threshold_critical}"
+    severity              = "Critical"
+    detect_label          = "CRIT"
+    disabled              = coalesce(var.node_status_disabled_critical, var.node_status_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.node_status_notifications, "critical", []), var.notifications.critical)
+    runbook_url           = try(coalesce(var.node_status_runbook_url, var.runbook_url), "")
+    tip                   = var.node_status_tip
+    parameterized_subject = local.rule_subject
+    parameterized_body    = local.rule_body
+  }
+
+  rule {
+    description           = "is unknown < ${var.node_status_threshold_minor}"
+    severity              = "Minor"
+    detect_label          = "MINOR"
+    disabled              = coalesce(var.node_status_disabled_minor, var.node_status_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.node_status_notifications, "minor", []), var.notifications.minor)
+    runbook_url           = try(coalesce(var.node_status_runbook_url, var.runbook_url), "")
+    tip                   = var.node_status_tip
+    parameterized_subject = local.rule_subject
+    parameterized_body    = local.rule_body
+  }
+}
+
+resource "signalfx_detector" "node_state" {
+  name = format("%s %s", local.detector_name_prefix, "Cassandra nodetool node state")
+
+  authorized_writer_teams = var.authorized_writer_teams
+
+  program_text = <<-EOF
+    signal = data('cassandra.state', filter=${module.filter-tags.filter_custom})${var.node_state_aggregation_function}${var.node_state_transformation_function}.publish('signal')
+    detect(when(signal > ${var.node_state_threshold_critical})).publish('CRIT')
+EOF
+
+  rule {
+    description           = "is not normal > ${var.node_state_threshold_critical}"
+    severity              = "Critical"
+    detect_label          = "CRIT"
+    disabled              = coalesce(var.node_state_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.node_state_notifications, "critical", []), var.notifications.critical)
+    runbook_url           = try(coalesce(var.node_state_runbook_url, var.runbook_url), "")
+    tip                   = var.node_state_tip
+    parameterized_subject = local.rule_subject
+    parameterized_body    = local.rule_body
+  }
+}
+

--- a/modules/smart-agent_cassandra-nodetool/outputs.tf
+++ b/modules/smart-agent_cassandra-nodetool/outputs.tf
@@ -1,0 +1,10 @@
+output "node_state" {
+  description = "Detector resource for node_state"
+  value       = signalfx_detector.node_state
+}
+
+output "node_status" {
+  description = "Detector resource for node_status"
+  value       = signalfx_detector.node_status
+}
+

--- a/modules/smart-agent_cassandra-nodetool/scripts/cassandra.groovy
+++ b/modules/smart-agent_cassandra-nodetool/scripts/cassandra.groovy
@@ -1,0 +1,67 @@
+// Query the JMX endpoint for a single MBean.
+ss = util.queryJMX("org.apache.cassandra.db:type=StorageService").first()
+
+// Copied and modified from https://github.com/apache/cassandra
+def parseFileSize(String value) {
+	if (!value.matches("\\d+(\\.\\d+)? (GiB|KiB|MiB|TiB|bytes|GB|KB|MB|TB)")) {
+		throw new IllegalArgumentException(
+			String.format("value %s is not a valid human-readable file size", value));
+	}
+	if (value.endsWith(" TiB")) {
+		return Math.round(Double.valueOf(value.replace(" TiB", "")) * 1.1e12);
+	}
+	else if (value.endsWith(" GiB")) {
+		return Math.round(Double.valueOf(value.replace(" GiB", "")) * 1.074e9);
+	}
+	else if (value.endsWith(" KiB")) {
+		return Math.round(Double.valueOf(value.replace(" KiB", "")) * 1024);
+	}
+	else if (value.endsWith(" MiB")) {
+		return Math.round(Double.valueOf(value.replace(" MiB", "")) * 1.049e6);
+	}
+	else if (value.endsWith(" bytes")) {
+		return Math.round(Double.valueOf(value.replace(" bytes", "")));
+	}
+  else if (value.endsWith(" TB")) {
+		return Math.round(Double.valueOf(value.replace(" TB", "")) * 1e12);
+	}
+	else if (value.endsWith(" GB")) {
+		return Math.round(Double.valueOf(value.replace(" GB", "")) * 1e9);
+	}
+	else if (value.endsWith(" KB")) {
+		return Math.round(Double.valueOf(value.replace(" KB", "")) * 1e3);
+	}
+	else if (value.endsWith(" MB")) {
+		return Math.round(Double.valueOf(value.replace(" MB", "")) * 1e6);
+	}
+	else {
+		throw new IllegalStateException(String.format("FileUtils.parseFileSize() reached an illegal state parsing %s", value));
+	}
+}
+
+localEndpoint = ss.HostIdToEndpoint.get(ss.LocalHostId)
+dims = [host_id: ss.LocalHostId, cluster_name: ss.ClusterName]
+
+output.sendDatapoints([
+	// Equivalent of "Up/Down" in the `nodetool status` output.
+	// 1 = Live; 0 = Dead; -1 = Unknown
+	util.makeGauge(
+		"cassandra.status",
+		ss.LiveNodes.contains(localEndpoint) ? 1 : (ss.DeadNodes.contains(localEndpoint) ? 0 : -1),
+		dims),
+
+	util.makeGauge(
+		"cassandra.state",
+		ss.JoiningNodes.contains(localEndpoint) ? 3 : (ss.LeavingNodes.contains(localEndpoint) ? 2 : 1),
+		dims),
+
+	util.makeGauge(
+		"cassandra.load",
+		parseFileSize(ss.LoadString),
+		dims),
+
+	util.makeGauge(
+		"cassandra.ownership",
+		ss.Ownership.get(InetAddress.getByName(localEndpoint)),
+		dims)
+	])

--- a/modules/smart-agent_cassandra-nodetool/variables-gen.tf
+++ b/modules/smart-agent_cassandra-nodetool/variables-gen.tf
@@ -1,0 +1,108 @@
+# node_status detector
+
+variable "node_status_notifications" {
+  description = "Notification recipients list per severity overridden for node_status detector"
+  type        = map(list(string))
+  default     = {}
+}
+
+variable "node_status_aggregation_function" {
+  description = "Aggregation function and group by for node_status detector (i.e. \".mean(by=['host'])\")"
+  type        = string
+  default     = ""
+}
+
+variable "node_status_transformation_function" {
+  description = "Transformation function for node_status detector (i.e. \".mean(over='5m')\")"
+  type        = string
+  default     = ".min(over='10m')"
+}
+
+variable "node_status_tip" {
+  description = "Suggested first course of action or any note useful for incident handling"
+  type        = string
+  default     = ""
+}
+
+variable "node_status_runbook_url" {
+  description = "URL like SignalFx dashboard or wiki page which can help to troubleshoot the incident cause"
+  type        = string
+  default     = ""
+}
+
+variable "node_status_disabled" {
+  description = "Disable all alerting rules for node_status detector"
+  type        = bool
+  default     = null
+}
+
+variable "node_status_disabled_critical" {
+  description = "Disable critical alerting rule for node_status detector"
+  type        = bool
+  default     = null
+}
+
+variable "node_status_disabled_minor" {
+  description = "Disable minor alerting rule for node_status detector"
+  type        = bool
+  default     = null
+}
+
+variable "node_status_threshold_critical" {
+  description = "Critical threshold for node_status detector"
+  type        = number
+  default     = 0
+}
+
+variable "node_status_threshold_minor" {
+  description = "Minor threshold for node_status detector"
+  type        = number
+  default     = 0
+}
+
+# node_state detector
+
+variable "node_state_notifications" {
+  description = "Notification recipients list per severity overridden for node_state detector"
+  type        = map(list(string))
+  default     = {}
+}
+
+variable "node_state_aggregation_function" {
+  description = "Aggregation function and group by for node_state detector (i.e. \".mean(by=['host'])\")"
+  type        = string
+  default     = ""
+}
+
+variable "node_state_transformation_function" {
+  description = "Transformation function for node_state detector (i.e. \".mean(over='5m')\")"
+  type        = string
+  default     = ".min(over='1h')"
+}
+
+variable "node_state_tip" {
+  description = "Suggested first course of action or any note useful for incident handling"
+  type        = string
+  default     = <<-EOF
+    The node state may be in leaving/joining for too long. Check the nodetool status result
+EOF
+}
+
+variable "node_state_runbook_url" {
+  description = "URL like SignalFx dashboard or wiki page which can help to troubleshoot the incident cause"
+  type        = string
+  default     = ""
+}
+
+variable "node_state_disabled" {
+  description = "Disable all alerting rules for node_state detector"
+  type        = bool
+  default     = null
+}
+
+variable "node_state_threshold_critical" {
+  description = "Critical threshold for node_state detector"
+  type        = number
+  default     = 1
+}
+

--- a/modules/smart-agent_cassandra/README.md
+++ b/modules/smart-agent_cassandra/README.md
@@ -126,7 +126,8 @@ Some of them are only available since agent version `v5.5.5` like `CASWrite` and
 
 ### JMX
 
-This module uses the common Java runtime metrics for every JVM based applications.
+This module uses the [Cassandra](https://cassandra.apache.org/doc/latest/operating/metrics.html) 
+specific metrics.
 
 You must [enable JMX 
 Remote](https://docs.datastax.com/en/cassandra-oss/2.1/cassandra/security/secureJmxAuthentication.html) 

--- a/modules/smart-agent_cassandra/conf/readme.yaml
+++ b/modules/smart-agent_cassandra/conf/readme.yaml
@@ -34,7 +34,8 @@ source_doc: |
 
   ### JMX
 
-  This module uses the common Java runtime metrics for every JVM based applications.
+  This module uses the [Cassandra](https://cassandra.apache.org/doc/latest/operating/metrics.html) 
+  specific metrics.
 
   You must [enable JMX 
   Remote](https://docs.datastax.com/en/cassandra-oss/2.1/cassandra/security/secureJmxAuthentication.html) 

--- a/modules/smart-agent_cassandra/detectors-cassandra.tf
+++ b/modules/smart-agent_cassandra/detectors-cassandra.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
-    signal = data('gauge.cassandra.Storage.Load.Count', filter=${local.not_running_vm_filters} and ${module.filter-tags.filter_custom})${var.heartbeat_aggregation_function}.publish('signal')
+    signal = data('counter.cassandra.Storage.Load.Count', filter=${local.not_running_vm_filters} and ${module.filter-tags.filter_custom})${var.heartbeat_aggregation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}').publish('CRIT')
 EOF
 
@@ -342,4 +342,3 @@ EOF
     parameterized_body    = local.rule_body
   }
 }
-

--- a/modules/smart-agent_tomcat/README.md
+++ b/modules/smart-agent_tomcat/README.md
@@ -109,7 +109,8 @@ mBeans](https://github.com/signalfx/signalfx-agent/blob/master/pkg/monitors/coll
 
 ### JMX
 
-This module uses the common Java runtime metrics for every JVM based applications.
+This module uses the [Tomcat](https://cwiki.apache.org/confluence/display/TOMCAT/Monitoring) 
+specific metrics.
 
 You must [enable JMX Remote](https://tomcat.apache.org/tomcat-7.0-doc/monitoring.html#Enabling_JMX_Remote) 
 on your `tomcat` server(s).

--- a/modules/smart-agent_tomcat/conf/readme.yaml
+++ b/modules/smart-agent_tomcat/conf/readme.yaml
@@ -24,7 +24,8 @@ source_doc: |
 
   ### JMX
 
-  This module uses the common Java runtime metrics for every JVM based applications.
+  This module uses the [Tomcat](https://cwiki.apache.org/confluence/display/TOMCAT/Monitoring) 
+  specific metrics.
 
   You must [enable JMX Remote](https://tomcat.apache.org/tomcat-7.0-doc/monitoring.html#Enabling_JMX_Remote) 
   on your `tomcat` server(s).


### PR DESCRIPTION
This PR proposes to adds 2 detectors. These detectors verify that Cassandra node is up and running in the cluster.
This is the equivalent of a "nodetool status".
The metrics are reported via the signalfx agent and a groovy script (visible here: https://docs.signalfx.com/en/latest/integrations/agent/monitors/jmx.html)

For information, the metrics can return the following values:
- cassandra.status: 1 == Live, 0 == Dead, -1 == Unknown
- cassandra.state: 1 == Normal, 2 == Leave, 3 == Join

If the code "1" is not received for each metrics, then an alert will be triggered.
