### PR TITLE
fix find order by using bash glob

### DIFF
--- a/docs/severity.md
+++ b/docs/severity.md
@@ -297,7 +297,6 @@
 
 |Detector|Critical|Major|Minor|Warning|Info|
 |---|---|---|---|---|---|
-|Azure Application Gateway capacity units|-|X|-|-|-|
 |Azure Application Gateway heartbeat|X|-|-|-|-|
 |Azure Application Gateway has no request|X|-|-|-|-|
 |Azure Application Gateway backend connect time|X|X|-|-|-|
@@ -307,6 +306,7 @@
 |Azure Application Gateway 5xx error rate|X|X|-|-|-|
 |Azure Application Gateway backend 4xx error rate|X|X|-|-|-|
 |Azure Application Gateway backend 5xx error rate|X|X|-|-|-|
+|Azure Application Gateway capacity units|-|X|-|-|-|
 
 
 ## azure-azure-search
@@ -910,13 +910,13 @@
 
 |Detector|Critical|Major|Minor|Warning|Info|
 |---|---|---|---|---|---|
-|System disk space running out|-|X|-|-|-|
 |System heartbeat|X|-|-|-|-|
 |System cpu utilization|X|X|-|-|-|
 |System load 5m ratio|X|X|-|-|-|
 |System disk space utilization|X|X|-|-|-|
 |System disk inodes utilization|X|X|-|-|-|
 |System memory utilization|X|X|-|-|-|
+|System disk space running out|-|X|-|-|-|
 
 
 ## tomcat

--- a/modules/integration_azure-application-gateway/README.md
+++ b/modules/integration_azure-application-gateway/README.md
@@ -78,7 +78,6 @@ This module creates the following SignalFx detectors which could contain one or 
 
 |Detector|Critical|Major|Minor|Warning|Info|
 |---|---|---|---|---|---|
-|Azure Application Gateway capacity units|-|X|-|-|-|
 |Azure Application Gateway heartbeat|X|-|-|-|-|
 |Azure Application Gateway has no request|X|-|-|-|-|
 |Azure Application Gateway backend connect time|X|X|-|-|-|
@@ -88,6 +87,7 @@ This module creates the following SignalFx detectors which could contain one or 
 |Azure Application Gateway 5xx error rate|X|X|-|-|-|
 |Azure Application Gateway backend 4xx error rate|X|X|-|-|-|
 |Azure Application Gateway backend 5xx error rate|X|X|-|-|-|
+|Azure Application Gateway capacity units|-|X|-|-|-|
 
 ## How to collect required metrics?
 

--- a/modules/smart-agent_system-common/README.md
+++ b/modules/smart-agent_system-common/README.md
@@ -76,13 +76,13 @@ This module creates the following SignalFx detectors which could contain one or 
 
 |Detector|Critical|Major|Minor|Warning|Info|
 |---|---|---|---|---|---|
-|System disk space running out|-|X|-|-|-|
 |System heartbeat|X|-|-|-|-|
 |System cpu utilization|X|X|-|-|-|
 |System load 5m ratio|X|X|-|-|-|
 |System disk space utilization|X|X|-|-|-|
 |System disk inodes utilization|X|X|-|-|-|
 |System memory utilization|X|X|-|-|-|
+|System disk space running out|-|X|-|-|-|
 
 ## How to collect required metrics?
 

--- a/scripts/module/gen_severity.sh
+++ b/scripts/module/gen_severity.sh
@@ -13,8 +13,7 @@ if [[ ${SEV_GLOBAL} == "true" ]]; then
 fi
 echo -e "|Detector|Critical|Major|Minor|Warning|Info|\n|---|---|---|---|---|---|"
 
-for tf in $(find ${TARGET} -name "detectors-*.tf")
-do
+for tf in ${TARGET}/detectors-*.tf; do
     line_table=""
     while read line  
     do


### PR DESCRIPTION
files list order from find command depends on the filesystem entry and could lead to different environment depending on the environment despite docker.