### PR TITLE
generator: support custom description rule

### DIFF
--- a/scripts/templates/detector.tf.j2
+++ b/scripts/templates/detector.tf.j2
@@ -91,10 +91,14 @@ EOF
     {%- if type == 'heartbeat' %}
     description           = "has not reported in ${var.heartbeat_timeframe}"
     {%- else %}
-      {%- if '>' in rule.comparator %}
+      {%- if rule.description is defined and rule.description is string %}
+        {%- set compare_string = rule.description %}
+      {%- elif '>' in rule.comparator %}
         {%- set compare_string = 'is too high' %}
-      {%- else %}
+      {%- elif '<' in rule.comparator %}
         {%- set compare_string = 'is too low' %}
+      {%- else %}
+        {%- set compare_string = 'is' %}
       {%- endif %}
     description           = "{{ compare_string }} {{ rule.comparator }} ${var.{{ id }}_threshold_{{ severity }}}{{ value_unit | default("") }}"
     {%- endif %}

--- a/scripts/templates/values.yaml
+++ b/scripts/templates/values.yaml
@@ -179,10 +179,16 @@ rules:
 
     ## @param comparator - string - optional
     ## The comparator to use against last signal value used in "when()"
-    ### function to create the condition.
-    ## Should be one of ">", ">=", "<", "<=".
+    ## function to create the condition.
+    ## Should be one of ">", ">=", "<", "<=", "!=", "==".
     ## Required for "threshold" detector type" only.
     comparator:
+
+    ## @param description - string - optional
+    ## The custom description to set for this rule. If not defined, it will 
+    ## fill the default generic description based on threshold comparison
+    ## like: "is too low < " / "is too high >" / "is !=" / "is ==".
+    #description:
 
     ## @param dependency - string - optional
     ## Add dependency to a previously defined rule {{severity}}.


### PR DESCRIPTION
it add the ability to customize the rule description when it is not a simple threshold comparison (i.e. often when we use `==` or `!=` we do not want say "the service == 0" but "the service is dead").