### PR TITLE
generator: lasting is per rule only and mandatory like threshold

### DIFF
--- a/modules/integration_azure-firewall/variables-gen.tf
+++ b/modules/integration_azure-firewall/variables-gen.tf
@@ -150,22 +150,10 @@ variable "throughput_disabled_critical" {
   default     = null
 }
 
-variable "throughput_lasting_duration_critical" {
-  description = "Minimum duration that conditions must be true before raising alert"
-  type        = string
-  default     = "300s"
-}
-
 variable "throughput_disabled_major" {
   description = "Disable major alerting rule for throughput detector"
   type        = bool
   default     = null
-}
-
-variable "throughput_lasting_duration_major" {
-  description = "Minimum duration that conditions must be true before raising alert"
-  type        = string
-  default     = "300s"
 }
 
 variable "throughput_disabled_minor" {
@@ -174,22 +162,10 @@ variable "throughput_disabled_minor" {
   default     = null
 }
 
-variable "throughput_lasting_duration_minor" {
-  description = "Minimum duration that conditions must be true before raising alert"
-  type        = string
-  default     = "300s"
-}
-
 variable "throughput_disabled_warning" {
   description = "Disable warning alerting rule for throughput detector"
   type        = bool
   default     = null
-}
-
-variable "throughput_lasting_duration_warning" {
-  description = "Minimum duration that conditions must be true before raising alert"
-  type        = string
-  default     = "300s"
 }
 
 variable "throughput_threshold_critical" {
@@ -198,10 +174,22 @@ variable "throughput_threshold_critical" {
   default     = 29696
 }
 
+variable "throughput_lasting_duration_critical" {
+  description = "Minimum duration that conditions must be true before raising alert"
+  type        = string
+  default     = "300s"
+}
+
 variable "throughput_threshold_major" {
   description = "Major threshold for throughput detector"
   type        = number
   default     = 27648
+}
+
+variable "throughput_lasting_duration_major" {
+  description = "Minimum duration that conditions must be true before raising alert"
+  type        = string
+  default     = "300s"
 }
 
 variable "throughput_threshold_minor" {
@@ -210,10 +198,22 @@ variable "throughput_threshold_minor" {
   default     = 25600
 }
 
+variable "throughput_lasting_duration_minor" {
+  description = "Minimum duration that conditions must be true before raising alert"
+  type        = string
+  default     = "300s"
+}
+
 variable "throughput_threshold_warning" {
   description = "Warning threshold for throughput detector"
   type        = number
   default     = 3072
+}
+
+variable "throughput_lasting_duration_warning" {
+  description = "Minimum duration that conditions must be true before raising alert"
+  type        = string
+  default     = "300s"
 }
 
 # health_state detector
@@ -262,22 +262,10 @@ variable "health_state_disabled_critical" {
   default     = null
 }
 
-variable "health_state_lasting_duration_critical" {
-  description = "Minimum duration that conditions must be true before raising alert"
-  type        = string
-  default     = "5m"
-}
-
 variable "health_state_disabled_major" {
   description = "Disable major alerting rule for health_state detector"
   type        = bool
   default     = null
-}
-
-variable "health_state_lasting_duration_major" {
-  description = "Minimum duration that conditions must be true before raising alert"
-  type        = string
-  default     = "5m"
 }
 
 variable "health_state_threshold_critical" {
@@ -286,9 +274,21 @@ variable "health_state_threshold_critical" {
   default     = 50
 }
 
+variable "health_state_lasting_duration_critical" {
+  description = "Minimum duration that conditions must be true before raising alert"
+  type        = string
+  default     = "5m"
+}
+
 variable "health_state_threshold_major" {
   description = "Major threshold for health_state detector"
   type        = number
   default     = 100
+}
+
+variable "health_state_lasting_duration_major" {
+  description = "Minimum duration that conditions must be true before raising alert"
+  type        = string
+  default     = "5m"
 }
 

--- a/modules/integration_azure-functions/variables-gen.tf
+++ b/modules/integration_azure-functions/variables-gen.tf
@@ -42,22 +42,10 @@ variable "errors_disabled_critical" {
   default     = null
 }
 
-variable "errors_lasting_duration_critical" {
-  description = "Minimum duration that conditions must be true before raising alert"
-  type        = string
-  default     = "900s"
-}
-
 variable "errors_disabled_major" {
   description = "Disable major alerting rule for errors detector"
   type        = bool
   default     = null
-}
-
-variable "errors_lasting_duration_major" {
-  description = "Minimum duration that conditions must be true before raising alert"
-  type        = string
-  default     = "900s"
 }
 
 variable "errors_threshold_critical" {
@@ -66,9 +54,21 @@ variable "errors_threshold_critical" {
   default     = 30
 }
 
+variable "errors_lasting_duration_critical" {
+  description = "Minimum duration that conditions must be true before raising alert"
+  type        = string
+  default     = "900s"
+}
+
 variable "errors_threshold_major" {
   description = "Major threshold for errors detector"
   type        = number
   default     = 0
+}
+
+variable "errors_lasting_duration_major" {
+  description = "Minimum duration that conditions must be true before raising alert"
+  type        = string
+  default     = "900s"
 }
 

--- a/scripts/templates/variables.tf.j2
+++ b/scripts/templates/variables.tf.j2
@@ -64,20 +64,7 @@ variable "{{ id }}_disabled_{{ severity }}" {
   type        = bool
   default     = null
 }
-{% if rule.lasting_duration is string %}
-variable "{{ id }}_lasting_duration_{{ severity }}" {
-  description = "Minimum duration that conditions must be true before raising alert"
-  type        = string
-  default     = "{{ rule.lasting_duration }}"
-}
-{% endif -%}
-{% if rule.lasting_at_least is number %}
-variable "{{ id }}_at_least_percentage_{{ severity }}" {
-  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
-  type        = number
-  default     = "{{ rule.lasting_at_least }}"
-}
-{% endif %}
+
 {% endfor -%}
 {% endif -%}
 
@@ -98,6 +85,19 @@ variable "{{ id }}_threshold_{{ severity }}" {
   default     = {{ rule.threshold }}
     {%- endif %}
 }
-
+{% if rule.lasting_duration is string %}
+variable "{{ id }}_lasting_duration_{{ severity }}" {
+  description = "Minimum duration that conditions must be true before raising alert"
+  type        = string
+  default     = "{{ rule.lasting_duration }}"
+}
+{% endif -%}
+{% if rule.lasting_at_least is number %}
+variable "{{ id }}_at_least_percentage_{{ severity }}" {
+  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
+  type        = number
+  default     = "{{ rule.lasting_at_least }}"
+}
+{% endif %}
 {% endfor -%}
 {% endif -%}


### PR DESCRIPTION
the lasting variable is "mandatory" (created as soon it has been configured) and its scope is `rule` only exactly like thresholds

the disabled is little special because it is also available at `detector` and `global` scope. But this is useless to provide a per rule variable if there is only one rule given that disabling the entire detector will does the same than disabling its only rule.

When we integrated this feature from https://github.com/claranet/terraform-signalfx-detectors/pull/248 I did not this error because we did not have any detector with only one rule using lasting.

so it works until now but the proper way to implement this is define lasting in the same block we define thresholds (and not the disabled per rule one).

I add @jmapro as reviewer to let him now this change on this feature.

@egouraud-claranet you should be able to fix the ci on https://github.com/claranet/terraform-signalfx-detectors/pull/271 after rebasing on this PR.