### PR TITLE
Add runbooks and tips on APIM detectors

### DIFF
--- a/modules/integration_azure-api-management-service/detectors-api_management_service.tf
+++ b/modules/integration_azure-api-management-service/detectors-api_management_service.tf
@@ -14,6 +14,8 @@ resource "signalfx_detector" "heartbeat" {
     detect_label          = "CRIT"
     disabled              = coalesce(var.heartbeat_disabled, var.detectors_disabled)
     notifications         = coalescelist(lookup(var.heartbeat_notifications, "critical", []), var.notifications.critical)
+    runbook_url           = try(coalesce(var.heartbeat_runbook_url, var.runbook_url), "")
+    tip                   = var.heartbeat_tip
     parameterized_subject = local.rule_subject_novalue
     parameterized_body    = local.rule_body
   }
@@ -35,6 +37,8 @@ resource "signalfx_detector" "capacity" {
     detect_label          = "CRIT"
     disabled              = coalesce(var.capacity_disabled_critical, var.capacity_disabled, var.detectors_disabled)
     notifications         = coalescelist(lookup(var.capacity_notifications, "critical", []), var.notifications.critical)
+    runbook_url           = try(coalesce(var.capacity_runbook_url, var.runbook_url), "")
+    tip                   = var.capacity_tip
     parameterized_subject = local.rule_subject
     parameterized_body    = local.rule_body
   }
@@ -45,6 +49,8 @@ resource "signalfx_detector" "capacity" {
     detect_label          = "MAJOR"
     disabled              = coalesce(var.capacity_disabled_major, var.capacity_disabled, var.detectors_disabled)
     notifications         = coalescelist(lookup(var.capacity_notifications, "major", []), var.notifications.major)
+    runbook_url           = try(coalesce(var.capacity_runbook_url, var.runbook_url), "")
+    tip                   = var.capacity_tip
     parameterized_subject = local.rule_subject
     parameterized_body    = local.rule_body
   }
@@ -66,6 +72,8 @@ resource "signalfx_detector" "gateway_requests_duration" {
     detect_label          = "CRIT"
     disabled              = coalesce(var.gateway_requests_duration_disabled_critical, var.gateway_requests_duration_disabled, var.detectors_disabled)
     notifications         = coalescelist(lookup(var.gateway_requests_duration_notifications, "critical", []), var.notifications.critical)
+    runbook_url           = try(coalesce(var.gateway_requests_duration_runbook_url, var.runbook_url), "")
+    tip                   = var.gateway_requests_duration_tip
     parameterized_subject = local.rule_subject
     parameterized_body    = local.rule_body
   }
@@ -76,6 +84,8 @@ resource "signalfx_detector" "gateway_requests_duration" {
     detect_label          = "MAJOR"
     disabled              = coalesce(var.gateway_requests_duration_disabled_major, var.gateway_requests_duration_disabled, var.detectors_disabled)
     notifications         = coalescelist(lookup(var.gateway_requests_duration_notifications, "major", []), var.notifications.major)
+    runbook_url           = try(coalesce(var.gateway_requests_duration_runbook_url, var.runbook_url), "")
+    tip                   = var.gateway_requests_duration_tip
     parameterized_subject = local.rule_subject
     parameterized_body    = local.rule_body
   }
@@ -97,6 +107,8 @@ resource "signalfx_detector" "backend_requests_duration" {
     detect_label          = "CRIT"
     disabled              = coalesce(var.backend_requests_duration_disabled_critical, var.backend_requests_duration_disabled, var.detectors_disabled)
     notifications         = coalescelist(lookup(var.backend_requests_duration_notifications, "critical", []), var.notifications.critical)
+    runbook_url           = try(coalesce(var.backend_requests_duration_runbook_url, var.runbook_url), "")
+    tip                   = var.backend_requests_duration_tip
     parameterized_subject = local.rule_subject
     parameterized_body    = local.rule_body
   }
@@ -107,6 +119,8 @@ resource "signalfx_detector" "backend_requests_duration" {
     detect_label          = "MAJOR"
     disabled              = coalesce(var.backend_requests_duration_disabled_major, var.backend_requests_duration_disabled, var.detectors_disabled)
     notifications         = coalescelist(lookup(var.backend_requests_duration_notifications, "major", []), var.notifications.major)
+    runbook_url           = try(coalesce(var.backend_requests_duration_runbook_url, var.runbook_url), "")
+    tip                   = var.backend_requests_duration_tip
     parameterized_subject = local.rule_subject
     parameterized_body    = local.rule_body
   }

--- a/modules/integration_azure-api-management-service/variables.tf
+++ b/modules/integration_azure-api-management-service/variables.tf
@@ -26,6 +26,18 @@ variable "heartbeat_aggregation_function" {
   default     = ".mean(by=['azure_resource_name', 'azure_resource_group_name', 'azure_region'])"
 }
 
+variable "heartbeat_tip" {
+  description = "Suggested first course of action or any note useful for incident handling"
+  type        = string
+  default     = ""
+}
+
+variable "heartbeat_runbook_url" {
+  description = "URL like SignalFx dashboard or wiki page which can help to troubleshoot the incident cause"
+  type        = string
+  default     = ""
+}
+
 # capacity detector
 
 variable "capacity_notifications" {
@@ -74,6 +86,18 @@ variable "capacity_threshold_major" {
   description = "Major threshold for capacity detector (in %)"
   type        = number
   default     = 90
+}
+
+variable "capacity_tip" {
+  description = "Suggested first course of action or any note useful for incident handling"
+  type        = string
+  default     = ""
+}
+
+variable "capacity_runbook_url" {
+  description = "URL like SignalFx dashboard or wiki page which can help to troubleshoot the incident cause"
+  type        = string
+  default     = ""
 }
 
 # gateway requests Duration
@@ -126,6 +150,18 @@ variable "gateway_requests_duration_threshold_major" {
   default     = 1
 }
 
+variable "gateway_requests_duration_tip" {
+  description = "Suggested first course of action or any note useful for incident handling"
+  type        = string
+  default     = ""
+}
+
+variable "gateway_requests_duration_runbook_url" {
+  description = "URL like SignalFx dashboard or wiki page which can help to troubleshoot the incident cause"
+  type        = string
+  default     = ""
+}
+
 # Backend requests Duration
 
 variable "backend_requests_duration_notifications" {
@@ -174,4 +210,16 @@ variable "backend_requests_duration_threshold_major" {
   description = "Major threshold for backend requests duration detector (in s)"
   type        = number
   default     = 1
+}
+
+variable "backend_requests_duration_tip" {
+  description = "Suggested first course of action or any note useful for incident handling"
+  type        = string
+  default     = ""
+}
+
+variable "backend_requests_duration_runbook_url" {
+  description = "URL like SignalFx dashboard or wiki page which can help to troubleshoot the incident cause"
+  type        = string
+  default     = ""
 }


### PR DESCRIPTION
Unlike others Azure detectors, the APIM detectors don't have runbook and tip variable.
I added it.
David (SG cell)