### PR TITLE
kubernetes-common: fix OMMKilled detector

### DIFF
--- a/modules/smart-agent_kubernetes-common/README.md
+++ b/modules/smart-agent_kubernetes-common/README.md
@@ -14,6 +14,7 @@
 - [Notes](#notes)
   - [About `node_ready` detector](#about-node_ready-detector)
   - [About `job_failed` detector](#about-job_failed-detector)
+  - [About `oom_killed` detector](#about-oom_killed-detector)
 - [Related documentation](#related-documentation)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -260,6 +261,11 @@ modules covering more data sources like `kubernetes-volumes` or use cases like `
 * it works only on job running from cronjob
 * this will obviously raise an alert when a job is considered as failed from kubernetes point of view. Indeed, some pods could eventually fail or retry without to mark the job as failed
 * but the alert will remain until you clean/purge jobs history. Indeed, even if a new, more recent, successful job has been running in the meantime the alert will continue until you delete the failed job
+
+### About `oom_killed` detector
+
+* default transformation function is used to avoid the detector to flap repeatedly
+* if unset, expect the detector to send several alerts per minute
 
 
 ## Related documentation

--- a/modules/smart-agent_kubernetes-common/conf/readme.yaml
+++ b/modules/smart-agent_kubernetes-common/conf/readme.yaml
@@ -125,3 +125,8 @@ notes: |
   * it works only on job running from cronjob
   * this will obviously raise an alert when a job is considered as failed from kubernetes point of view. Indeed, some pods could eventually fail or retry without to mark the job as failed
   * but the alert will remain until you clean/purge jobs history. Indeed, even if a new, more recent, successful job has been running in the meantime the alert will continue until you delete the failed job
+
+  ### About `oom_killed` detector
+
+  * default transformation function is used to avoid the detector to flap repeatedly
+  * if unset, expect the detector to send several alerts per minute

--- a/modules/smart-agent_kubernetes-common/variables.tf
+++ b/modules/smart-agent_kubernetes-common/variables.tf
@@ -223,7 +223,7 @@ variable "oom_killed_aggregation_function" {
 variable "oom_killed_transformation_function" {
   description = "Transformation function for oom_killed detector (i.e. \".mean(over='5m')\")"
   type        = string
-  default     = ""
+  default     = ".max(over='1m')"
 }
 
 variable "oom_killed_threshold_major" {


### PR DESCRIPTION
Add .max(over='1m') to avoid triggering alert repeatedly