### PR TITLE
improve cassandra detectors

### DIFF
--- a/modules/smart-agent_cassandra/detectors-cassandra.tf
+++ b/modules/smart-agent_cassandra/detectors-cassandra.tf
@@ -106,9 +106,9 @@ resource "signalfx_detector" "read_real_time_latency" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
-    A = data('counter.cassandra.ClientRequest.Read.TotalLatency.Count', filter=${module.filter-tags.filter_custom})${var.read_real_time_latency_aggregation_function}${var.read_real_time_latency_transformation_function}
-    B = data('counter.cassandra.ClientRequest.Read.Latency.Count', filter=${module.filter-tags.filter_custom})${var.read_real_time_latency_aggregation_function}${var.read_real_time_latency_transformation_function}
-    signal = (A/B).fill(0).scale(0.001).publish('signal')
+    A = data('counter.cassandra.ClientRequest.Read.TotalLatency.Count', filter=${module.filter-tags.filter_custom})
+    B = data('counter.cassandra.ClientRequest.Read.Latency.Count', filter=${module.filter-tags.filter_custom})
+    signal = (A/B).fill(0).scale(0.001)${var.read_real_time_latency_aggregation_function}${var.read_real_time_latency_transformation_function}.publish('signal')
     detect(when(signal > ${var.read_real_time_latency_threshold_critical})).publish('CRIT')
     detect(when(signal > ${var.read_real_time_latency_threshold_major}) and when(signal <= ${var.read_real_time_latency_threshold_critical})).publish('MAJOR')
 EOF
@@ -145,9 +145,9 @@ resource "signalfx_detector" "write_real_time_latency" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
 
   program_text = <<-EOF
-    A = data('counter.cassandra.ClientRequest.Write.TotalLatency.Count', filter=${module.filter-tags.filter_custom})${var.write_real_time_latency_aggregation_function}${var.write_real_time_latency_transformation_function}
-    B = data('counter.cassandra.ClientRequest.Write.Latency.Count', filter=${module.filter-tags.filter_custom})${var.write_real_time_latency_aggregation_function}${var.write_real_time_latency_transformation_function}
-    signal = (A/B).fill(0).scale(0.001).publish('signal')
+    A = data('counter.cassandra.ClientRequest.Write.TotalLatency.Count', filter=${module.filter-tags.filter_custom})
+    B = data('counter.cassandra.ClientRequest.Write.Latency.Count', filter=${module.filter-tags.filter_custom})
+    signal = (A/B).fill(0).scale(0.001)${var.write_real_time_latency_aggregation_function}${var.write_real_time_latency_transformation_function}.publish('signal')
     detect(when(signal > ${var.write_real_time_latency_threshold_critical})).publish('CRIT')
     detect(when(signal > ${var.write_real_time_latency_threshold_major}) and when(signal <= ${var.write_real_time_latency_threshold_critical})).publish('MAJOR')
 EOF


### PR DESCRIPTION
Currently, the aggregation is done on the delta and not on the latency itself. 
This can lead to weird results we think.
This commit fixes that. 