### PR TITLE
kubernetes_volumes: filter out empty volume_type

### DIFF
--- a/modules/smart-agent_kubernetes-volumes/detectors-kubernetes-volumes.tf
+++ b/modules/smart-agent_kubernetes-volumes/detectors-kubernetes-volumes.tf
@@ -5,8 +5,8 @@ resource "signalfx_detector" "volume_space" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
-    A = data('kubernetes.volume_available_bytes', filter=${module.filter-tags.filter_custom} and not filter('volume_type', 'configMap', 'secret'))${var.volume_space_aggregation_function}${var.volume_space_transformation_function}
-    B = data('kubernetes.volume_capacity_bytes', filter=${module.filter-tags.filter_custom} and not filter('volume_type', 'configMap', 'secret'))${var.volume_space_aggregation_function}${var.volume_space_transformation_function}
+    A = data('kubernetes.volume_available_bytes', filter=${module.filter-tags.filter_custom} and (not filter('volume_type', 'configMap', 'secret')) and filter('volume_type', '*'))${var.volume_space_aggregation_function}${var.volume_space_transformation_function}
+    B = data('kubernetes.volume_capacity_bytes', filter=${module.filter-tags.filter_custom} and (not filter('volume_type', 'configMap', 'secret')) and filter('volume_type', '*'))${var.volume_space_aggregation_function}${var.volume_space_transformation_function}
     signal = ((B-A)/B).scale(100).publish('signal')
     detect(when(signal > ${var.volume_space_threshold_critical})).publish('CRIT')
     detect(when(signal > ${var.volume_space_threshold_major}) and when(signal < ${var.volume_space_threshold_critical})).publish('MAJOR')
@@ -44,8 +44,8 @@ resource "signalfx_detector" "volume_inodes" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
-    A = data('kubernetes.volume_inodes_free', filter=${module.filter-tags.filter_custom} and not filter('volume_type', 'configMap', 'secret'))${var.volume_inodes_aggregation_function}${var.volume_inodes_transformation_function}
-    B = data('kubernetes.volume_inodes', filter=${module.filter-tags.filter_custom} and not filter('volume_type', 'configMap', 'secret'))${var.volume_inodes_aggregation_function}${var.volume_inodes_transformation_function}
+    A = data('kubernetes.volume_inodes_free', filter=${module.filter-tags.filter_custom} and (not filter('volume_type', 'configMap', 'secret')) and filter('volume_type', '*'))${var.volume_inodes_aggregation_function}${var.volume_inodes_transformation_function}
+    B = data('kubernetes.volume_inodes', filter=${module.filter-tags.filter_custom} and (not filter('volume_type', 'configMap', 'secret')) and filter('volume_type', '*'))${var.volume_inodes_aggregation_function}${var.volume_inodes_transformation_function}
     signal = ((B-A)/B).scale(100).publish('signal')
     detect(when(signal > ${var.volume_inodes_threshold_critical})).publish('CRIT')
     detect(when(signal > ${var.volume_inodes_threshold_major}) and when(signal < ${var.volume_inodes_threshold_critical})).publish('MAJOR')


### PR DESCRIPTION
in some environment it is possible to have volume metrics without the `volume_type` dimension value which are not relevant for alerting.