### PR TITLE
add teams common variable

### DIFF
--- a/common/module/variables.tf
+++ b/common/module/variables.tf
@@ -52,3 +52,15 @@ variable "authorized_writer_teams" {
   default     = null
 }
 
+
+variable "authorized_writer_teams" {
+  description = "List of teams IDs authorized (with admins) to edit the detector. If defined, it requires an user token to work"
+  type        = list(string)
+  default     = null
+}
+
+variable "teams" {
+  description = "List of teams IDs to associate the detector to"
+  type        = list(string)
+  default     = null
+}

--- a/common/module/variables.tf
+++ b/common/module/variables.tf
@@ -55,5 +55,5 @@ variable "authorized_writer_teams" {
 variable "teams" {
   description = "List of teams IDs to associate the detector to"
   type        = list(string)
-  default     = null
+  default     = []
 }

--- a/common/module/variables.tf
+++ b/common/module/variables.tf
@@ -52,13 +52,6 @@ variable "authorized_writer_teams" {
   default     = null
 }
 
-
-variable "authorized_writer_teams" {
-  description = "List of teams IDs authorized (with admins) to edit the detector. If defined, it requires an user token to work"
-  type        = list(string)
-  default     = null
-}
-
 variable "teams" {
   description = "List of teams IDs to associate the detector to"
   type        = list(string)

--- a/modules/integration_aws-alb/detectors-alb.tf
+++ b/modules/integration_aws-alb/detectors-alb.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "heartbeat" {
   name = format("%s %s", local.detector_name_prefix, "AWS ALB heartbeat")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
@@ -26,6 +27,7 @@ resource "signalfx_detector" "no_healthy_instances" {
   name = format("%s %s", local.detector_name_prefix, "AWS ALB healthy instances percentage")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('HealthyHostCount', filter=filter('namespace', 'AWS/ApplicationELB') and filter('stat', 'lower') and (not filter('AvailabilityZone', '*')) and ${module.filter-tags.filter_custom})${var.no_healthy_instances_aggregation_function}${var.no_healthy_instances_transformation_function}
@@ -64,6 +66,7 @@ resource "signalfx_detector" "latency" {
   name = format("%s %s", local.detector_name_prefix, "AWS ALB latency")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('TargetResponseTime', filter=filter('namespace', 'AWS/ApplicationELB') and filter('stat', 'mean') and filter('TargetGroup', '*') and (not filter('AvailabilityZone', '*')) and ${module.filter-tags.filter_custom}, extrapolation='zero', rollup='average')${var.latency_aggregation_function}${var.latency_transformation_function}.publish('signal')
@@ -100,6 +103,7 @@ resource "signalfx_detector" "alb_5xx" {
   name = format("%s %s", local.detector_name_prefix, "AWS ALB 5xx error rate")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('HTTPCode_ELB_5XX_Count', filter=filter('namespace', 'AWS/ApplicationELB') and filter('stat', 'sum') and (not filter('AvailabilityZone', '*')) and ${module.filter-tags.filter_custom}, extrapolation='zero', rollup='sum')${var.alb_5xx_aggregation_function}${var.alb_5xx_transformation_function}
@@ -138,6 +142,7 @@ resource "signalfx_detector" "alb_4xx" {
   name = format("%s %s", local.detector_name_prefix, "AWS ALB 4xx error rate")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('HTTPCode_ELB_4XX_Count', filter=filter('namespace', 'AWS/ApplicationELB') and filter('stat', 'sum') and (not filter('AvailabilityZone', '*')) and ${module.filter-tags.filter_custom}, extrapolation='zero', rollup='sum')${var.alb_4xx_aggregation_function}${var.alb_4xx_transformation_function}
@@ -176,6 +181,7 @@ resource "signalfx_detector" "target_5xx" {
   name = format("%s %s", local.detector_name_prefix, "AWS ALB target 5xx error rate")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('HTTPCode_Target_5XX_Count', filter=filter('namespace', 'AWS/ApplicationELB') and filter('stat', 'sum') and filter('TargetGroup', '*') and (not filter('AvailabilityZone', '*')) and ${module.filter-tags.filter_custom}, extrapolation='zero', rollup='sum')${var.target_5xx_aggregation_function}${var.target_5xx_transformation_function}
@@ -214,6 +220,7 @@ resource "signalfx_detector" "target_4xx" {
   name = format("%s %s", local.detector_name_prefix, "AWS ALB target 4xx error rate")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('HTTPCode_Target_4XX_Count', filter=filter('namespace', 'AWS/ApplicationELB') and filter('stat', 'sum') and filter('TargetGroup', '*') and (not filter('AvailabilityZone', '*')) and ${module.filter-tags.filter_custom}, extrapolation='zero', rollup='sum')${var.target_4xx_aggregation_function}${var.target_4xx_transformation_function}

--- a/modules/integration_aws-apigateway/detectors-api.tf
+++ b/modules/integration_aws-apigateway/detectors-api.tf
@@ -3,6 +3,7 @@ resource "signalfx_detector" "latency" {
   name = format("%s %s", local.detector_name_prefix, "AWS ApiGateway latency")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('Latency', filter=filter('namespace', 'AWS/ApiGateway') and filter('stat', 'sum') and (not filter('Stage', '*')) and (not filter('Method', '*')) and (not filter('Resource', '*')) and ${module.filter-tags.filter_custom}, extrapolation='zero', rollup='average')${var.latency_aggregation_function}${var.latency_transformation_function}.publish('signal')
@@ -40,6 +41,7 @@ resource "signalfx_detector" "http_5xx" {
   name = format("%s %s", local.detector_name_prefix, "AWS ApiGateway HTTP 5xx error rate")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('${var.is_v2 ? "5xx" : "5XXError"}', filter=filter('namespace', 'AWS/ApiGateway') and filter('stat', 'sum') and (not filter('Stage', '*')) and (not filter('Method', '*')) and (not filter('Resource', '*')) and ${module.filter-tags.filter_custom}, extrapolation='zero', rollup='sum')${var.http_5xx_aggregation_function}${var.http_5xx_transformation_function}
@@ -79,6 +81,7 @@ resource "signalfx_detector" "http_4xx" {
   name = format("%s %s", local.detector_name_prefix, "AWS ApiGateway HTTP 4xx error rate")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('${var.is_v2 ? "4xx" : "4XXError"}', filter=filter('namespace', 'AWS/ApiGateway') and filter('stat', 'sum') and (not filter('Stage', '*')) and (not filter('Method', '*')) and (not filter('Resource', '*')) and ${module.filter-tags.filter_custom}, extrapolation='zero', rollup='sum')${var.http_4xx_aggregation_function}${var.http_4xx_transformation_function}

--- a/modules/integration_aws-beanstalk/detectors-beanstalk.tf
+++ b/modules/integration_aws-beanstalk/detectors-beanstalk.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "heartbeat" {
   name = format("%s %s", local.detector_name_prefix, "AWS Beanstalk heartbeat")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
@@ -26,6 +27,7 @@ resource "signalfx_detector" "health" {
   name = format("%s %s", local.detector_name_prefix, "AWS Beanstalk environment health")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('EnvironmentHealth', filter=filter('namespace', 'AWS/ElasticBeanstalk') and filter('stat', 'upper') and ${module.filter-tags.filter_custom})${var.health_aggregation_function}${var.health_transformation_function}.publish('signal')
@@ -62,6 +64,7 @@ resource "signalfx_detector" "latency_p90" {
   name = format("%s %s", local.detector_name_prefix, "AWS Beanstalk application latency p90")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('ApplicationLatencyP90', filter=filter('namespace', 'AWS/ElasticBeanstalk') and filter('stat', 'lower') and (not filter('InstanceId', '*')) and ${module.filter-tags.filter_custom})${var.latency_p90_aggregation_function}${var.latency_p90_transformation_function}.publish('signal')
@@ -98,6 +101,7 @@ resource "signalfx_detector" "app_5xx_error_rate" {
   name = format("%s %s", local.detector_name_prefix, "AWS Beanstalk application 5xx error rate")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('ApplicationRequests5xx', filter=filter('namespace', 'AWS/ElasticBeanstalk') and filter('stat', 'sum') and (not filter('InstanceId', '*')) and ${module.filter-tags.filter_custom})${var.app_5xx_error_rate_aggregation_function}${var.app_5xx_error_rate_transformation_function}
@@ -137,6 +141,7 @@ resource "signalfx_detector" "root_filesystem_usage" {
   name = format("%s %s", local.detector_name_prefix, "AWS Beanstalk instance root filesystem usage")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('RootFilesystemUtil', filter=filter('namespace', 'AWS/ElasticBeanstalk') and filter('stat', 'lower') and (not filter('InstanceId', '*')) and ${module.filter-tags.filter_custom})${var.root_filesystem_usage_aggregation_function}${var.root_filesystem_usage_transformation_function}.publish('signal')

--- a/modules/integration_aws-ecs-cluster/detectors-ecs-cluster.tf
+++ b/modules/integration_aws-ecs-cluster/detectors-ecs-cluster.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "heartbeat" {
   name = format("%s %s", local.detector_name_prefix, "AWS ECS heartbeat")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
@@ -26,6 +27,7 @@ resource "signalfx_detector" "cpu_utilization" {
   name = format("%s %s", local.detector_name_prefix, "AWS ECS cluster CPU utilization")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('CPUUtilization', filter=filter('namespace', 'AWS/ECS') and filter('stat', 'mean') and not filter('ServiceName', '*') and ${module.filter-tags.filter_custom}).mean(by=['ClusterName'])${var.cpu_utilization_aggregation_function}${var.cpu_utilization_transformation_function}.publish('signal')
@@ -62,6 +64,7 @@ resource "signalfx_detector" "memory_utilization" {
   name = format("%s %s", local.detector_name_prefix, "AWS ECS cluster memory utilization")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('MemoryUtilization', filter=filter('namespace', 'AWS/ECS') and filter('stat', 'mean') and not filter('ServiceName', '*') and ${module.filter-tags.filter_custom}).mean(by=['ClusterName'])${var.memory_utilization_aggregation_function}${var.memory_utilization_transformation_function}.publish('signal')

--- a/modules/integration_aws-ecs-service/detectors-ecs-service.tf
+++ b/modules/integration_aws-ecs-service/detectors-ecs-service.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "heartbeat" {
   name = format("%s %s", local.detector_name_prefix, "AWS ECS heartbeat")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
@@ -27,6 +28,7 @@ resource "signalfx_detector" "cpu_utilization" {
   name = format("%s %s", local.detector_name_prefix, "AWS ECS service CPU utilization")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('CPUUtilization', filter=filter('namespace', 'AWS/ECS') and filter('stat', 'mean') and filter('ServiceName', '*') and ${module.filter-tags.filter_custom}).mean(by=['ServiceName'])${var.cpu_utilization_aggregation_function}${var.cpu_utilization_transformation_function}.publish('signal')
@@ -63,6 +65,7 @@ resource "signalfx_detector" "memory_utilization" {
   name = format("%s %s", local.detector_name_prefix, "AWS ECS service memory utilization")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('MemoryUtilization', filter=filter('namespace', 'AWS/ECS') and filter('stat', 'mean') and filter('ServiceName', '*') and ${module.filter-tags.filter_custom}).mean(by=['ServiceName'])${var.memory_utilization_aggregation_function}${var.memory_utilization_transformation_function}.publish('signal')

--- a/modules/integration_aws-elasticache-common/detectors-elasticache.tf
+++ b/modules/integration_aws-elasticache-common/detectors-elasticache.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "heartbeat" {
   name = format("%s %s", local.detector_name_prefix, "AWS ElastiCache heartbeat")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
@@ -26,6 +27,7 @@ resource "signalfx_detector" "evictions" {
   name = format("%s %s", local.detector_name_prefix, "AWS ElastiCache evictions")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('Evictions', filter=filter('namespace', 'AWS/ElastiCache') and filter('stat', 'mean') and filter('CacheNodeId', '*') and ${module.filter-tags.filter_custom})${var.evictions_aggregation_function}${var.evictions_transformation_function}.publish('signal')
@@ -62,6 +64,7 @@ resource "signalfx_detector" "max_connection" {
   name = format("%s %s", local.detector_name_prefix, "AWS ElastiCache connections over max allowed")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('CurrConnections', filter=filter('namespace', 'AWS/ElastiCache') and filter('stat', 'upper') and filter('CacheNodeId', '*') and ${module.filter-tags.filter_custom})${var.max_connection_aggregation_function}${var.max_connection_transformation_function}.publish('signal')
@@ -85,6 +88,7 @@ resource "signalfx_detector" "no_connection" {
   name = format("%s %s", local.detector_name_prefix, "AWS ElastiCache current connections")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('CurrConnections', filter=filter('namespace', 'AWS/ElastiCache') and filter('stat', 'lower') and filter('CacheNodeId', '*') and ${module.filter-tags.filter_custom})${var.no_connection_aggregation_function}${var.no_connection_transformation_function}.publish('signal')
@@ -108,6 +112,7 @@ resource "signalfx_detector" "swap" {
   name = format("%s %s", local.detector_name_prefix, "AWS ElastiCache swap")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('SwapUsage', filter=filter('namespace', 'AWS/ElastiCache') and filter('stat', 'upper') and filter('CacheNodeId', '*') and ${module.filter-tags.filter_custom})${var.swap_aggregation_function}${var.swap_transformation_function}.publish('signal')
@@ -144,6 +149,7 @@ resource "signalfx_detector" "free_memory" {
   name = format("%s %s", local.detector_name_prefix, "AWS ElastiCache freeable memory")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('FreeableMemory', filter=filter('namespace', 'AWS/ElastiCache') and filter('stat', 'lower') and filter('CacheNodeId', '*') and ${module.filter-tags.filter_custom}).rateofchange()${var.free_memory_aggregation_function}${var.free_memory_transformation_function}.publish('signal')
@@ -180,6 +186,7 @@ resource "signalfx_detector" "evictions_growing" {
   name = format("%s %s", local.detector_name_prefix, "AWS ElastiCache evictions changing rate grows")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('Evictions', filter=filter('namespace', 'AWS/ElastiCache') and filter('stat', 'mean') and filter('CacheNodeId', '*') and ${module.filter-tags.filter_custom})${var.evictions_growing_aggregation_function}${var.evictions_growing_transformation_function}.rateofchange().scale(100).publish('signal')

--- a/modules/integration_aws-elasticache-memcached/detectors-memcached.tf
+++ b/modules/integration_aws-elasticache-memcached/detectors-memcached.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "hit_ratio" {
   name = format("%s %s", local.detector_name_prefix, "AWS ElastiCache memcached hit ratio")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('GetHits', filter=filter('namespace', 'AWS/ElastiCache') and filter('stat', 'mean') and filter('CacheNodeId', '*') and ${module.filter-tags.filter_custom}, extrapolation='zero', rollup='sum')${var.hit_ratio_aggregation_function}${var.hit_ratio_transformation_function}
@@ -40,6 +41,7 @@ resource "signalfx_detector" "cpu" {
   name = format("%s %s", local.detector_name_prefix, "AWS ElastiCache memcached CPU")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('CPUUtilization', filter=filter('namespace', 'AWS/ElastiCache') and filter('stat', 'mean') and filter('CacheNodeId', '*') and ${module.filter-tags.filter_custom})${var.cpu_aggregation_function}${var.cpu_transformation_function}.publish('signal')

--- a/modules/integration_aws-elasticache-redis/detectors-redis.tf
+++ b/modules/integration_aws-elasticache-redis/detectors-redis.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "cache_hits" {
   name = format("%s %s", local.detector_name_prefix, "AWS ElastiCache redis cache hit ratio")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('CacheHits', filter=filter('namespace', 'AWS/ElastiCache') and filter('stat', 'mean') and filter('CacheNodeId', '*') and ${module.filter-tags.filter_custom}, extrapolation='zero', rollup='sum')${var.cache_hits_aggregation_function}${var.cache_hits_transformation_function}
@@ -40,6 +41,7 @@ resource "signalfx_detector" "cpu_high" {
   name = format("%s %s", local.detector_name_prefix, "AWS ElastiCache redis CPU")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('EngineCPUUtilization', filter=filter('namespace', 'AWS/ElastiCache') and filter('stat', 'upper') and filter('CacheNodeId', '*') and ${module.filter-tags.filter_custom})${var.cpu_high_aggregation_function}${var.cpu_high_transformation_function}.publish('signal')
@@ -76,6 +78,7 @@ resource "signalfx_detector" "replication_lag" {
   name = format("%s %s", local.detector_name_prefix, "AWS ElastiCache redis replication lag")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('ReplicationLag', filter=filter('namespace', 'AWS/ElastiCache') and filter('stat', 'upper') and filter('CacheNodeId', '*') and ${module.filter-tags.filter_custom})${var.replication_lag_aggregation_function}${var.replication_lag_transformation_function}.publish('signal')
@@ -112,6 +115,7 @@ resource "signalfx_detector" "commands" {
   name = format("%s %s", local.detector_name_prefix, "AWS ElastiCache redis commands")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('GetTypeCmds', filter=filter('namespace', 'AWS/ElastiCache') and filter('stat', 'lower') and filter('CacheNodeId', '*') and ${module.filter-tags.filter_custom})${var.commands_aggregation_function}${var.commands_transformation_function}

--- a/modules/integration_aws-elasticsearch/detectors-elasticsearch.tf
+++ b/modules/integration_aws-elasticsearch/detectors-elasticsearch.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "heartbeat" {
   name = format("%s %s", local.detector_name_prefix, "AWS ElasticSearch heartbeat")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
@@ -26,6 +27,7 @@ resource "signalfx_detector" "cluster_status" {
   name = format("%s %s", local.detector_name_prefix, "AWS ElasticSearch cluster status")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('ClusterStatus.red', filter=filter('namespace', 'AWS/ES') and filter('stat', 'upper') and ${module.filter-tags.filter_custom})${var.cluster_status_aggregation_function}${var.cluster_status_transformation_function}.publish('A')
@@ -63,6 +65,7 @@ resource "signalfx_detector" "free_space" {
   name = format("%s %s", local.detector_name_prefix, "AWS ElasticSearch cluster free storage space")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('FreeStorageSpace', filter=filter('namespace', 'AWS/ES') and filter('stat', 'lower') and filter('NodeId', '*') and ${module.filter-tags.filter_custom})${var.free_space_aggregation_function}${var.free_space_transformation_function}.publish('signal')
@@ -99,6 +102,7 @@ resource "signalfx_detector" "cpu_90_15min" {
   name = format("%s %s", local.detector_name_prefix, "AWS ElasticSearch cluster CPU")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('CPUUtilization', filter=filter('namespace', 'AWS/ES') and filter('stat', 'upper') and filter('NodeId', '*') and ${module.filter-tags.filter_custom})${var.cpu_90_15min_aggregation_function}${var.cpu_90_15min_transformation_function}.publish('signal')

--- a/modules/integration_aws-elb/detectors-elb.tf
+++ b/modules/integration_aws-elb/detectors-elb.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "heartbeat" {
   name = format("%s %s", local.detector_name_prefix, "AWS ELB heartbeat")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
@@ -26,6 +27,7 @@ resource "signalfx_detector" "no_healthy_instances" {
   name = format("%s %s", local.detector_name_prefix, "AWS ELB healthy instances percentage")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('HealthyHostCount', filter=filter('namespace', 'AWS/ELB') and filter('stat', 'lower') and (not filter('AvailabilityZone', '*')) and filter('LoadBalancerName', '*') and ${module.filter-tags.filter_custom})${var.no_healthy_instances_aggregation_function}${var.no_healthy_instances_transformation_function}
@@ -64,6 +66,7 @@ resource "signalfx_detector" "elb_4xx" {
   name = format("%s %s", local.detector_name_prefix, "AWS ELB 4xx error rate")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('HTTPCode_ELB_4XX', filter=filter('namespace', 'AWS/ELB') and filter('stat', 'sum') and (not filter('AvailabilityZone', '*')) and filter('LoadBalancerName', '*') and ${module.filter-tags.filter_custom}, rollup='sum', extrapolation='zero')${var.elb_4xx_aggregation_function}${var.elb_4xx_transformation_function}
@@ -102,6 +105,7 @@ resource "signalfx_detector" "elb_5xx" {
   name = format("%s %s", local.detector_name_prefix, "AWS ELB 5xx error rate")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('HTTPCode_ELB_5XX', filter=filter('namespace', 'AWS/ELB') and filter('stat', 'sum') and (not filter('AvailabilityZone', '*')) and filter('LoadBalancerName', '*') and ${module.filter-tags.filter_custom}, rollup='sum', extrapolation='zero')${var.elb_5xx_aggregation_function}${var.elb_5xx_transformation_function}
@@ -140,6 +144,7 @@ resource "signalfx_detector" "backend_4xx" {
   name = format("%s %s", local.detector_name_prefix, "AWS ELB backend 4xx error rate")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('HTTPCode_Backend_4XX', filter=filter('namespace', 'AWS/ELB') and filter('stat', 'sum') and (not filter('AvailabilityZone', '*')) and filter('LoadBalancerName', '*') and ${module.filter-tags.filter_custom}, rollup='sum', extrapolation='zero')${var.backend_4xx_aggregation_function}${var.backend_4xx_transformation_function}
@@ -178,6 +183,7 @@ resource "signalfx_detector" "backend_5xx" {
   name = format("%s %s", local.detector_name_prefix, "AWS ELB backend 5xx error rate")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('HTTPCode_Backend_5XX', filter=filter('namespace', 'AWS/ELB') and filter('stat', 'sum') and (not filter('AvailabilityZone', '*')) and filter('LoadBalancerName', '*') and ${module.filter-tags.filter_custom}, extrapolation='zero', rollup='sum')${var.backend_5xx_aggregation_function}${var.backend_5xx_transformation_function}
@@ -216,6 +222,7 @@ resource "signalfx_detector" "backend_latency" {
   name = format("%s %s", local.detector_name_prefix, "AWS ELB backend latency")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('Latency', filter=filter('namespace', 'AWS/ELB') and filter('stat', 'mean') and (not filter('AvailabilityZone', '*')) and filter('LoadBalancerName', '*') and ${module.filter-tags.filter_custom}, extrapolation='zero', rollup='average')${var.backend_latency_aggregation_function}${var.backend_latency_transformation_function}.publish('signal')

--- a/modules/integration_aws-kinesis-firehose/detectors-kinesis-firehose.tf
+++ b/modules/integration_aws-kinesis-firehose/detectors-kinesis-firehose.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "heartbeat" {
   name = format("%s %s", local.detector_name_prefix, "AWS Kinesis heartbeat")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
@@ -26,6 +27,7 @@ resource "signalfx_detector" "incoming_records" {
   name = format("%s %s", local.detector_name_prefix, "AWS Kinesis incoming records")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('IncomingRecords', filter=filter('namespace', 'AWS/Kinesis') and filter('stat', 'lower') and (not filter('ShardId', '*')) and ${module.filter-tags.filter_custom})${var.incoming_records_aggregation_function}${var.incoming_records_transformation_function}.publish('signal')

--- a/modules/integration_aws-lambda/detectors-lambda.tf
+++ b/modules/integration_aws-lambda/detectors-lambda.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "pct_errors" {
   name = format("%s %s", local.detector_name_prefix, "AWS Lambda errors rate")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('Errors', filter=filter('namespace', 'AWS/Lambda') and filter('stat', 'mean') and filter('Resource', '*') and ${module.filter-tags.filter_custom}, extrapolation='last_value', rollup='average')${var.pct_errors_aggregation_function}${var.pct_errors_transformation_function}
@@ -40,6 +41,7 @@ resource "signalfx_detector" "throttles" {
   name = format("%s %s", local.detector_name_prefix, "AWS Lambda invocations throttled")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('Throttles', filter=filter('namespace', 'AWS/Lambda') and filter('stat', 'mean') and filter('Resource', '*') and ${module.filter-tags.filter_custom}, extrapolation='last_value', rollup='average')${var.throttles_aggregation_function}${var.throttles_transformation_function}.publish('signal')
@@ -76,6 +78,7 @@ resource "signalfx_detector" "invocations" {
   name = format("%s %s", local.detector_name_prefix, "AWS Lambda invocations")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('Invocations', filter=filter('namespace', 'AWS/Lambda') and filter('stat', 'mean') and filter('Resource', '*') and ${module.filter-tags.filter_custom}, extrapolation='last_value', rollup='average')${var.invocations_aggregation_function}${var.invocations_transformation_function}.publish('signal')

--- a/modules/integration_aws-nlb/detectors-nlb.tf
+++ b/modules/integration_aws-nlb/detectors-nlb.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "heartbeat" {
   name = format("%s %s", local.detector_name_prefix, "AWS NLB heartbeat")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
@@ -26,6 +27,7 @@ resource "signalfx_detector" "no_healthy_instances" {
   name = format("%s %s", local.detector_name_prefix, "AWS NLB healthy instances percentage")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('HealthyHostCount', filter=filter('namespace', 'AWS/NetworkELB') and filter('stat', 'lower') and (not filter('AvailabilityZone', '*')) and ${module.filter-tags.filter_custom})${var.no_healthy_instances_aggregation_function}${var.no_healthy_instances_transformation_function}

--- a/modules/integration_aws-rds-aurora-mysql/detectors-rds-aurora-mysql.tf
+++ b/modules/integration_aws-rds-aurora-mysql/detectors-rds-aurora-mysql.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "aurora_mysql_replica_lag" {
   name = format("%s %s", local.detector_name_prefix, "AWS RDS Aurora Mysql replica lag")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('AuroraReplicaLag', filter=filter('namespace', 'AWS/RDS') and filter('stat', 'mean') and filter('DBInstanceIdentifier', '*') and ${module.filter-tags.filter_custom})${var.aurora_mysql_replica_lag_aggregation_function}${var.aurora_mysql_replica_lag_transformation_function}.publish('signal')

--- a/modules/integration_aws-rds-aurora-postgresql/detectors-rds-aurora-postgresql.tf
+++ b/modules/integration_aws-rds-aurora-postgresql/detectors-rds-aurora-postgresql.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "aurora_postgresql_replica_lag" {
   name = format("%s %s", local.detector_name_prefix, "AWS RDS Aurora PostgreSQL replica lag")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('RDSToAuroraPostgreSQLReplicaLag', filter=filter('namespace', 'AWS/RDS') and filter('stat', 'mean') and filter('DBInstanceIdentifier', '*') and ${module.filter-tags.filter_custom})${var.aurora_postgresql_replica_lag_aggregation_function}${var.aurora_postgresql_replica_lag_transformation_function}.publish('signal')

--- a/modules/integration_aws-rds-common/detectors-rds-common.tf
+++ b/modules/integration_aws-rds-common/detectors-rds-common.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "heartbeat" {
   name = format("%s %s", local.detector_name_prefix, "AWS RDS heartbeat")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
@@ -26,6 +27,7 @@ resource "signalfx_detector" "cpu_90_15min" {
   name = format("%s %s", local.detector_name_prefix, "AWS RDS instance CPU")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('CPUUtilization', filter=filter('namespace', 'AWS/RDS') and filter('stat', 'mean') and filter('DBInstanceIdentifier', '*') and ${module.filter-tags.filter_custom})${var.cpu_90_15min_aggregation_function}${var.cpu_90_15min_transformation_function}.publish('signal')
@@ -62,6 +64,7 @@ resource "signalfx_detector" "free_space_low" {
   name = format("%s %s", local.detector_name_prefix, "AWS RDS instance free space")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('FreeStorageSpace', filter=filter('namespace', 'AWS/RDS') and filter('stat', 'mean') and filter('DBInstanceIdentifier', '*') and ${module.filter-tags.filter_custom})${var.free_space_low_aggregation_function}${var.free_space_low_transformation_function}.publish('signal')
@@ -98,6 +101,7 @@ resource "signalfx_detector" "replica_lag" {
   name = format("%s %s", local.detector_name_prefix, "AWS RDS replica lag")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('ReplicaLag', filter=filter('namespace', 'AWS/RDS') and filter('stat', 'mean') and filter('DBInstanceIdentifier', '*') and ${module.filter-tags.filter_custom})${var.replica_lag_aggregation_function}${var.replica_lag_transformation_function}.publish('signal')

--- a/modules/integration_aws-sqs/detectors-sqs.tf
+++ b/modules/integration_aws-sqs/detectors-sqs.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "heartbeat" {
   name = format("%s %s", local.detector_name_prefix, "AWS SQS heartbeat")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
@@ -26,6 +27,7 @@ resource "signalfx_detector" "visible_messages" {
   name = format("%s %s", local.detector_name_prefix, "AWS SQS Visible messages")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('ApproximateNumberOfMessagesVisible', filter=filter('namespace', 'AWS/SQS') and filter('stat', 'upper') and ${module.filter-tags.filter_custom})${var.visible_messages_aggregation_function}${var.visible_messages_transformation_function}.publish('signal')
@@ -62,6 +64,7 @@ resource "signalfx_detector" "age_of_oldest_message" {
   name = format("%s %s", local.detector_name_prefix, "AWS SQS Age of the oldest message")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('ApproximateAgeOfOldestMessage', filter=filter('namespace', 'AWS/SQS') and filter('stat', 'upper') and ${module.filter-tags.filter_custom})${var.age_of_oldest_message_aggregation_function}${var.age_of_oldest_message_transformation_function}.publish('signal')

--- a/modules/integration_aws-vpn/detectors-vpn.tf
+++ b/modules/integration_aws-vpn/detectors-vpn.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "heartbeat" {
   name = format("%s %s", local.detector_name_prefix, "AWS VPN heartbeat")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
@@ -26,6 +27,7 @@ resource "signalfx_detector" "VPN_status" {
   name = format("%s %s", local.detector_name_prefix, "AWS VPN tunnel state")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('TunnelState', filter=filter('namespace', 'AWS/VPN') and filter('stat', 'mean') and filter('VpnId', '*') and ${module.filter-tags.filter_custom})${var.vpn_status_aggregation_function}${var.vpn_status_transformation_function}.publish('signal')

--- a/modules/integration_azure-app-service-plan/detectors-azure-app-service-plan.tf
+++ b/modules/integration_azure-app-service-plan/detectors-azure-app-service-plan.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "heartbeat" {
   name = format("%s %s", local.detector_name_prefix, "Azure App Service Plan heartbeat")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         from signalfx.detectors.not_reporting import not_reporting
@@ -27,6 +28,7 @@ resource "signalfx_detector" "cpu_percentage" {
   name = format("%s %s", local.detector_name_prefix, "Azure App Service Plan CPU percentage")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         base_filter = filter('resource_type', 'Microsoft.Web/serverFarms') and filter('primary_aggregation_type', 'true')
@@ -64,6 +66,7 @@ resource "signalfx_detector" "memory_percentage" {
   name = format("%s %s", local.detector_name_prefix, "Azure App Service Plan memory percentage")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         base_filter = filter('resource_type', 'Microsoft.Web/serverFarms') and filter('primary_aggregation_type', 'true')

--- a/modules/integration_azure-app-service/detectors-app_services.tf
+++ b/modules/integration_azure-app-service/detectors-app_services.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "heartbeat" {
   name = format("%s %s", local.detector_name_prefix, "Azure App Service heartbeat")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         from signalfx.detectors.not_reporting import not_reporting
@@ -27,6 +28,7 @@ resource "signalfx_detector" "response_time" {
   name = format("%s %s", local.detector_name_prefix, "Azure App Service response time")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         base_filter = filter('resource_type', 'Microsoft.Web/sites') and filter('is_Azure_Function', 'false') and filter('primary_aggregation_type', 'true')
@@ -65,6 +67,7 @@ resource "signalfx_detector" "memory_usage_count" {
   name = format("%s %s", local.detector_name_prefix, "Azure App Service memory usage")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         base_filter = filter('resource_type', 'Microsoft.Web/sites') and filter('is_Azure_Function', 'false') and filter('primary_aggregation_type', 'true')
@@ -103,6 +106,7 @@ resource "signalfx_detector" "http_5xx_errors_count" {
   name = format("%s %s", local.detector_name_prefix, "Azure App Service 5xx error rate")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         base_filter = filter('resource_type', 'Microsoft.Web/sites') and filter('is_Azure_Function', 'false') and filter('primary_aggregation_type', 'true')
@@ -143,6 +147,7 @@ resource "signalfx_detector" "http_4xx_errors_count" {
   name = format("%s %s", local.detector_name_prefix, "Azure App Service 4xx error rate")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         base_filter = filter('resource_type', 'Microsoft.Web/sites') and filter('is_Azure_Function', 'false') and filter('primary_aggregation_type', 'true')
@@ -182,6 +187,7 @@ resource "signalfx_detector" "http_success_status_rate" {
   name = format("%s %s", local.detector_name_prefix, "Azure App Service successful response rate")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         base_filter = filter('resource_type', 'Microsoft.Web/sites') and filter('is_Azure_Function', 'false') and filter('primary_aggregation_type', 'true')

--- a/modules/integration_azure-application-gateway/detectors-app-gateway.tf
+++ b/modules/integration_azure-application-gateway/detectors-app-gateway.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "heartbeat" {
   name = format("%s %s", local.detector_name_prefix, "Azure Application Gateway heartbeat")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         from signalfx.detectors.not_reporting import not_reporting
@@ -27,6 +28,7 @@ resource "signalfx_detector" "total_requests" {
   name = format("%s %s", local.detector_name_prefix, "Azure Application Gateway has no request")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         base_filter = filter('resource_type', 'Microsoft.Network/applicationGateways') and filter('primary_aggregation_type', 'true')
@@ -52,6 +54,7 @@ resource "signalfx_detector" "backend_connect_time" {
   name = format("%s %s", local.detector_name_prefix, "Azure Application Gateway backend connect time")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         base_filter = filter('resource_type', 'Microsoft.Network/applicationGateways') and filter('primary_aggregation_type', 'true')
@@ -89,6 +92,7 @@ resource "signalfx_detector" "failed_requests" {
   name = format("%s %s", local.detector_name_prefix, "Azure Application Gateway failed request rate")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         from signalfx.detectors.aperiodic import conditions
@@ -129,6 +133,7 @@ resource "signalfx_detector" "unhealthy_host_ratio" {
   name = format("%s %s", local.detector_name_prefix, "Azure Application Gateway backend unhealthy host ratio")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         base_filter = filter('resource_type', 'Microsoft.Network/applicationGateways') and filter('primary_aggregation_type', 'true')
@@ -168,6 +173,7 @@ resource "signalfx_detector" "http_4xx_errors" {
   name = format("%s %s", local.detector_name_prefix, "Azure Application Gateway 4xx error rate")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         base_filter = filter('resource_type', 'Microsoft.Network/applicationGateways') and filter('primary_aggregation_type', 'true')
@@ -207,6 +213,7 @@ resource "signalfx_detector" "http_5xx_errors" {
   name = format("%s %s", local.detector_name_prefix, "Azure Application Gateway 5xx error rate")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         base_filter = filter('resource_type', 'Microsoft.Network/applicationGateways') and filter('primary_aggregation_type', 'true')
@@ -246,6 +253,7 @@ resource "signalfx_detector" "backend_http_4xx_errors" {
   name = format("%s %s", local.detector_name_prefix, "Azure Application Gateway backend 4xx error rate")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         base_filter = filter('resource_type', 'Microsoft.Network/applicationGateways') and filter('primary_aggregation_type', 'true')
@@ -285,6 +293,7 @@ resource "signalfx_detector" "backend_http_5xx_errors" {
   name = format("%s %s", local.detector_name_prefix, "Azure Application Gateway backend 5xx error rate")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         base_filter = filter('resource_type', 'Microsoft.Network/applicationGateways') and filter('primary_aggregation_type', 'true')

--- a/modules/integration_azure-application-gateway/detectors-gen.tf
+++ b/modules/integration_azure-application-gateway/detectors-gen.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "capacity_units" {
   name = format("%s %s", local.detector_name_prefix, "Azure Application Gateway capacity units")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     base_filtering = filter('resource_type', 'Microsoft.Network/applicationGateways') and filter('primary_aggregation_type', 'true')

--- a/modules/integration_azure-azure-search/detectors-azure-search.tf
+++ b/modules/integration_azure-azure-search/detectors-azure-search.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "search_latency" {
   name = format("%s %s", local.detector_name_prefix, "Azure Search latency")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         base_filter = filter('resource_type', 'Microsoft.Search/searchServices') and filter('primary_aggregation_type', 'true')
@@ -39,6 +40,7 @@ resource "signalfx_detector" "search_throttled_queries_rate" {
   name = format("%s %s", local.detector_name_prefix, "Azure Search throttled queries rate")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         base_filter = filter('resource_type', 'Microsoft.Search/searchServices') and filter('primary_aggregation_type', 'true')

--- a/modules/integration_azure-container-instance/detectors-gen.tf
+++ b/modules/integration_azure-container-instance/detectors-gen.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "heartbeat" {
   name = format("%s %s", local.detector_name_prefix, "Azure Container Instance heartbeat")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   max_delay = 900
 

--- a/modules/integration_azure-cosmos-db/detectors-cosmosdb.tf
+++ b/modules/integration_azure-cosmos-db/detectors-cosmosdb.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "heartbeat" {
   name = format("%s %s", local.detector_name_prefix, "Azure Cosmos DB heartbeat")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         from signalfx.detectors.not_reporting import not_reporting
@@ -27,6 +28,7 @@ resource "signalfx_detector" "db_4xx_requests" {
   name = format("%s %s", local.detector_name_prefix, "Azure Cosmos DB 4xx request rate")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         base_filter = filter('resource_type', 'Microsoft.DocumentDB/databaseAccounts') and filter('primary_aggregation_type', 'true')
@@ -66,6 +68,7 @@ resource "signalfx_detector" "db_5xx_requests" {
   name = format("%s %s", local.detector_name_prefix, "Azure Cosmos DB 5xx error rate")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         base_filter = filter('resource_type', 'Microsoft.DocumentDB/databaseAccounts') and filter('primary_aggregation_type', 'true')
@@ -105,6 +108,7 @@ resource "signalfx_detector" "scaling" {
   name = format("%s %s", local.detector_name_prefix, "Azure Cosmos DB scaling errors rate")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         base_filter = filter('resource_type', 'Microsoft.DocumentDB/databaseAccounts') and filter('primary_aggregation_type', 'true')
@@ -144,6 +148,7 @@ resource "signalfx_detector" "used_rus_capacity" {
   name = format("%s %s", local.detector_name_prefix, "Azure Cosmos DB used RUs capacity")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     base_filter = filter('resource_type', 'Microsoft.DocumentDB/databaseAccounts') and filter('primary_aggregation_type', 'true')

--- a/modules/integration_azure-datafactory/detectors-gen.tf
+++ b/modules/integration_azure-datafactory/detectors-gen.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "activity_error_rate" {
   name = format("%s %s", local.detector_name_prefix, "Azure DataFactory activity error rate")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   viz_options {
     label        = "signal"
@@ -46,6 +47,7 @@ resource "signalfx_detector" "pipeline_error_rate" {
   name = format("%s %s", local.detector_name_prefix, "Azure DataFactory pipeline error rate")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   viz_options {
     label        = "signal"
@@ -90,6 +92,7 @@ resource "signalfx_detector" "trigger_error_rate" {
   name = format("%s %s", local.detector_name_prefix, "Azure DataFactory trigger error rate")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     base_filtering = filter('resource_type', 'Microsoft.DataFactory/factories') and filter('primary_aggregation_type', 'true')
@@ -129,6 +132,7 @@ resource "signalfx_detector" "available_memory" {
   name = format("%s %s", local.detector_name_prefix, "Azure DataFactory available memory")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   viz_options {
     label        = "signal"
@@ -172,6 +176,7 @@ resource "signalfx_detector" "cpu_percentage" {
   name = format("%s %s", local.detector_name_prefix, "Azure DataFactory cpu percentage")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   viz_options {
     label        = "signal"

--- a/modules/integration_azure-event-hub/detectors-gen.tf
+++ b/modules/integration_azure-event-hub/detectors-gen.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "throttled_requests" {
   name = format("%s %s", local.detector_name_prefix, "Azure Event Hub throttled requests")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   viz_options {
     label        = "signal"

--- a/modules/integration_azure-functions/detectors-functions.tf
+++ b/modules/integration_azure-functions/detectors-functions.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "heartbeat" {
   name = format("%s %s", local.detector_name_prefix, "Azure Functions heartbeat")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         from signalfx.detectors.not_reporting import not_reporting
@@ -27,6 +28,7 @@ resource "signalfx_detector" "http_5xx_errors_rate" {
   name = format("%s %s", local.detector_name_prefix, "Azure Functions HTTP 5xx error rate")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         base_filter = filter('resource_type', 'Microsoft.Web/sites') and filter('is_Azure_Function', 'true') and filter('primary_aggregation_type', 'true')
@@ -66,6 +68,7 @@ resource "signalfx_detector" "high_connections_count" {
   name = format("%s %s", local.detector_name_prefix, "Azure Functions connections count")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         base_filter = filter('resource_type', 'Microsoft.Web/sites') and filter('is_Azure_Function', 'true') and filter('primary_aggregation_type', 'true')
@@ -103,6 +106,7 @@ resource "signalfx_detector" "high_threads_count" {
   name = format("%s %s", local.detector_name_prefix, "Azure Functions thread count")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         base_filter = filter('resource_type', 'Microsoft.Web/sites') and filter('is_Azure_Function', 'true') and filter('primary_aggregation_type', 'true')

--- a/modules/integration_azure-functions/detectors-gen.tf
+++ b/modules/integration_azure-functions/detectors-gen.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "errors" {
   name = format("%s %s", local.detector_name_prefix, "Azure Functions wrapper errors")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     base_filtering = filter('is_Azure_Function', 'true')

--- a/modules/integration_azure-key-vault/detectors-keyvault.tf
+++ b/modules/integration_azure-key-vault/detectors-keyvault.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "api_result" {
   name = format("%s %s", local.detector_name_prefix, "Azure Key Vault API result rate")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         base_filter = filter('resource_type', 'Microsoft.KeyVault/vaults') and filter('primary_aggregation_type', 'true')
@@ -41,6 +42,7 @@ resource "signalfx_detector" "api_latency" {
   name = format("%s %s", local.detector_name_prefix, "Azure Key Vault API latency")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         base_filter = filter('resource_type', 'Microsoft.KeyVault/vaults') and filter('primary_aggregation_type', 'true')

--- a/modules/integration_azure-load-balancer/detectors-load-balancer.tf
+++ b/modules/integration_azure-load-balancer/detectors-load-balancer.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "heartbeat" {
   name = format("%s %s", local.detector_name_prefix, "Azure Load balancer heartbeat")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         from signalfx.detectors.not_reporting import not_reporting

--- a/modules/integration_azure-mysql/detectors-mysql.tf
+++ b/modules/integration_azure-mysql/detectors-mysql.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "heartbeat" {
   name = format("%s %s", local.detector_name_prefix, "Azure MySQL heartbeat")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         from signalfx.detectors.not_reporting import not_reporting
@@ -27,6 +28,7 @@ resource "signalfx_detector" "cpu_usage" {
   name = format("%s %s", local.detector_name_prefix, "Azure MySQL CPU usage")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         base_filter = filter('resource_type', 'Microsoft.DBforMySQL/servers') and filter('primary_aggregation_type', 'true')
@@ -64,6 +66,7 @@ resource "signalfx_detector" "free_storage" {
   name = format("%s %s", local.detector_name_prefix, "Azure MySQL storage usage")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         base_filter = filter('resource_type', 'Microsoft.DBforMySQL/servers') and filter('primary_aggregation_type', 'true')
@@ -101,6 +104,7 @@ resource "signalfx_detector" "io_consumption" {
   name = format("%s %s", local.detector_name_prefix, "Azure MySQL IO consumption")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         base_filter = filter('resource_type', 'Microsoft.DBforMySQL/servers') and filter('primary_aggregation_type', 'true')
@@ -138,6 +142,7 @@ resource "signalfx_detector" "memory_usage" {
   name = format("%s %s", local.detector_name_prefix, "Azure MySQL memory usage")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         base_filter = filter('resource_type', 'Microsoft.DBforMySQL/servers') and filter('primary_aggregation_type', 'true')
@@ -175,6 +180,7 @@ resource "signalfx_detector" "replication_lag" {
   name = format("%s %s", local.detector_name_prefix, "Azure MySQL replication lag")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         base_filter = filter('resource_type', 'Microsoft.DBforMySQL/servers') and filter('primary_aggregation_type', 'true')

--- a/modules/integration_azure-postgresql/detectors-postgresql.tf
+++ b/modules/integration_azure-postgresql/detectors-postgresql.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "heartbeat" {
   name = format("%s %s", local.detector_name_prefix, "Azure PostgreSQL heartbeat")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         from signalfx.detectors.not_reporting import not_reporting
@@ -27,6 +28,7 @@ resource "signalfx_detector" "cpu_usage" {
   name = format("%s %s", local.detector_name_prefix, "Azure PostgreSQL CPU usage")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         base_filter = filter('resource_type', 'Microsoft.DBforPostgreSQL/servers') and filter('primary_aggregation_type', 'true')
@@ -64,6 +66,7 @@ resource "signalfx_detector" "no_connection" {
   name = format("%s %s", local.detector_name_prefix, "Azure PostgreSQL has no connection")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         base_filter = filter('resource_type', 'Microsoft.DBforPostgreSQL/servers') and filter('primary_aggregation_type', 'true')
@@ -87,6 +90,7 @@ resource "signalfx_detector" "storage_usage" {
   name = format("%s %s", local.detector_name_prefix, "Azure PostgreSQL storage usage")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         base_filter = filter('resource_type', 'Microsoft.DBforPostgreSQL/servers') and filter('primary_aggregation_type', 'true')
@@ -124,6 +128,7 @@ resource "signalfx_detector" "io_consumption" {
   name = format("%s %s", local.detector_name_prefix, "Azure PostgreSQL IO consumption")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         base_filter = filter('resource_type', 'Microsoft.DBforPostgreSQL/servers') and filter('primary_aggregation_type', 'true')
@@ -161,6 +166,7 @@ resource "signalfx_detector" "memory_usage" {
   name = format("%s %s", local.detector_name_prefix, "Azure PostgreSQL memory usage ")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         base_filter = filter('resource_type', 'Microsoft.DBforPostgreSQL/servers') and filter('primary_aggregation_type', 'true')

--- a/modules/integration_azure-redis/detectors-azure-redis.tf
+++ b/modules/integration_azure-redis/detectors-azure-redis.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "heartbeat" {
   name = format("%s %s", local.detector_name_prefix, "Azure Redis heartbeat")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         from signalfx.detectors.not_reporting import not_reporting
@@ -27,6 +28,7 @@ resource "signalfx_detector" "evictedkeys" {
   name = format("%s %s", local.detector_name_prefix, "Azure Redis evicted keys")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         base_filter = filter('resource_type', 'Microsoft.Cache/Redis') and filter('primary_aggregation_type', 'true')
@@ -64,6 +66,7 @@ resource "signalfx_detector" "percent_processor_time" {
   name = format("%s %s", local.detector_name_prefix, "Azure Redis processor time")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         base_filter = filter('resource_type', 'Microsoft.Cache/Redis') and filter('primary_aggregation_type', 'true')
@@ -101,6 +104,7 @@ resource "signalfx_detector" "load" {
   name = format("%s %s", local.detector_name_prefix, "Azure Redis load")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         base_filter = filter('resource_type', 'Microsoft.Cache/Redis') and filter('primary_aggregation_type', 'true')

--- a/modules/integration_azure-service-bus/detectors-service-bus.tf
+++ b/modules/integration_azure-service-bus/detectors-service-bus.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "heartbeat" {
   name = format("%s %s", local.detector_name_prefix, "Azure Service Bus heartbeat")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         from signalfx.detectors.not_reporting import not_reporting
@@ -27,6 +28,7 @@ resource "signalfx_detector" "active_connections" {
   name = format("%s %s", local.detector_name_prefix, "Azure Service Bus no active connections")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         base_filter = filter('resource_type', 'Microsoft.ServiceBus/namespaces') and filter('primary_aggregation_type', 'true') and ${module.filter-tags.filter_custom}
@@ -52,6 +54,7 @@ resource "signalfx_detector" "user_errors" {
   name = format("%s %s", local.detector_name_prefix, "Azure Service Bus user error rate")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         base_filter = filter('resource_type', 'Microsoft.ServiceBus/namespaces') and filter('primary_aggregation_type', 'true') and ${module.filter-tags.filter_custom}
@@ -91,6 +94,7 @@ resource "signalfx_detector" "server_errors" {
   name = format("%s %s", local.detector_name_prefix, "Azure Service Bus server error rate")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         base_filter = filter('resource_type', 'Microsoft.ServiceBus/namespaces') and filter('primary_aggregation_type', 'true') and ${module.filter-tags.filter_custom}
@@ -130,6 +134,7 @@ resource "signalfx_detector" "throttled_requests" {
   name = format("%s %s", local.detector_name_prefix, "Azure Service Bus throttled requests rate")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     base_filter = filter('resource_type', 'Microsoft.ServiceBus/namespaces') and filter('primary_aggregation_type', 'true') and ${module.filter-tags.filter_custom}

--- a/modules/integration_azure-sql-database/detectors-sql-database.tf
+++ b/modules/integration_azure-sql-database/detectors-sql-database.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "heartbeat" {
   name = format("%s %s", local.detector_name_prefix, "Azure SQL Database heartbeat")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         from signalfx.detectors.not_reporting import not_reporting
@@ -27,6 +28,7 @@ resource "signalfx_detector" "cpu" {
   name = format("%s %s", local.detector_name_prefix, "Azure Sql Database CPU")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         base_filter = filter('resource_type', 'Microsoft.Sql/servers/databases') and filter('primary_aggregation_type', 'true')
@@ -64,6 +66,7 @@ resource "signalfx_detector" "free_space" {
   name = format("%s %s", local.detector_name_prefix, "Azure SQL Database disk usage")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         base_filter = filter('resource_type', 'Microsoft.Sql/servers/databases') and filter('primary_aggregation_type', 'true')
@@ -101,6 +104,7 @@ resource "signalfx_detector" "dtu_consumption" {
   name = format("%s %s", local.detector_name_prefix, "Azure SQL Database DTU consumption")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         base_filter = filter('resource_type', 'Microsoft.Sql/servers/databases') and filter('primary_aggregation_type', 'true')
@@ -138,6 +142,7 @@ resource "signalfx_detector" "deadlocks_count" {
   name = format("%s %s", local.detector_name_prefix, "Azure SQL Database deadlocks count")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         base_filter = filter('resource_type', 'Microsoft.Sql/servers/databases') and filter('primary_aggregation_type', 'true')

--- a/modules/integration_azure-sql-elastic-pool/detectors-sql-elasticpool.tf
+++ b/modules/integration_azure-sql-elastic-pool/detectors-sql-elasticpool.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "heartbeat" {
   name = format("%s %s", local.detector_name_prefix, "Azure SQL Elastic Pool heartbeat")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         from signalfx.detectors.not_reporting import not_reporting
@@ -27,6 +28,7 @@ resource "signalfx_detector" "cpu" {
   name = format("%s %s", local.detector_name_prefix, "Azure SQL Elastic Pool CPU")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         base_filter = filter('resource_type', 'Microsoft.Sql/servers/elasticpools') and filter('primary_aggregation_type', 'true')
@@ -64,6 +66,7 @@ resource "signalfx_detector" "free_space" {
   name = format("%s %s", local.detector_name_prefix, "Azure SQL Elastic Pool disk usage")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         base_filter = filter('resource_type', 'Microsoft.Sql/servers/elasticpools') and filter('primary_aggregation_type', 'true')
@@ -101,6 +104,7 @@ resource "signalfx_detector" "dtu_consumption" {
   name = format("%s %s", local.detector_name_prefix, "Azure SQL Elastic Pool DTU consumption")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         base_filter = filter('resource_type', 'Microsoft.Sql/servers/elasticpools') and filter('primary_aggregation_type', 'true')

--- a/modules/integration_azure-storage-account-blob/detectors-gen.tf
+++ b/modules/integration_azure-storage-account-blob/detectors-gen.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "requests_error_rate" {
   name = format("%s %s", local.detector_name_prefix, "Azure Storage Account on Blob requests error rate")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   viz_options {
     label        = "signal"
@@ -46,6 +47,7 @@ resource "signalfx_detector" "latency_e2e" {
   name = format("%s %s", local.detector_name_prefix, "Azure Storage Account on Blob latency e2e")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   viz_options {
     label        = "signal"

--- a/modules/integration_azure-storage-account-capacity/detectors-azure-storage.tf
+++ b/modules/integration_azure-storage-account-capacity/detectors-azure-storage.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "used_capacity" {
   name = format("%s %s", local.detector_name_prefix, "Azure storage account Used capacity")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     base_filter = filter('resource_type', 'Microsoft.Storage/storageAccounts') and filter('primary_aggregation_type', 'true')

--- a/modules/integration_azure-storage-account/detectors-gen.tf
+++ b/modules/integration_azure-storage-account/detectors-gen.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "count" {
   name = format("%s %s", local.detector_name_prefix, "Azure Storage Account count")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     base_filtering = filter('resource_type', 'Microsoft.Storage/storageAccounts') and filter('primary_aggregation_type', 'true')
@@ -40,6 +41,7 @@ resource "signalfx_detector" "capacity" {
   name = format("%s %s", local.detector_name_prefix, "Azure Storage Account capacity")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   viz_options {
     label        = "signal"
@@ -83,6 +85,7 @@ resource "signalfx_detector" "ingress" {
   name = format("%s %s", local.detector_name_prefix, "Azure Storage Account ingress")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   viz_options {
     label        = "signal"
@@ -126,6 +129,7 @@ resource "signalfx_detector" "egress" {
   name = format("%s %s", local.detector_name_prefix, "Azure Storage Account egress")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   viz_options {
     label        = "signal"
@@ -169,6 +173,7 @@ resource "signalfx_detector" "requests_rate" {
   name = format("%s %s", local.detector_name_prefix, "Azure Storage Account requests rate")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     base_filtering = filter('resource_type', 'Microsoft.Storage/storageAccounts') and filter('primary_aggregation_type', 'true')

--- a/modules/integration_azure-stream-analytics/detectors-stream-analytics.tf
+++ b/modules/integration_azure-stream-analytics/detectors-stream-analytics.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "heartbeat" {
   name = format("%s %s", local.detector_name_prefix, "Azure Stream Analytics heartbeat")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         from signalfx.detectors.not_reporting import not_reporting
@@ -27,6 +28,7 @@ resource "signalfx_detector" "su_utilization" {
   name = format("%s %s", local.detector_name_prefix, "Azure Stream Analytics resource utilization")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         base_filter = filter('resource_type', 'Microsoft.StreamAnalytics/streamingjobs') and filter('primary_aggregation_type', 'true') and ${module.filter-tags.filter_custom}
@@ -64,6 +66,7 @@ resource "signalfx_detector" "failed_function_requests" {
   name = format("%s %s", local.detector_name_prefix, "Azure Stream Analytics failed function requests rate")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         base_filter = filter('resource_type', 'Microsoft.StreamAnalytics/streamingjobs') and filter('primary_aggregation_type', 'true') and ${module.filter-tags.filter_custom}
@@ -103,6 +106,7 @@ resource "signalfx_detector" "conversion_errors" {
   name = format("%s %s", local.detector_name_prefix, "Azure Stream Analytics conversion errors rate")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         base_filter = filter('resource_type', 'Microsoft.StreamAnalytics/streamingjobs') and filter('primary_aggregation_type', 'true') and ${module.filter-tags.filter_custom}
@@ -140,6 +144,7 @@ resource "signalfx_detector" "runtime_errors" {
   name = format("%s %s", local.detector_name_prefix, "Azure Stream Analytics runtime errors rate")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         base_filter = filter('resource_type', 'Microsoft.StreamAnalytics/streamingjobs') and filter('primary_aggregation_type', 'true') and ${module.filter-tags.filter_custom}

--- a/modules/integration_azure-virtual-machine-scaleset/detectors-virtual-machine-scaleset.tf
+++ b/modules/integration_azure-virtual-machine-scaleset/detectors-virtual-machine-scaleset.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "heartbeat" {
   name = format("%s %s", local.detector_name_prefix, "Azure Virtual Machine ScaleSet heartbeat")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         from signalfx.detectors.not_reporting import not_reporting

--- a/modules/integration_azure-virtual-machine/detectors-virtual-machine.tf
+++ b/modules/integration_azure-virtual-machine/detectors-virtual-machine.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "heartbeat" {
   name = format("%s %s", local.detector_name_prefix, "Azure Virtual Machine heartbeat")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         from signalfx.detectors.not_reporting import not_reporting
@@ -27,6 +28,7 @@ resource "signalfx_detector" "cpu_usage" {
   name = format("%s %s", local.detector_name_prefix, "Azure Virtual Machine CPU usage")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         base_filter = filter('resource_type', 'Microsoft.Compute/virtualMachines') and filter('primary_aggregation_type', 'true') and ${local.not_running_vm_filters_azure}
@@ -64,6 +66,7 @@ resource "signalfx_detector" "credit_cpu" {
   name = format("%s %s", local.detector_name_prefix, "Azure Virtual Machine remaining CPU credit")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         base_filter = filter('resource_type', 'Microsoft.Compute/virtualMachines') and filter('primary_aggregation_type', 'true') and ${local.not_running_vm_filters_azure}

--- a/modules/integration_gcp-bigquery/detectors-big-query.tf
+++ b/modules/integration_gcp-bigquery/detectors-big-query.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "concurrent_queries" {
   name = format("%s %s", local.detector_name_prefix, "GCP BigQuery concurrent queries")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     from signalfx.detectors.aperiodic import conditions
@@ -42,6 +43,7 @@ resource "signalfx_detector" "execution_time" {
   name = format("%s %s", local.detector_name_prefix, "GCP BigQuery execution time")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     from signalfx.detectors.aperiodic import conditions
@@ -82,6 +84,7 @@ resource "signalfx_detector" "scanned_bytes" {
   name = format("%s %s", local.detector_name_prefix, "GCP BigQuery scanned bytes")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     from signalfx.detectors.aperiodic import conditions
@@ -122,6 +125,7 @@ resource "signalfx_detector" "scanned_bytes_billed" {
   name = format("%s %s", local.detector_name_prefix, "GCP BigQuery scanned bytes billed")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     from signalfx.detectors.aperiodic import conditions
@@ -162,6 +166,7 @@ resource "signalfx_detector" "available_slots" {
   name = format("%s %s", local.detector_name_prefix, "GCP BigQuery available slots")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     from signalfx.detectors.aperiodic import conditions
@@ -202,6 +207,7 @@ resource "signalfx_detector" "stored_bytes" {
   name = format("%s %s", local.detector_name_prefix, "GCP BigQuery stored bytes")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     from signalfx.detectors.aperiodic import conditions
@@ -242,6 +248,7 @@ resource "signalfx_detector" "table_count" {
   name = format("%s %s", local.detector_name_prefix, "GCP BigQuery table count")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     from signalfx.detectors.aperiodic import conditions
@@ -282,6 +289,7 @@ resource "signalfx_detector" "uploaded_bytes" {
   name = format("%s %s", local.detector_name_prefix, "GCP BigQuery uploaded bytes")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     from signalfx.detectors.aperiodic import conditions
@@ -322,6 +330,7 @@ resource "signalfx_detector" "uploaded_bytes_billed" {
   name = format("%s %s", local.detector_name_prefix, "GCP BigQuery uploaded bytes billed")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     from signalfx.detectors.aperiodic import conditions

--- a/modules/integration_gcp-cloud-sql-common/detectors-cloud-sql-common.tf
+++ b/modules/integration_gcp-cloud-sql-common/detectors-cloud-sql-common.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "heartbeat" {
   name = format("%s %s", local.detector_name_prefix, "GCP Cloud SQL heartbeat")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
@@ -26,6 +27,7 @@ resource "signalfx_detector" "cpu_utilization" {
   name = format("%s %s", local.detector_name_prefix, "GCP Cloud SQL CPU utilization")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('database/cpu/utilization', ${module.filter-tags.filter_custom})${var.cpu_utilization_aggregation_function}${var.cpu_utilization_transformation_function}.scale(100).publish('signal')
@@ -62,6 +64,7 @@ resource "signalfx_detector" "disk_utilization" {
   name = format("%s %s", local.detector_name_prefix, "GCP Cloud SQL disk utilization")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('database/disk/utilization', ${module.filter-tags.filter_custom})${var.disk_utilization_aggregation_function}${var.disk_utilization_transformation_function}.scale(100).publish('signal')
@@ -98,6 +101,7 @@ resource "signalfx_detector" "disk_utilization_forecast" {
   name = format("%s %s", local.detector_name_prefix, "GCP Cloud SQL disk space is running out")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     from signalfx.detectors.countdown import countdown
@@ -122,6 +126,7 @@ resource "signalfx_detector" "memory_utilization" {
   name = format("%s %s", local.detector_name_prefix, "GCP Cloud SQL memory utilization")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('database/memory/utilization', ${module.filter-tags.filter_custom})${var.memory_utilization_aggregation_function}${var.memory_utilization_transformation_function}.scale(100).publish('signal')
@@ -158,6 +163,7 @@ resource "signalfx_detector" "memory_utilization_forecast" {
   name = format("%s %s", local.detector_name_prefix, "GCP Cloud SQL memory is running out")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     from signalfx.detectors.countdown import countdown

--- a/modules/integration_gcp-cloud-sql-failover/detectors-cloud-sql-failover.tf
+++ b/modules/integration_gcp-cloud-sql-failover/detectors-cloud-sql-failover.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "failover_unavailable" {
   name = format("%s %s", local.detector_name_prefix, "GCP Cloud SQL failover")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('database/available_for_failover', ${module.filter-tags.filter_custom})${var.failover_unavailable_aggregation_function}${var.failover_unavailable_transformation_function}.publish('signal')

--- a/modules/integration_gcp-cloud-sql-mysql/detectors-cloudsql-mysql.tf
+++ b/modules/integration_gcp-cloud-sql-mysql/detectors-cloudsql-mysql.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "replication_lag" {
   name = format("%s %s", local.detector_name_prefix, "GCP Cloud SQL MySQL replication lag")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('database/mysql/replication/seconds_behind_master', ${module.filter-tags.filter_custom})${var.replication_lag_aggregation_function}${var.replication_lag_transformation_function}.publish('signal')

--- a/modules/integration_gcp-compute-engine/detectors-gce-instance.tf
+++ b/modules/integration_gcp-compute-engine/detectors-gce-instance.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "heartbeat" {
   name = format("%s %s", local.detector_name_prefix, "GCP GCE Instance heartbeat")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
@@ -26,6 +27,7 @@ resource "signalfx_detector" "cpu_utilization" {
   name = format("%s %s", local.detector_name_prefix, "GCP GCE Instance CPU utilization")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('instance/cpu/utilization', ${module.filter-tags.filter_custom})${var.cpu_utilization_aggregation_function}${var.cpu_utilization_transformation_function}.scale(100).publish('signal')
@@ -62,6 +64,7 @@ resource "signalfx_detector" "disk_throttled_bps" {
   name = format("%s %s", local.detector_name_prefix, "GCP GCE Instance disk throttled bps")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('instance/disk/throttled_read_bytes_count', ${module.filter-tags.filter_custom})${var.disk_throttled_bps_aggregation_function}${var.disk_throttled_bps_transformation_function}
@@ -102,6 +105,7 @@ resource "signalfx_detector" "disk_throttled_ops" {
   name = format("%s %s", local.detector_name_prefix, "GCP GCE Instance disk throttled ops")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('instance/disk/throttled_read_ops_count', ${module.filter-tags.filter_custom})${var.disk_throttled_ops_aggregation_function}${var.disk_throttled_ops_transformation_function}

--- a/modules/integration_gcp-load-balancing/detectors-lb.tf
+++ b/modules/integration_gcp-load-balancing/detectors-lb.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "error_rate_4xx" {
   name = format("%s %s", local.detector_name_prefix, "GCP Load Balancer 4xx error rate")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('https/request_count', filter=filter('service', 'loadbalancing') and filter('response_code_class', '400')  and ${module.filter-tags.filter_custom}, extrapolation='zero', rollup='sum')${var.error_rate_4xx_aggregation_function}${var.error_rate_4xx_transformation_function}
@@ -40,6 +41,7 @@ resource "signalfx_detector" "error_rate_5xx" {
   name = format("%s %s", local.detector_name_prefix, "GCP Load Balancer 5xx error rate")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('https/request_count', filter=filter('service', 'loadbalancing') and filter('response_code_class', '400')  and ${module.filter-tags.filter_custom}, extrapolation='zero', rollup='sum')${var.error_rate_5xx_aggregation_function}${var.error_rate_5xx_transformation_function}
@@ -78,6 +80,7 @@ resource "signalfx_detector" "backend_latency_service" {
   name = format("%s %s", local.detector_name_prefix, "GCP Load Balancer backend latency by service")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('https/backend_latencies', filter=filter('service', 'loadbalancing') and filter('backend_target_type', 'BACKEND_SERVICE') and ${module.filter-tags.filter_custom}, extrapolation='zero', rollup='average')${var.backend_latency_service_aggregation_function}${var.backend_latency_service_transformation_function}.publish('signal')
@@ -114,6 +117,7 @@ resource "signalfx_detector" "backend_latency_bucket" {
   name = format("%s %s", local.detector_name_prefix, "GCP Load Balancer backend latency by bucket")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('https/backend_latencies', filter=filter('service', 'loadbalancing') and filter('backend_target_type', 'BACKEND_BUCKET') and ${module.filter-tags.filter_custom}, extrapolation='zero', rollup='average')${var.backend_latency_bucket_aggregation_function}${var.backend_latency_bucket_transformation_function}.publish('signal')
@@ -150,6 +154,7 @@ resource "signalfx_detector" "request_count" {
   name = format("%s %s", local.detector_name_prefix, "GCP Load Balancer request count")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('https/request_count', filter=filter('service', 'loadbalancing') and ${module.filter-tags.filter_custom}, extrapolation='last_value', rollup='sum')${var.request_count_aggregation_function}${var.request_count_transformation_function}.rateofchange().publish('signal')

--- a/modules/integration_gcp-pubsub-subscription/detectors-subscription.tf
+++ b/modules/integration_gcp-pubsub-subscription/detectors-subscription.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "heartbeat" {
   name = format("%s %s", local.detector_name_prefix, "GCP Pub/Sub Subscription heartbeat")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
@@ -26,6 +27,7 @@ resource "signalfx_detector" "oldest_unacked_message" {
   name = format("%s %s", local.detector_name_prefix, "GCP Pub/Sub Subscription oldest unacknowledged message")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('subscription/oldest_unacked_message_age', filter=filter('monitored_resource', 'pubsub_subscription') and ${module.filter-tags.filter_custom})${var.oldest_unacked_message_aggregation_function}${var.oldest_unacked_message_transformation_function}.publish('signal')
@@ -62,6 +64,7 @@ resource "signalfx_detector" "push_latency" {
   name = format("%s %s", local.detector_name_prefix, "GCP Pub/Sub Subscription latency on push endpoint")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('subscription/push_request_latencies', filter=filter('monitored_resource', 'pubsub_subscription') and ${module.filter-tags.filter_custom}, extrapolation='zero', rollup='average')${var.push_latency_aggregation_function}${var.push_latency_transformation_function}.publish('signal')

--- a/modules/integration_gcp-pubsub-topic/detectors-topics.tf
+++ b/modules/integration_gcp-pubsub-topic/detectors-topics.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "sending_operations" {
   name = format("%s %s", local.detector_name_prefix, "GCP Pub/Sub Topic sending messages operations")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     reserved_topics = (not filter('topic_id', 'container-analysis-occurrences*', 'container-analysis-notes*', 'cloud-builds', 'gcr'))
@@ -26,6 +27,7 @@ resource "signalfx_detector" "unavailable_sending_operations" {
   name = format("%s %s", local.detector_name_prefix, "GCP Pub/Sub Topic sending unavailable messages")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     reserved_topics = (not filter('topic_id', 'container-analysis-occurrences*', 'container-analysis-notes*', 'cloud-builds', 'gcr'))
@@ -63,6 +65,7 @@ resource "signalfx_detector" "unavailable_sending_operations_ratio" {
   name = format("%s %s", local.detector_name_prefix, "GCP Pub/Sub Topic sending unavailable messages ratio")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     reserved_topics = (not filter('topic_id', 'container-analysis-occurrences*', 'container-analysis-notes*', 'cloud-builds', 'gcr'))

--- a/modules/integration_newrelic-apm/detectors-new-relic.tf
+++ b/modules/integration_newrelic-apm/detectors-new-relic.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "heartbeat" {
   name = format("%s %s", local.detector_name_prefix, "New Relic heartbeat")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
@@ -26,6 +27,7 @@ resource "signalfx_detector" "error_rate" {
   name = format("%s %s", local.detector_name_prefix, "New Relic error rate")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('Errors/all/errors_per_minute/*', ${module.filter-tags.filter_custom})${var.error_rate_aggregation_function}${var.error_rate_transformation_function}.publish('signal')
@@ -63,6 +65,7 @@ resource "signalfx_detector" "apdex" {
   name = format("%s %s", local.detector_name_prefix, "New Relic apdex score ratio")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('Apdex/score/*', ${module.filter-tags.filter_custom})${var.apdex_aggregation_function}${var.apdex_transformation_function}.publish('signal')

--- a/modules/organization_usage/detectors-usage.tf
+++ b/modules/organization_usage/detectors-usage.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "hosts_limit" {
   name = format("%s %s", local.detector_name_prefix, "Organization usage hosts limit")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('${"sf.org.${var.is_parent ? "child." : ""}numResourcesMonitored"}', filter=filter('resourceType', 'host'))${local.aggregation_function}${var.hosts_limit_transformation_function}.publish('signal')
@@ -26,6 +27,7 @@ resource "signalfx_detector" "containers_limit" {
   name = format("%s %s", local.detector_name_prefix, "Organization usage containers limit")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('${"sf.org.${var.is_parent ? "child." : ""}numResourcesMonitored"}', filter=filter('resourceType', 'container'))${local.aggregation_function}${var.containers_limit_transformation_function}.publish('signal')
@@ -50,6 +52,7 @@ resource "signalfx_detector" "custom_metrics_limit" {
   name = format("%s %s", local.detector_name_prefix, "Organization usage custom metrics limit")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('${"sf.org.${var.is_parent ? "child." : ""}numCustomMetrics"}')${local.aggregation_function}${var.custom_metrics_limit_transformation_function}.publish('signal')
@@ -74,6 +77,7 @@ resource "signalfx_detector" "containers_ratio" {
   name = format("%s %s", local.detector_name_prefix, "Organization usage containers ratio per host included")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     containers = data('${"sf.org.${var.is_parent ? "child." : ""}numResourcesMonitored"}', filter=filter('resourceType', 'container'))${local.aggregation_function}${var.containers_ratio_transformation_function}
@@ -99,6 +103,7 @@ resource "signalfx_detector" "custom_metrics_ratio" {
   name = format("%s %s", local.detector_name_prefix, "Organization usage custom metrics ratio per host included")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     custom_metrics = data('${"sf.org.${var.is_parent ? "child." : ""}numCustomMetrics"}')${local.aggregation_function}${var.custom_metrics_ratio_transformation_function}

--- a/modules/smart-agent_apache/detectors-apache.tf
+++ b/modules/smart-agent_apache/detectors-apache.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "heartbeat" {
   name = format("%s %s", local.detector_name_prefix, "Apache heartbeat")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   max_delay = 900
 
@@ -28,6 +29,7 @@ resource "signalfx_detector" "apache_workers" {
   name = format("%s %s", local.detector_name_prefix, "Apache busy workers")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('apache_connections', filter=${module.filter-tags.filter_custom})${var.apache_workers_aggregation_function}${var.apache_workers_transformation_function}

--- a/modules/smart-agent_cassandra-nodetool/detectors-gen.tf
+++ b/modules/smart-agent_cassandra-nodetool/detectors-gen.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "node_status" {
   name = format("%s %s", local.detector_name_prefix, "Cassandra nodetool node status")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('cassandra.status', filter=${module.filter-tags.filter_custom})${var.node_status_aggregation_function}${var.node_status_transformation_function}.publish('signal')
@@ -38,6 +39,7 @@ resource "signalfx_detector" "node_state" {
   name = format("%s %s", local.detector_name_prefix, "Cassandra nodetool node state")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('cassandra.state', filter=${module.filter-tags.filter_custom})${var.node_state_aggregation_function}${var.node_state_transformation_function}.publish('signal')

--- a/modules/smart-agent_cassandra/detectors-cassandra.tf
+++ b/modules/smart-agent_cassandra/detectors-cassandra.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "heartbeat" {
   name = format("%s %s", local.detector_name_prefix, "Cassandra heartbeat")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   max_delay = 900
 
@@ -28,6 +29,7 @@ resource "signalfx_detector" "read_p99_latency" {
   name = format("%s %s", local.detector_name_prefix, "Cassandra read latency 99th percentile")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('gauge.cassandra.ClientRequest.Read.Latency.99thPercentile', filter=${module.filter-tags.filter_custom}).scale(0.001)${var.read_p99_latency_aggregation_function}${var.read_p99_latency_transformation_function}.publish('signal')
@@ -64,6 +66,7 @@ resource "signalfx_detector" "write_p99_latency" {
   name = format("%s %s", local.detector_name_prefix, "Cassandra write latency 99th percentile")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('gauge.cassandra.ClientRequest.Write.Latency.99thPercentile', filter=${module.filter-tags.filter_custom}).scale(0.001)${var.write_p99_latency_aggregation_function}${var.write_p99_latency_transformation_function}.publish('signal')
@@ -100,6 +103,7 @@ resource "signalfx_detector" "read_real_time_latency" {
   name = format("%s %s", local.detector_name_prefix, "Cassandra read latency real time")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('counter.cassandra.ClientRequest.Read.TotalLatency.Count', filter=${module.filter-tags.filter_custom})${var.read_real_time_latency_aggregation_function}${var.read_real_time_latency_transformation_function}
@@ -138,6 +142,7 @@ resource "signalfx_detector" "write_real_time_latency" {
   name = format("%s %s", local.detector_name_prefix, "Cassandra write latency real time")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('counter.cassandra.ClientRequest.Write.TotalLatency.Count', filter=${module.filter-tags.filter_custom})${var.write_real_time_latency_aggregation_function}${var.write_real_time_latency_transformation_function}
@@ -176,6 +181,7 @@ resource "signalfx_detector" "casread_p99_latency" {
   name = format("%s %s", local.detector_name_prefix, "Cassandra transactional read latency 99th percentile")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('gauge.cassandra.ClientRequest.CASRead.Latency.99thPercentile', filter=${module.filter-tags.filter_custom}).scale(0.001)${var.casread_p99_latency_aggregation_function}${var.casread_p99_latency_transformation_function}.publish('signal')
@@ -212,6 +218,7 @@ resource "signalfx_detector" "caswrite_p99_latency" {
   name = format("%s %s", local.detector_name_prefix, "Cassandra transactional write latency 99th percentile")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('gauge.cassandra.ClientRequest.CASWrite.Latency.99thPercentile', filter=${module.filter-tags.filter_custom}).scale(0.001)${var.caswrite_p99_latency_aggregation_function}${var.caswrite_p99_latency_transformation_function}.publish('signal')
@@ -248,6 +255,7 @@ resource "signalfx_detector" "casread_real_time_latency" {
   name = format("%s %s", local.detector_name_prefix, "Cassandra transactional read latency real time")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('counter.cassandra.ClientRequest.CASRead.TotalLatency.Count', filter=${module.filter-tags.filter_custom})${var.casread_real_time_latency_aggregation_function}${var.casread_real_time_latency_transformation_function}
@@ -286,6 +294,7 @@ resource "signalfx_detector" "caswrite_real_time_latency" {
   name = format("%s %s", local.detector_name_prefix, "Cassandra transactional write latency real time")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('counter.cassandra.ClientRequest.CASWrite.TotalLatency.Count', filter=${module.filter-tags.filter_custom})${var.caswrite_real_time_latency_aggregation_function}${var.caswrite_real_time_latency_transformation_function}
@@ -324,6 +333,7 @@ resource "signalfx_detector" "storage_exceptions" {
   name = format("%s %s", local.detector_name_prefix, "Cassandra storage exceptions count")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('counter.cassandra.Storage.Exceptions.Count', filter=${module.filter-tags.filter_custom})${var.storage_exceptions_aggregation_function}${var.storage_exceptions_transformation_function}.publish('signal')

--- a/modules/smart-agent_couchbase/detectors-gen.tf
+++ b/modules/smart-agent_couchbase/detectors-gen.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "memory_used" {
   name = format("%s %s", local.detector_name_prefix, "Couchbase memory used")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   viz_options {
     label        = "signal"
@@ -45,6 +46,7 @@ resource "signalfx_detector" "out_of_memory_errors" {
   name = format("%s %s", local.detector_name_prefix, "Couchbase out of memory errors")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('gauge.bucket.op.ep_oom_errors', filter=${module.filter-tags.filter_custom})${var.out_of_memory_errors_aggregation_function}${var.out_of_memory_errors_transformation_function}.publish('signal')
@@ -68,6 +70,7 @@ resource "signalfx_detector" "disk_write_queue" {
   name = format("%s %s", local.detector_name_prefix, "Couchbase disk write queue")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('gauge.bucket.op.disk_write_queue', filter=${module.filter-tags.filter_custom})${var.disk_write_queue_aggregation_function}${var.disk_write_queue_transformation_function}.publish('signal')

--- a/modules/smart-agent_dns/detectors-dns.tf
+++ b/modules/smart-agent_dns/detectors-dns.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "heartbeat" {
   name = format("%s %s", local.detector_name_prefix, "DNS heartbeat")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   max_delay = 900
 
@@ -28,6 +29,7 @@ resource "signalfx_detector" "dns_query_time" {
   name = format("%s %s", local.detector_name_prefix, "DNS query time")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('dns.query_time_ms', filter=filter('plugin', 'telegraf/dns') and ${module.filter-tags.filter_custom})${var.dns_query_time_aggregation_function}${var.dns_query_time_transformation_function}.publish('signal')
@@ -64,6 +66,7 @@ resource "signalfx_detector" "dns_result_code" {
   name = format("%s %s", local.detector_name_prefix, "DNS query result")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('dns.result_code', filter=filter('plugin', 'telegraf/dns') and ${module.filter-tags.filter_custom})${var.dns_result_code_aggregation_function}${var.dns_result_code_transformation_function}.publish('signal')

--- a/modules/smart-agent_docker/detectors-docker.tf
+++ b/modules/smart-agent_docker/detectors-docker.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "heartbeat" {
   name = format("%s %s", local.detector_name_prefix, "Docker host heartbeat")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   max_delay = 900
 
@@ -28,6 +29,7 @@ resource "signalfx_detector" "cpu" {
   name = format("%s %s", local.detector_name_prefix, "Docker container usage of cpu host")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
 		signal = data('cpu.percent', filter=filter('plugin', 'docker') and ${module.filter-tags.filter_custom})${var.cpu_aggregation_function}${var.cpu_transformation_function}.publish('signal')
@@ -64,6 +66,7 @@ resource "signalfx_detector" "throttling" {
   name = format("%s %s", local.detector_name_prefix, "Docker container cpu throttling time")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
 		A = data('cpu.throttling_data.throttled_time', filter=filter('plugin', 'docker') and ${module.filter-tags.filter_custom}, rollup='delta')${var.throttling_aggregation_function}${var.throttling_transformation_function}
@@ -102,6 +105,7 @@ resource "signalfx_detector" "memory" {
   name = format("%s %s", local.detector_name_prefix, "Docker memory usage")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
 		A = data('memory.usage.total', filter=filter('plugin', 'docker') and ${module.filter-tags.filter_custom})${var.memory_aggregation_function}${var.memory_transformation_function}

--- a/modules/smart-agent_elasticsearch/detectors-elasticsearch.tf
+++ b/modules/smart-agent_elasticsearch/detectors-elasticsearch.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "heartbeat" {
   name = format("%s %s", local.detector_name_prefix, "ElasticSearch heartbeat")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   max_delay = 900
 
@@ -28,6 +29,7 @@ resource "signalfx_detector" "cluster_status" {
   name = format("%s %s", local.detector_name_prefix, "ElasticSearch cluster status")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('elasticsearch.cluster.status', filter=filter('plugin', 'elasticsearch') and ${module.filter-tags.filter_custom})${var.cluster_status_aggregation_function}${var.cluster_status_transformation_function}.publish('signal')
@@ -64,6 +66,7 @@ resource "signalfx_detector" "cluster_initializing_shards" {
   name = format("%s %s", local.detector_name_prefix, "ElasticSearch cluster initializing shards")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('elasticsearch.cluster.initializing-shards', filter=filter('plugin', 'elasticsearch') and ${module.filter-tags.filter_custom}, rollup='average')${var.cluster_initializing_shards_aggregation_function}${var.cluster_initializing_shards_transformation_function}.publish('signal')
@@ -100,6 +103,7 @@ resource "signalfx_detector" "cluster_relocating_shards" {
   name = format("%s %s", local.detector_name_prefix, "ElasticSearch cluster relocating shards")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('elasticsearch.cluster.relocating-shards', filter=filter('plugin', 'elasticsearch') and ${module.filter-tags.filter_custom}, rollup='average')${var.cluster_relocating_shards_aggregation_function}${var.cluster_relocating_shards_transformation_function}.publish('signal')
@@ -136,6 +140,7 @@ resource "signalfx_detector" "cluster_unassigned_shards" {
   name = format("%s %s", local.detector_name_prefix, "ElasticSearch Cluster unassigned shards")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('elasticsearch.cluster.unassigned-shards', filter=filter('plugin', 'elasticsearch') and ${module.filter-tags.filter_custom}, rollup='average')${var.cluster_unassigned_shards_aggregation_function}${var.cluster_unassigned_shards_transformation_function}.publish('signal')
@@ -172,6 +177,7 @@ resource "signalfx_detector" "pending_tasks" {
   name = format("%s %s", local.detector_name_prefix, "ElasticSearch Pending tasks")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('elasticsearch.cluster.pending-tasks', filter=filter('plugin', 'elasticsearch') and ${module.filter-tags.filter_custom}, rollup='average')${var.pending_tasks_aggregation_function}${var.pending_tasks_transformation_function}.publish('signal')
@@ -208,6 +214,7 @@ resource "signalfx_detector" "cpu_usage" {
   name = format("%s %s", local.detector_name_prefix, "Elasticsearch CPU usage")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('elasticsearch.process.cpu.percent', filter=filter('plugin', 'elasticsearch') and filter('node_name', '*') and ${module.filter-tags.filter_custom}, rollup='average')${var.cpu_usage_aggregation_function}${var.cpu_usage_transformation_function}.publish('signal')
@@ -244,6 +251,7 @@ resource "signalfx_detector" "file_descriptors" {
   name = format("%s %s", local.detector_name_prefix, "Elasticsearch file descriptors usage")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('elasticsearch.process.open_file_descriptors', filter=filter('plugin', 'elasticsearch') and filter('node_name', '*') and ${module.filter-tags.filter_custom}, rollup='average')${var.file_descriptors_aggregation_function}${var.file_descriptors_transformation_function}
@@ -282,6 +290,7 @@ resource "signalfx_detector" "jvm_heap_memory_usage" {
   name = format("%s %s", local.detector_name_prefix, "Elasticsearch JVM heap memory usage")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('elasticsearch.jvm.mem.heap-used-percent', filter=filter('plugin', 'elasticsearch') and filter('node_name', '*') and ${module.filter-tags.filter_custom}, rollup='average')${var.jvm_heap_memory_usage_aggregation_function}${var.jvm_heap_memory_usage_transformation_function}.publish('signal')
@@ -318,6 +327,7 @@ resource "signalfx_detector" "jvm_memory_young_usage" {
   name = format("%s %s", local.detector_name_prefix, "Elasticsearch JVM memory young usage")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('elasticsearch.jvm.mem.pools.young.used_in_bytes', filter=filter('plugin', 'elasticsearch') and filter('node_name', '*') and ${module.filter-tags.filter_custom}, rollup='average')${var.jvm_memory_young_usage_aggregation_function}${var.jvm_memory_young_usage_transformation_function}
@@ -356,6 +366,7 @@ resource "signalfx_detector" "jvm_memory_old_usage" {
   name = format("%s %s", local.detector_name_prefix, "Elasticsearch JVM memory old usage")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('elasticsearch.jvm.mem.pools.old.used_in_bytes', filter=filter('plugin', 'elasticsearch') and filter('node_name', '*') and ${module.filter-tags.filter_custom}, rollup='average')${var.jvm_memory_old_usage_aggregation_function}${var.jvm_memory_old_usage_transformation_function}
@@ -394,6 +405,7 @@ resource "signalfx_detector" "jvm_gc_old_collection_latency" {
   name = format("%s %s", local.detector_name_prefix, "Elasticsearch old-generation garbage collections latency")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('elasticsearch.jvm.gc.old-time', filter=filter('plugin', 'elasticsearch') and filter('node_name', '*') and ${module.filter-tags.filter_custom}, extrapolation='zero', rollup='delta')${var.jvm_gc_old_collection_latency_aggregation_function}${var.jvm_gc_old_collection_latency_transformation_function}
@@ -432,6 +444,7 @@ resource "signalfx_detector" "jvm_gc_young_collection_latency" {
   name = format("%s %s", local.detector_name_prefix, "Elasticsearch young-generation garbage collections latency")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('elasticsearch.jvm.gc.time', filter=filter('plugin', 'elasticsearch') and filter('node_name', '*') and ${module.filter-tags.filter_custom}, extrapolation='zero', rollup='delta')${var.jvm_gc_young_collection_latency_aggregation_function}${var.jvm_gc_young_collection_latency_transformation_function}
@@ -470,6 +483,7 @@ resource "signalfx_detector" "indexing_latency" {
   name = format("%s %s", local.detector_name_prefix, "Elasticsearch indexing latency")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('elasticsearch.indices.indexing.index-time', filter=filter('plugin', 'elasticsearch') and filter('node_name', '*') and ${module.filter-tags.filter_custom}, extrapolation='zero', rollup='delta')${var.indexing_latency_aggregation_function}${var.indexing_latency_transformation_function}
@@ -508,6 +522,7 @@ resource "signalfx_detector" "flush_latency" {
   name = format("%s %s", local.detector_name_prefix, "Elasticsearch index flushing to disk latency")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('elasticsearch.indices.flush.total-time', filter=filter('plugin', 'elasticsearch') and filter('node_name', '*') and ${module.filter-tags.filter_custom}, extrapolation='zero', rollup='delta')${var.flush_latency_aggregation_function}${var.flush_latency_transformation_function}
@@ -546,6 +561,7 @@ resource "signalfx_detector" "search_latency" {
   name = format("%s %s", local.detector_name_prefix, "Elasticsearch search query latency")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('elasticsearch.indices.search.query-time', filter=filter('plugin', 'elasticsearch') and filter('node_name', '*') and ${module.filter-tags.filter_custom}, extrapolation='zero', rollup='delta')${var.search_latency_aggregation_function}${var.search_latency_transformation_function}
@@ -584,6 +600,7 @@ resource "signalfx_detector" "fetch_latency" {
   name = format("%s %s", local.detector_name_prefix, "Elasticsearch search fetch latency")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('elasticsearch.indices.search.fetch-time', filter=filter('plugin', 'elasticsearch') and filter('node_name', '*') and ${module.filter-tags.filter_custom}, extrapolation='zero', rollup='delta')${var.fetch_latency_aggregation_function}${var.fetch_latency_transformation_function}
@@ -622,6 +639,7 @@ resource "signalfx_detector" "field_data_evictions_change" {
   name = format("%s %s", local.detector_name_prefix, "Elasticsearch fielddata cache evictions rate of change")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('elasticsearch.indices.fielddata.evictions', filter=filter('plugin', 'elasticsearch') and filter('node_name', '*') and ${module.filter-tags.filter_custom}, extrapolation='zero', rollup='delta').rateofchange()${var.field_data_evictions_change_aggregation_function}${var.field_data_evictions_change_transformation_function}.publish('signal')
@@ -658,6 +676,7 @@ resource "signalfx_detector" "task_time_in_queue_change" {
   name = format("%s %s", local.detector_name_prefix, "Elasticsearch max time spent by task in queue rate of change")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('elasticsearch.cluster.task-max-wait-time', filter=filter('plugin', 'elasticsearch') and ${module.filter-tags.filter_custom}, rollup='average').rateofchange()${var.task_time_in_queue_change_aggregation_function}${var.task_time_in_queue_change_transformation_function}.publish('signal')

--- a/modules/smart-agent_genericjmx/detectors-genericjmx.tf
+++ b/modules/smart-agent_genericjmx/detectors-genericjmx.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "jmx_memory_heap" {
   name = format("%s %s", local.detector_name_prefix, "JMX memory heap usage")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('jmx_memory.used', filter=filter('plugin_instance', 'memory-heap') and ${module.filter-tags.filter_custom})${var.memory_heap_aggregation_function}${var.memory_heap_transformation_function}
@@ -39,6 +40,7 @@ resource "signalfx_detector" "jmx_old_gen" {
   name = format("%s %s", local.detector_name_prefix, "JMX GC old generation usage")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('jmx_memory.used', filter=filter('plugin_instance', 'memory_pool-G1 Old Gen') and ${module.filter-tags.filter_custom})${var.gc_old_gen_aggregation_function}${var.gc_old_gen_transformation_function}

--- a/modules/smart-agent_haproxy/detectors-haproxy.tf
+++ b/modules/smart-agent_haproxy/detectors-haproxy.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "heartbeat" {
   name = format("%s %s", local.detector_name_prefix, "Haproxy heartbeat")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   max_delay = 900
 
@@ -28,6 +29,7 @@ resource "signalfx_detector" "server_status" {
   name = format("%s %s", local.detector_name_prefix, "Haproxy server status")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('haproxy_status', filter=filter('type', '2') and ${module.filter-tags.filter_custom})${var.server_status_aggregation_function}${var.server_status_transformation_function}.publish('signal')
@@ -51,6 +53,7 @@ resource "signalfx_detector" "backend_status" {
   name = format("%s %s", local.detector_name_prefix, "Haproxy backend status")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('haproxy_status', filter=filter('type', '1') and ${module.filter-tags.filter_custom})${var.backend_status_aggregation_function}${var.backend_status_transformation_function}.publish('signal')
@@ -74,6 +77,7 @@ resource "signalfx_detector" "session_limit" {
   name = format("%s %s", local.detector_name_prefix, "Haproxy session")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('haproxy_session_current', filter=filter('type', '0', '2') and ${module.filter-tags.filter_custom})${var.session_limit_aggregation_function}${var.session_limit_transformation_function}
@@ -112,6 +116,7 @@ resource "signalfx_detector" "http_5xx_response" {
   name = format("%s %s", local.detector_name_prefix, "Haproxy 5xx response rate")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('haproxy_response_5xx', filter=${module.filter-tags.filter_custom}, rollup='delta')${var.http_5xx_response_aggregation_function}${var.http_5xx_response_transformation_function}
@@ -150,6 +155,7 @@ resource "signalfx_detector" "http_4xx_response" {
   name = format("%s %s", local.detector_name_prefix, "Haproxy 4xx response rate")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('haproxy_response_4xx', filter=${module.filter-tags.filter_custom}, rollup='delta')${var.http_4xx_response_aggregation_function}${var.http_4xx_response_transformation_function}

--- a/modules/smart-agent_http/detectors-http.tf
+++ b/modules/smart-agent_http/detectors-http.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "heartbeat" {
   name = format("%s %s", local.detector_name_prefix, "HTTP heartbeat")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   max_delay = 900
 
@@ -28,6 +29,7 @@ resource "signalfx_detector" "http_code_matched" {
   name = format("%s %s", local.detector_name_prefix, "HTTP code")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('http.code_matched', filter=${module.filter-tags.filter_custom}, rollup='max')${var.http_code_matched_aggregation_function}${var.http_code_matched_transformation_function}.publish('signal')
@@ -52,6 +54,7 @@ resource "signalfx_detector" "http_regex_matched" {
   name = format("%s %s", local.detector_name_prefix, "HTTP regex expression")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('http.regex_matched', filter=${module.filter-tags.filter_custom}, rollup='min')${var.http_regex_matched_aggregation_function}${var.http_regex_matched_transformation_function}.publish('signal')
@@ -76,6 +79,7 @@ resource "signalfx_detector" "http_response_time" {
   name = format("%s %s", local.detector_name_prefix, "HTTP response time")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('http.response_time', filter=${module.filter-tags.filter_custom}, rollup='max')${var.http_response_time_aggregation_function}${var.http_response_time_transformation_function}.publish('signal')
@@ -112,6 +116,7 @@ resource "signalfx_detector" "http_content_length" {
   name = format("%s %s", local.detector_name_prefix, "HTTP content length")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('http.content_length', filter=${module.filter-tags.filter_custom}, rollup='min')${var.http_content_length_aggregation_function}${var.http_content_length_transformation_function}.publish('signal')
@@ -135,6 +140,7 @@ resource "signalfx_detector" "certificate_expiration_date" {
   name = format("%s %s", local.detector_name_prefix, "TLS certificate expiry date")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('http.cert_expiry', filter=${module.filter-tags.filter_custom}, rollup='min')${var.certificate_expiration_date_aggregation_function}${var.certificate_expiration_date_transformation_function}
@@ -172,6 +178,7 @@ resource "signalfx_detector" "invalid_tls_certificate" {
   name = format("%s %s", local.detector_name_prefix, "TLS certificate")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('http.cert_valid', filter=${module.filter-tags.filter_custom}, rollup='min')${var.invalid_tls_certificate_aggregation_function}${var.invalid_tls_certificate_transformation_function}.publish('signal')

--- a/modules/smart-agent_kong/detectors-kong.tf
+++ b/modules/smart-agent_kong/detectors-kong.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "heartbeat" {
   name = format("%s %s", local.detector_name_prefix, "Kong heartbeat")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   max_delay = 900
 
@@ -28,6 +29,7 @@ resource "signalfx_detector" "treatment_limit" {
   name = format("%s %s", local.detector_name_prefix, "Kong treatment limit")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('kong_nginx_http_current_connections', filter=filter('state', 'handled') and ${module.filter-tags.filter_custom})${var.treatment_limit_aggregation_function}${var.treatment_limit_transformation_function}

--- a/modules/smart-agent_kubernetes-apiserver/detectors-k8s-cluster.tf
+++ b/modules/smart-agent_kubernetes-apiserver/detectors-k8s-cluster.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "heartbeat" {
   name = format("%s %s", local.detector_name_prefix, "Kubernetes API server heartbeat")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting

--- a/modules/smart-agent_kubernetes-common/detectors-kubernetes-common.tf
+++ b/modules/smart-agent_kubernetes-common/detectors-kubernetes-common.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "heartbeat" {
   name = format("%s %s", local.detector_name_prefix, "Kubernetes node heartbeat")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
@@ -26,6 +27,7 @@ resource "signalfx_detector" "node_ready" {
   name = format("%s %s", local.detector_name_prefix, "Kubernetes node status")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('kubernetes.node_ready', filter=${module.filter-tags.filter_custom})${var.node_ready_aggregation_function}${var.node_ready_transformation_function}.fill(1).publish('signal')
@@ -62,6 +64,7 @@ resource "signalfx_detector" "pod_phase_status" {
   name = format("%s %s", local.detector_name_prefix, "Kubernetes pod status phase")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('kubernetes.pod_phase', filter=(not filter('job', '*')) and (not filter('cronjob', '*')) and ${module.filter-tags.filter_custom})${var.pod_phase_status_aggregation_function}${var.pod_phase_status_transformation_function}.fill(2).publish('signal')
@@ -85,6 +88,7 @@ resource "signalfx_detector" "terminated" {
   name = format("%s %s", local.detector_name_prefix, "Kubernetes pod terminated abnormally")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('kubernetes.container_ready', filter=filter('container_status', 'terminated') and (not filter('container_status_reason', 'Completed')) and ${module.filter-tags.filter_custom})${var.terminated_aggregation_function}${var.terminated_transformation_function}.publish('signal')
@@ -108,6 +112,7 @@ resource "signalfx_detector" "oom_killed" {
   name = format("%s %s", local.detector_name_prefix, "Kubernetes container killed by OOM")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('kubernetes.container_ready', filter=filter('container_status', 'terminated') and filter('container_status_reason', 'OOMKilled') and ${module.filter-tags.filter_custom})${var.oom_killed_aggregation_function}${var.oom_killed_transformation_function}.count().publish('signal')
@@ -131,6 +136,7 @@ resource "signalfx_detector" "deployment_crashloopbackoff" {
   name = format("%s %s", local.detector_name_prefix, "Kubernetes deployment in CrashLoopBackOff")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('kubernetes.container_restart_count', filter=filter('container_status', 'waiting') and filter('deployment', '*') and filter('container_status_reason', 'CrashLoopBackOff') and ${module.filter-tags.filter_custom}, extrapolation='zero')${var.deployment_crashloopbackoff_aggregation_function}${var.deployment_crashloopbackoff_transformation_function}.publish('signal')
@@ -154,6 +160,7 @@ resource "signalfx_detector" "daemonset_crashloopbackoff" {
   name = format("%s %s", local.detector_name_prefix, "Kubernetes daemonset in CrashLoopBackOff")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('kubernetes.container_restart_count', filter=filter('container_status', 'waiting') and filter('daemonSet', '*') and filter('container_status_reason', 'CrashLoopBackOff') and ${module.filter-tags.filter_custom}, extrapolation='zero')${var.daemonset_crashloopbackoff_aggregation_function}${var.daemonset_crashloopbackoff_transformation_function}.publish('signal')
@@ -177,6 +184,7 @@ resource "signalfx_detector" "job_failed" {
   name = format("%s %s", local.detector_name_prefix, "Kubernetes job from cronjob failed")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('kubernetes.job.completions', extrapolation='zero', filter=${module.filter-tags.filter_custom})${var.job_failed_aggregation_function}${var.job_failed_transformation_function}
@@ -203,6 +211,7 @@ resource "signalfx_detector" "daemonset_scheduled" {
   name = format("%s %s", local.detector_name_prefix, "Kubernetes daemonsets not scheduled")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('kubernetes.daemon_set.desired_scheduled', filter=${module.filter-tags.filter_custom})${var.daemonset_scheduled_aggregation_function}${var.daemonset_scheduled_transformation_function}
@@ -228,6 +237,7 @@ resource "signalfx_detector" "daemonset_ready" {
   name = format("%s %s", local.detector_name_prefix, "Kubernetes daemonsets not ready")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('kubernetes.daemon_set.ready', filter=${module.filter-tags.filter_custom})${var.daemonset_ready_aggregation_function}${var.daemonset_ready_transformation_function}
@@ -253,6 +263,7 @@ resource "signalfx_detector" "daemonset_misscheduled" {
   name = format("%s %s", local.detector_name_prefix, "Kubernetes daemonsets misscheduled")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('kubernetes.daemon_set.misscheduled', filter=${module.filter-tags.filter_custom})${var.daemonset_misscheduled_aggregation_function}${var.daemonset_misscheduled_transformation_function}.publish('signal')
@@ -276,6 +287,7 @@ resource "signalfx_detector" "deployment_available" {
   name = format("%s %s", local.detector_name_prefix, "Kubernetes deployments available")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('kubernetes.deployment.desired', filter=${module.filter-tags.filter_custom})${var.deployment_available_aggregation_function}${var.deployment_available_transformation_function}
@@ -301,6 +313,7 @@ resource "signalfx_detector" "replicaset_available" {
   name = format("%s %s", local.detector_name_prefix, "Kubernetes replicasets available")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('kubernetes.replica_set.desired', filter=${module.filter-tags.filter_custom})${var.replicaset_available_aggregation_function}${var.replicaset_available_transformation_function}
@@ -326,6 +339,7 @@ resource "signalfx_detector" "replication_controller_available" {
   name = format("%s %s", local.detector_name_prefix, "Kubernetes replication_controllers available")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('kubernetes.replication_controller.desired', filter=${module.filter-tags.filter_custom})${var.replication_controller_available_aggregation_function}${var.replication_controller_available_transformation_function}
@@ -351,6 +365,7 @@ resource "signalfx_detector" "statefulset_ready" {
   name = format("%s %s", local.detector_name_prefix, "Kubernetes statefulsets ready")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('kubernetes.stateful_set.desired', filter=${module.filter-tags.filter_custom})${var.statefulset_ready_aggregation_function}${var.statefulset_ready_transformation_function}

--- a/modules/smart-agent_kubernetes-velero/detectors-velero.tf
+++ b/modules/smart-agent_kubernetes-velero/detectors-velero.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "velero_scheduled_backup_missing" {
   name = format("%s %s", local.detector_name_prefix, "Kubernetes velero successful backup")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('velero_backup_success_total', filter=filter('schedule', '*') and ${module.filter-tags.filter_custom}, extrapolation='zero', rollup='delta')${var.velero_scheduled_backup_missing_aggregation_function}${var.velero_scheduled_backup_missing_transformation_function}.publish('signal')
@@ -25,6 +26,7 @@ resource "signalfx_detector" "velero_backup_failure" {
   name = format("%s %s", local.detector_name_prefix, "Kubernetes velero failed backup")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('velero_backup_failure_total', filter=filter('schedule', '*') and ${module.filter-tags.filter_custom}, extrapolation='zero', rollup='delta')${var.velero_backup_failure_aggregation_function}${var.velero_backup_failure_transformation_function}.publish('signal')
@@ -48,6 +50,7 @@ resource "signalfx_detector" "velero_backup_partial_failure" {
   name = format("%s %s", local.detector_name_prefix, "Kubernetes velero failed partial backup")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('velero_backup_partial_failure_total', filter=filter('schedule', '*') and ${module.filter-tags.filter_custom}, extrapolation='zero', rollup='delta')${var.velero_backup_partial_failure_aggregation_function}${var.velero_backup_partial_failure_transformation_function}.publish('signal')
@@ -71,6 +74,7 @@ resource "signalfx_detector" "velero_backup_deletion_failure" {
   name = format("%s %s", local.detector_name_prefix, "Kubernetes velero failed backup deletion")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('velero_backup_deletion_failure_total', filter=filter('schedule', '*') and ${module.filter-tags.filter_custom}, extrapolation='zero', rollup='delta')${var.velero_backup_deletion_failure_aggregation_function}${var.velero_backup_deletion_failure_transformation_function}.publish('signal')
@@ -94,6 +98,7 @@ resource "signalfx_detector" "velero_volume_snapshot_failure" {
   name = format("%s %s", local.detector_name_prefix, "Kubernetes velero failed volume snapshot")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('velero_volume_snapshot_failure_total', filter=filter('schedule', '*') and ${module.filter-tags.filter_custom}, extrapolation='zero', rollup='delta')${var.velero_volume_snapshot_failure_aggregation_function}${var.velero_volume_snapshot_failure_transformation_function}.publish('signal')

--- a/modules/smart-agent_kubernetes-volumes/detectors-kubernetes-volumes.tf
+++ b/modules/smart-agent_kubernetes-volumes/detectors-kubernetes-volumes.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "volume_space" {
   name = format("%s %s", local.detector_name_prefix, "Kubernetes node volume space usage")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('kubernetes.volume_available_bytes', filter=${module.filter-tags.filter_custom} and not filter('volume_type', 'configMap', 'secret'))${var.volume_space_aggregation_function}${var.volume_space_transformation_function}
@@ -40,6 +41,7 @@ resource "signalfx_detector" "volume_inodes" {
   name = format("%s %s", local.detector_name_prefix, "Kubernetes node volume inodes usage")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('kubernetes.volume_inodes_free', filter=${module.filter-tags.filter_custom} and not filter('volume_type', 'configMap', 'secret'))${var.volume_inodes_aggregation_function}${var.volume_inodes_transformation_function}

--- a/modules/smart-agent_memcached/detectors-memcached.tf
+++ b/modules/smart-agent_memcached/detectors-memcached.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "heartbeat" {
   name = format("%s %s", local.detector_name_prefix, "Memcached heartbeat")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   max_delay = 900
 
@@ -28,6 +29,7 @@ resource "signalfx_detector" "memcached_max_conn" {
   name = format("%s %s", local.detector_name_prefix, "Memcached max conn")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('total_events.listen_disabled', filter=${module.filter-tags.filter_custom}, rollup='delta')${var.memcached_max_conn_aggregation_function}${var.memcached_max_conn_transformation_function}.publish('signal')
@@ -64,6 +66,7 @@ resource "signalfx_detector" "memcached_hit_ratio" {
   name = format("%s %s", local.detector_name_prefix, "Memcached hit ratio")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('memcached_ops.hits', filter=${module.filter-tags.filter_custom})${var.memcached_hit_ratio_aggregation_function}${var.memcached_hit_ratio_transformation_function}

--- a/modules/smart-agent_mongodb/detectors-mongo.tf
+++ b/modules/smart-agent_mongodb/detectors-mongo.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "heartbeat" {
   name = format("%s %s", local.detector_name_prefix, "MongoDB heartbeat")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   max_delay = 900
 
@@ -28,6 +29,7 @@ resource "signalfx_detector" "page_faults" {
   name = format("%s %s", local.detector_name_prefix, "MongoDB page faults")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('counter.extra_info.page_faults', filter=${module.filter-tags.filter_custom})${var.page_faults_aggregation_function}${var.page_faults_transformation_function}.publish('signal')
@@ -51,6 +53,7 @@ resource "signalfx_detector" "max_connections" {
   name = format("%s %s", local.detector_name_prefix, "MongoDB number of connections over max capacity")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('gauge.connections.current', filter=${module.filter-tags.filter_custom})${var.max_connections_aggregation_function}${var.max_connections_transformation_function}
@@ -89,6 +92,7 @@ resource "signalfx_detector" "asserts" {
   name = format("%s %s", local.detector_name_prefix, "MongoDB asserts (warning and regular) errors")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('counter.asserts.regular', filter=${module.filter-tags.filter_custom})${var.asserts_aggregation_function}${var.asserts_transformation_function}
@@ -114,6 +118,7 @@ resource "signalfx_detector" "primary" {
   name = format("%s %s", local.detector_name_prefix, "MongoDB primary in replicaset")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('gauge.repl.is_primary_node', filter=${module.filter-tags.filter_custom})${var.primary_aggregation_function}${var.primary_transformation_function}.publish('signal')
@@ -137,6 +142,7 @@ resource "signalfx_detector" "secondary" {
   name = format("%s %s", local.detector_name_prefix, "MongoDB secondary members count in replicaset")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('gauge.repl.active_nodes', filter=${module.filter-tags.filter_custom})${var.secondary_aggregation_function}${var.secondary_transformation_function}
@@ -162,6 +168,7 @@ resource "signalfx_detector" "replication_lag" {
   name = format("%s %s", local.detector_name_prefix, "MongoDB replication lag")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('gauge.repl.max_lag', filter=${module.filter-tags.filter_custom})${var.replication_lag_aggregation_function}${var.replication_lag_transformation_function}.publish('signal')

--- a/modules/smart-agent_mysql/detectors-mysql.tf
+++ b/modules/smart-agent_mysql/detectors-mysql.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "heartbeat" {
   name = format("%s %s", local.detector_name_prefix, "MySQL heartbeat")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   max_delay = 900
 
@@ -28,6 +29,7 @@ resource "signalfx_detector" "mysql_connections" {
   name = format("%s %s", local.detector_name_prefix, "MySQL number of connections over max capacity")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('mysql_threads_connected', filter=${module.filter-tags.filter_custom}, rollup='average')${var.connections_aggregation_function}${var.connections_transformation_function}
@@ -66,6 +68,7 @@ resource "signalfx_detector" "mysql_slow" {
   name = format("%s %s", local.detector_name_prefix, "MySQL slow queries percentage")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('mysql_slow_queries', filter=(not filter('plugin', 'mysql')) and ${module.filter-tags.filter_custom}, rollup='delta')${var.slow_aggregation_function}${var.slow_transformation_function}
@@ -104,6 +107,7 @@ resource "signalfx_detector" "mysql_pool_efficiency" {
   name = format("%s %s", local.detector_name_prefix, "MySQL Innodb buffer pool efficiency")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('mysql_bpool_counters.reads', filter=filter('plugin', 'mysql') and ${module.filter-tags.filter_custom}, rollup='delta')${var.pool_efficiency_aggregation_function}${var.pool_efficiency_transformation_function}
@@ -142,6 +146,7 @@ resource "signalfx_detector" "mysql_pool_utilization" {
   name = format("%s %s", local.detector_name_prefix, "MySQL Innodb buffer pool utilization")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('mysql_bpool_pages.free', filter=filter('plugin', 'mysql') and ${module.filter-tags.filter_custom}, rollup='average')${var.pool_utilization_aggregation_function}${var.pool_utilization_transformation_function}
@@ -180,6 +185,7 @@ resource "signalfx_detector" "mysql_threads_anomaly" {
   name = format("%s %s", local.detector_name_prefix, "MySQL running threads changed abruptly")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     from signalfx.detectors.against_periods import against_periods
@@ -204,6 +210,7 @@ resource "signalfx_detector" "mysql_questions_anomaly" {
   name = format("%s %s", local.detector_name_prefix, "MySQL running queries changed abruptly")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     from signalfx.detectors.against_periods import against_periods
@@ -228,6 +235,7 @@ resource "signalfx_detector" "mysql_replication_lag" {
   name = format("%s %s", local.detector_name_prefix, "MySQL replication lag")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('mysql_seconds_behind_master', filter=${module.filter-tags.filter_custom}, rollup='average')${var.replication_lag_aggregation_function}${var.replication_lag_transformation_function}.publish('signal')
@@ -264,6 +272,7 @@ resource "signalfx_detector" "mysql_slave_sql_status" {
   name = format("%s %s", local.detector_name_prefix, "MySQL slave sql status")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('mysql_slave_sql_running', filter=${module.filter-tags.filter_custom}, rollup='average')${var.slave_sql_status_aggregation_function}${var.slave_sql_status_transformation_function}.publish('signal')
@@ -287,6 +296,7 @@ resource "signalfx_detector" "mysql_slave_io_status" {
   name = format("%s %s", local.detector_name_prefix, "MySQL slave sql status")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('mysql_slave_io_running', filter=${module.filter-tags.filter_custom}, rollup='average')${var.slave_io_status_aggregation_function}${var.slave_io_status_transformation_function}.publish('signal')

--- a/modules/smart-agent_nagios-status-check/detectors-nagios-status-check.tf
+++ b/modules/smart-agent_nagios-status-check/detectors-nagios-status-check.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "status_check" {
   name = format("%s %s", local.detector_name_prefix, "Nagios check status")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         signal = data('nagios.state', filter=${module.filter-tags.filter_custom})${var.status_check_aggregation_function}${var.status_check_transformation_function}.publish('signal')

--- a/modules/smart-agent_nginx-ingress/detectors-ingress-nginx.tf
+++ b/modules/smart-agent_nginx-ingress/detectors-ingress-nginx.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "nginx_ingress_5xx" {
   name = format("%s %s", local.detector_name_prefix, "Kubernetes Ingress Nginx 5xx errors ratio")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('nginx_ingress_controller_requests', filter=filter('status', '5*') and ${module.filter-tags.filter_custom}, rollup='delta', extrapolation='zero')${var.ingress_5xx_aggregation_function}${var.ingress_5xx_transformation_function}
@@ -40,6 +41,7 @@ resource "signalfx_detector" "nginx_ingress_4xx" {
   name = format("%s %s", local.detector_name_prefix, "Kubernetes Ingress Nginx 4xx errors ratio")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('nginx_ingress_controller_requests', filter=filter('status', '4*') and ${module.filter-tags.filter_custom}, rollup='delta', extrapolation='zero')${var.ingress_4xx_aggregation_function}${var.ingress_4xx_transformation_function}
@@ -78,6 +80,7 @@ resource "signalfx_detector" "nginx_ingress_latency" {
   name = format("%s %s", local.detector_name_prefix, "Kubernetes Ingress Nginx latency")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('nginx_ingress_controller_ingress_upstream_latency_seconds', filter=${module.filter-tags.filter_custom}, rollup='delta', extrapolation='zero')${var.ingress_latency_aggregation_function}${var.ingress_latency_transformation_function}.publish('signal')

--- a/modules/smart-agent_nginx/detectors-nginx.tf
+++ b/modules/smart-agent_nginx/detectors-nginx.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "heartbeat" {
   name = format("%s %s", local.detector_name_prefix, "Nginx heartbeat")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   max_delay = 900
 
@@ -28,6 +29,7 @@ resource "signalfx_detector" "dropped_connections" {
   name = format("%s %s", local.detector_name_prefix, "Nginx dropped connections")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('connections.failed', filter=${module.filter-tags.filter_custom})${var.dropped_connections_aggregation_function}${var.dropped_connections_transformation_function}.publish('signal')

--- a/modules/smart-agent_ntp/detectors-ntp.tf
+++ b/modules/smart-agent_ntp/detectors-ntp.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "heartbeat" {
   name = format("%s %s", local.detector_name_prefix, "NTP heartbeat")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   max_delay = 900
 
@@ -28,6 +29,7 @@ resource "signalfx_detector" "ntp" {
   name = format("%s %s", local.detector_name_prefix, "NTP offset")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         signal = data('ntp.offset_seconds', filter=${module.filter-tags.filter_custom})${var.ntp_aggregation_function}${var.ntp_transformation_function}.publish('signal')

--- a/modules/smart-agent_php-fpm/detectors-fpm.tf
+++ b/modules/smart-agent_php-fpm/detectors-fpm.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "heartbeat" {
   name = format("%s %s", local.detector_name_prefix, "PHP-FPM heartbeat")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   max_delay = 900
 
@@ -28,6 +29,7 @@ resource "signalfx_detector" "php_fpm_connect_idle" {
   name = format("%s %s", local.detector_name_prefix, "PHP-FPM busy workers")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('phpfpm_processes.active', filter=${module.filter-tags.filter_custom})${var.php_fpm_connect_idle_aggregation_function}${var.php_fpm_connect_idle_transformation_function}

--- a/modules/smart-agent_postgresql/detectors-postgresql.tf
+++ b/modules/smart-agent_postgresql/detectors-postgresql.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "heartbeat" {
   name = format("%s %s", local.detector_name_prefix, "PostgreSQL heartbeat")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   max_delay = 900
 
@@ -28,6 +29,7 @@ resource "signalfx_detector" "deadlocks" {
   name = format("%s %s", local.detector_name_prefix, "PostgreSQL deadlocks")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('postgres_deadlocks', filter=${module.filter-tags.filter_custom}, rollup='delta')${var.deadlocks_aggregation_function}${var.deadlocks_transformation_function}.publish('signal')
@@ -64,6 +66,7 @@ resource "signalfx_detector" "hit_ratio" {
   name = format("%s %s", local.detector_name_prefix, "PostgreSQL hit ratio")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('postgres_block_hit_ratio', filter=(not filter('index', '*')) and (not filter('schemaname', '*')) and (not filter('type', '*')) and (not filter('table', '*')) and ${module.filter-tags.filter_custom}, rollup='average').scale(100)${var.hit_ratio_aggregation_function}${var.hit_ratio_transformation_function}.publish('signal')
@@ -100,6 +103,7 @@ resource "signalfx_detector" "rollbacks" {
   name = format("%s %s", local.detector_name_prefix, "PostgreSQL rollbacks ratio compared to commits")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('postgres_xact_rollbacks', filter=${module.filter-tags.filter_custom}, rollup='delta')${var.rollbacks_aggregation_function}${var.rollbacks_transformation_function}
@@ -138,6 +142,7 @@ resource "signalfx_detector" "conflicts" {
   name = format("%s %s", local.detector_name_prefix, "PostgreSQL conflicts")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('postgres_conflicts', filter=${module.filter-tags.filter_custom}, rollup='average')${var.conflicts_aggregation_function}${var.conflicts_transformation_function}.publish('signal')
@@ -174,6 +179,7 @@ resource "signalfx_detector" "max_connections" {
   name = format("%s %s", local.detector_name_prefix, "PostgreSQL number of connections compared to max")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('postgres_pct_connections', filter=${module.filter-tags.filter_custom}, rollup='average').scale(100)${var.max_connections_aggregation_function}${var.max_connections_transformation_function}.publish('signal')
@@ -210,6 +216,7 @@ resource "signalfx_detector" "replication_lag" {
   name = format("%s %s", local.detector_name_prefix, "PostgreSQL replication lag")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('postgres_replication_lag', filter=${module.filter-tags.filter_custom}, rollup='average')${var.replication_lag_aggregation_function}${var.replication_lag_transformation_function}.publish('signal')
@@ -246,6 +253,7 @@ resource "signalfx_detector" "replication_state" {
   name = format("%s %s", local.detector_name_prefix, "PostgreSQL replication state")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('postgres_replication_state', filter=${module.filter-tags.filter_custom}, rollup='average')${var.replication_state_aggregation_function}${var.replication_state_transformation_function}.publish('signal')

--- a/modules/smart-agent_processes/detectors-processes.tf
+++ b/modules/smart-agent_processes/detectors-processes.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "processes" {
   name = format("%s %s", local.detector_name_prefix, "Processes aliveness")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
         signal = data('ps_count.processes', filter=${module.filter-tags.filter_custom})${var.processes_aggregation_function}${var.processes_transformation_function}.publish('signal')

--- a/modules/smart-agent_rabbitmq-node/detectors-rabbitmq-node.tf
+++ b/modules/smart-agent_rabbitmq-node/detectors-rabbitmq-node.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "heartbeat" {
   name = format("%s %s", local.detector_name_prefix, "RabbitMQ  heartbeat")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   max_delay = 900
 
@@ -28,6 +29,7 @@ resource "signalfx_detector" "file_descriptors" {
   name = format("%s %s", local.detector_name_prefix, "RabbitMQ Node file descriptors usage")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('gauge.node.fd_used', filter=filter('plugin', 'rabbitmq') and ${module.filter-tags.filter_custom})${var.file_descriptors_aggregation_function}${var.file_descriptors_transformation_function}
@@ -66,6 +68,7 @@ resource "signalfx_detector" "processes" {
   name = format("%s %s", local.detector_name_prefix, "RabbitMQ Node process usage")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('gauge.node.proc_used', filter=filter('plugin', 'rabbitmq') and ${module.filter-tags.filter_custom})${var.processes_aggregation_function}${var.processes_transformation_function}
@@ -104,6 +107,7 @@ resource "signalfx_detector" "sockets" {
   name = format("%s %s", local.detector_name_prefix, "RabbitMQ Node sockets usage")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('gauge.node.sockets_used', filter=filter('plugin', 'rabbitmq') and ${module.filter-tags.filter_custom})${var.sockets_aggregation_function}${var.sockets_transformation_function}
@@ -142,6 +146,7 @@ resource "signalfx_detector" "vm_memory" {
   name = format("%s %s", local.detector_name_prefix, "RabbitMQ Node vm_memory usage")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('gauge.node.mem_used', filter=filter('plugin', 'rabbitmq') and ${module.filter-tags.filter_custom})${var.vm_memory_aggregation_function}${var.vm_memory_transformation_function}

--- a/modules/smart-agent_rabbitmq-queue/detectors-rabbitmq-queue.tf
+++ b/modules/smart-agent_rabbitmq-queue/detectors-rabbitmq-queue.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "messages_ready" {
   name = format("%s %s", local.detector_name_prefix, "RabbitMQ Queue messages ready")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('gauge.queue.messages_ready', filter=filter('plugin', 'rabbitmq') and ${module.filter-tags.filter_custom})${var.messages_ready_aggregation_function}${var.messages_ready_transformation_function}.publish('signal')
@@ -38,6 +39,7 @@ resource "signalfx_detector" "messages_unacknowledged" {
   name = format("%s %s", local.detector_name_prefix, "RabbitMQ Queue messages unacknowledged")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('gauge.queue.messages_unacknowledged', filter=filter('plugin', 'rabbitmq') and ${module.filter-tags.filter_custom})${var.messages_unacknowledged_aggregation_function}${var.messages_unacknowledged_transformation_function}.publish('signal')
@@ -74,6 +76,7 @@ resource "signalfx_detector" "messages_ack_rate" {
   name = format("%s %s", local.detector_name_prefix, "RabbitMQ Queue messages ack rate")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('counter.queue.message_stats.ack', filter=filter('plugin', 'rabbitmq') and ${module.filter-tags.filter_custom})${var.messages_ack_rate_aggregation_function}.publish('signal')
@@ -111,6 +114,7 @@ resource "signalfx_detector" "consumer_use" {
   name = format("%s %s", local.detector_name_prefix, "RabbitMQ Queue consumer use")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('gauge.queue.consumer_use', filter=filter('plugin', 'rabbitmq') and ${module.filter-tags.filter_custom})${var.consumer_use_aggregation_function}.publish('util')

--- a/modules/smart-agent_redis/detectors-redis.tf
+++ b/modules/smart-agent_redis/detectors-redis.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "heartbeat" {
   name = format("%s %s", local.detector_name_prefix, "Redis heartbeat")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   max_delay = 900
 
@@ -28,6 +29,7 @@ resource "signalfx_detector" "evicted_keys" {
   name = format("%s %s", local.detector_name_prefix, "Redis evicted keys rate of change")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('counter.evicted_keys', filter=filter('plugin', 'redis_info') and ${module.filter-tags.filter_custom}, rollup='delta').rateofchange()${var.evicted_keys_aggregation_function}${var.evicted_keys_transformation_function}.publish('signal')
@@ -64,6 +66,7 @@ resource "signalfx_detector" "expirations" {
   name = format("%s %s", local.detector_name_prefix, "Redis expired keys rate of change")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('counter.expired_keys', filter=filter('plugin', 'redis_info') and ${module.filter-tags.filter_custom}, rollup='delta').rateofchange()${var.expirations_aggregation_function}${var.expirations_transformation_function}.publish('signal')
@@ -100,6 +103,7 @@ resource "signalfx_detector" "blocked_clients" {
   name = format("%s %s", local.detector_name_prefix, "Redis blocked client rate")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('gauge.blocked_clients', filter=filter('plugin', 'redis_info') and ${module.filter-tags.filter_custom})${var.blocked_clients_aggregation_function}${var.blocked_clients_transformation_function}
@@ -138,6 +142,7 @@ resource "signalfx_detector" "keyspace_full" {
   name = format("%s %s", local.detector_name_prefix, "Redis keyspace seems full")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('gauge.db0_keys', filter=filter('plugin', 'redis_info') and ${module.filter-tags.filter_custom}).rateofchange().abs()${var.keyspace_full_aggregation_function}${var.keyspace_full_transformation_function}.publish('signal')
@@ -161,6 +166,7 @@ resource "signalfx_detector" "memory_used_max" {
   name = format("%s %s", local.detector_name_prefix, "Redis memory used over max memory (if configured)")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('bytes.used_memory', filter=filter('plugin', 'redis_info') and ${module.filter-tags.filter_custom})${var.memory_used_max_aggregation_function}${var.memory_used_max_transformation_function}
@@ -199,6 +205,7 @@ resource "signalfx_detector" "memory_used_total" {
   name = format("%s %s", local.detector_name_prefix, "Redis memory used over total system memory")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('bytes.used_memory', filter=filter('plugin', 'redis_info') and ${module.filter-tags.filter_custom})${var.memory_used_total_aggregation_function}${var.memory_used_total_transformation_function}
@@ -237,6 +244,7 @@ resource "signalfx_detector" "memory_frag_high" {
   name = format("%s %s", local.detector_name_prefix, "Redis memory fragmentation ratio (excessive fragmentation)")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('bytes.used_memory_rss', filter=filter('plugin', 'redis_info') and ${module.filter-tags.filter_custom}, rollup='average')${var.memory_frag_high_aggregation_function}${var.memory_frag_high_transformation_function}
@@ -275,6 +283,7 @@ resource "signalfx_detector" "memory_frag_low" {
   name = format("%s %s", local.detector_name_prefix, "Redis memory fragmentation ratio (missing memory)")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('bytes.used_memory_rss', filter=filter('plugin', 'redis_info') and ${module.filter-tags.filter_custom}, rollup='average')${var.memory_frag_low_aggregation_function}${var.memory_frag_low_transformation_function}
@@ -313,6 +322,7 @@ resource "signalfx_detector" "rejected_connections" {
   name = format("%s %s", local.detector_name_prefix, "Redis rejected connections (maxclient reached)")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('counter.rejected_connections', filter=filter('plugin', 'redis_info') and ${module.filter-tags.filter_custom}, rollup='delta').${var.rejected_connections_aggregation_function}${var.rejected_connections_transformation_function}.publish('signal')
@@ -349,6 +359,7 @@ resource "signalfx_detector" "hitrate" {
   name = format("%s %s", local.detector_name_prefix, "Redis hitrate")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('derive.keyspace_hits', filter=filter('plugin', 'redis_info') and ${module.filter-tags.filter_custom}, rollup='delta')${var.hitrate_aggregation_function}${var.hitrate_transformation_function}

--- a/modules/smart-agent_solr/detectors-solr.tf
+++ b/modules/smart-agent_solr/detectors-solr.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "heartbeat" {
   name = format("%s %s", local.detector_name_prefix, "Apache Solr heartbeat")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   max_delay = 900
 
@@ -28,6 +29,7 @@ resource "signalfx_detector" "errors" {
   name = format("%s %s", local.detector_name_prefix, "Apache Solr errors count")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('counter.solr.zookeeper_errors', filter=${module.filter-tags.filter_custom})${var.errors_aggregation_function}${var.errors_transformation_function}.publish('signal')
@@ -64,6 +66,7 @@ resource "signalfx_detector" "searcher_warmup_time" {
   name = format("%s %s", local.detector_name_prefix, "Apache Solr searcher warmup time")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('gauge.solr.searcher_warmup', filter=${module.filter-tags.filter_custom})${var.searcher_warmup_time_aggregation_function}${var.searcher_warmup_time_transformation_function}.publish('signal')

--- a/modules/smart-agent_supervisor/detectors-supervisor.tf
+++ b/modules/smart-agent_supervisor/detectors-supervisor.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "heartbeat" {
   name = format("%s %s", local.detector_name_prefix, "Supervisor heartbeat")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   max_delay = 900
 
@@ -28,6 +29,7 @@ resource "signalfx_detector" "process_state" {
   name = format("%s %s", local.detector_name_prefix, "Supervisor process")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('supervisor.state', filter=${module.filter-tags.filter_custom})${var.process_state_aggregation_function}${var.process_state_transformation_function}.publish('signal')

--- a/modules/smart-agent_system-common/detectors-gen.tf
+++ b/modules/smart-agent_system-common/detectors-gen.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "heartbeat" {
   name = format("%s %s", local.detector_name_prefix, "System heartbeat")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   max_delay = 900
 
@@ -28,6 +29,7 @@ resource "signalfx_detector" "cpu" {
   name = format("%s %s", local.detector_name_prefix, "System cpu utilization")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   viz_options {
     label        = "signal"
@@ -69,6 +71,7 @@ resource "signalfx_detector" "load" {
   name = format("%s %s", local.detector_name_prefix, "System load 5m ratio")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('load.midterm', filter=${module.filter-tags.filter_custom})${var.load_aggregation_function}${var.load_transformation_function}.publish('signal')
@@ -105,6 +108,7 @@ resource "signalfx_detector" "disk_space" {
   name = format("%s %s", local.detector_name_prefix, "System disk space utilization")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   viz_options {
     label        = "signal"
@@ -146,6 +150,7 @@ resource "signalfx_detector" "disk_inodes" {
   name = format("%s %s", local.detector_name_prefix, "System disk inodes utilization")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   viz_options {
     label        = "signal"
@@ -187,6 +192,7 @@ resource "signalfx_detector" "memory" {
   name = format("%s %s", local.detector_name_prefix, "System memory utilization")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   viz_options {
     label        = "signal"

--- a/modules/smart-agent_system-common/detectors-system.tf
+++ b/modules/smart-agent_system-common/detectors-system.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "disk_running_out" {
   name = format("%s %s", local.detector_name_prefix, "System disk space running out")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     from signalfx.detectors.countdown import countdown

--- a/modules/smart-agent_tomcat/detectors-tomcat.tf
+++ b/modules/smart-agent_tomcat/detectors-tomcat.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "heartbeat" {
   name = format("%s %s", local.detector_name_prefix, "Tomcat heartbeat")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   max_delay = 900
 
@@ -28,6 +29,7 @@ resource "signalfx_detector" "average_processing_time" {
   name = format("%s %s", local.detector_name_prefix, "Tomcat average processing time")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('counter.tomcat.GlobalRequestProcessor.processingTime', filter=${module.filter-tags.filter_custom}, rollup='delta')${var.average_processing_time_aggregation_function}${var.average_processing_time_transformation_function}
@@ -66,6 +68,7 @@ resource "signalfx_detector" "busy_threads_percentage" {
   name = format("%s %s", local.detector_name_prefix, "Tomcat busy threads percentage")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('gauge.tomcat.ThreadPool.currentThreadsBusy', filter=${module.filter-tags.filter_custom})${var.busy_threads_percentage_aggregation_function}${var.busy_threads_percentage_transformation_function}

--- a/modules/smart-agent_varnish/detectors-varnish.tf
+++ b/modules/smart-agent_varnish/detectors-varnish.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "heartbeat" {
   name = format("%s %s", local.detector_name_prefix, "Varnish heartbeat")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   max_delay = 900
 
@@ -28,6 +29,7 @@ resource "signalfx_detector" "backend_failed" {
   name = format("%s %s", local.detector_name_prefix, "Varnish backend Failed")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('varnish.backend_fail', filter=filter('plugin', 'telegraf/varnish') and ${module.filter-tags.filter_custom})${var.backend_failed_aggregation_function}${var.backend_failed_transformation_function}.publish('signal')
@@ -51,6 +53,7 @@ resource "signalfx_detector" "threads_number" {
   name = format("%s %s", local.detector_name_prefix, "Varnish threads number")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('varnish.threads', filter=filter('plugin', 'telegraf/varnish') and ${module.filter-tags.filter_custom})${var.threads_number_aggregation_function}${var.threads_number_transformation_function}.publish('signal')
@@ -74,6 +77,7 @@ resource "signalfx_detector" "session_dropped" {
   name = format("%s %s", local.detector_name_prefix, "Varnish session dropped")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('varnish.sess_dropped', filter=filter('plugin', 'telegraf/varnish') and ${module.filter-tags.filter_custom})${var.session_dropped_aggregation_function}${var.session_dropped_transformation_function}.publish('signal')
@@ -97,6 +101,7 @@ resource "signalfx_detector" "cache_hit_rate" {
   name = format("%s %s", local.detector_name_prefix, "Varnish hit rate")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('varnish.cache_hit', filter=filter('plugin', 'telegraf/varnish') and ${module.filter-tags.filter_custom})${var.cache_hit_rate_aggregation_function}${var.cache_hit_rate_transformation_function}.publish('A')
@@ -135,6 +140,7 @@ resource "signalfx_detector" "memory_usage" {
   name = format("%s %s", local.detector_name_prefix, "Varnish memory usage")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('varnish.s0.g_bytes', filter=filter('plugin', 'telegraf/varnish') and ${module.filter-tags.filter_custom})${var.memory_usage_aggregation_function}${var.memory_usage_transformation_function}

--- a/modules/smart-agent_zookeeper/detectors-zookeeper.tf
+++ b/modules/smart-agent_zookeeper/detectors-zookeeper.tf
@@ -2,6 +2,7 @@ resource "signalfx_detector" "heartbeat" {
   name = format("%s %s", local.detector_name_prefix, "Zookeeper heartbeat")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   max_delay = 900
 
@@ -28,6 +29,7 @@ resource "signalfx_detector" "zookeeper_health" {
   name = format("%s %s", local.detector_name_prefix, "Zookeeper service health")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('gauge.zk_service_health', filter=filter('plugin', 'zookeeper') and ${module.filter-tags.filter_custom})${var.zookeeper_health_aggregation_function}${var.zookeeper_health_transformation_function}.publish('signal')
@@ -51,6 +53,7 @@ resource "signalfx_detector" "zookeeper_latency" {
   name = format("%s %s", local.detector_name_prefix, "Zookeeper latency")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     signal = data('gauge.zk_avg_latency', filter=filter('plugin', 'zookeeper') and ${module.filter-tags.filter_custom})${var.zookeeper_latency_aggregation_function}${var.zookeeper_latency_transformation_function}.publish('signal')
@@ -87,6 +90,7 @@ resource "signalfx_detector" "file_descriptors" {
   name = format("%s %s", local.detector_name_prefix, "Zookeeper file descriptors usage")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
     A = data('gauge.zk_open_file_descriptor_count', filter=filter('plugin', 'zookeeper') and ${module.filter-tags.filter_custom}, rollup='average')${var.file_descriptors_aggregation_function}${var.file_descriptors_transformation_function}

--- a/scripts/templates/detector.tf.j2
+++ b/scripts/templates/detector.tf.j2
@@ -14,6 +14,7 @@ resource "signalfx_detector" "{{ id }}" {
   name = format("%s %s", local.detector_name_prefix, "{{ module[0]|upper}}{{module[1:] }} {{ name | lower }}")
 
   authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   {%- if type == 'heartbeat' %}
 
   max_delay = 900


### PR DESCRIPTION
This PR adds `Teams` as a common parameter. It allows to link detector(s) to Sfx Teams.

https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#teams