### PR TITLE
Add missing curly bracket in AWS default filters

### DIFF
--- a/common/module/locals.tf
+++ b/common/module/locals.tf
@@ -1,6 +1,6 @@
 locals {
   not_running_vm_filters_gcp   = "(not filter('gcp_status', '{Code=3, Name=STOPPING}', '{Code=4, Name=TERMINATED}'))"
-  not_running_vm_filters_aws   = "(not filter('aws_state', '{Code: 32,Name: shutting-down', '{Code: 48,Name: terminated}', '{Code: 62,Name: stopping}', '{Code: 80,Name: stopped}'))"
+  not_running_vm_filters_aws   = "(not filter('aws_state', '{Code: 32,Name: shutting-down}', '{Code: 48,Name: terminated}', '{Code: 62,Name: stopping}', '{Code: 80,Name: stopped}'))"
   not_running_vm_filters_azure = "(not filter('azure_power_state', 'PowerState/stopping', 'PowerState/stopped', 'PowerState/deallocating', 'PowerState/deallocated'))"
   not_running_vm_filters = format(
     "%s and %s and %s",


### PR DESCRIPTION
It looks like a curly bracket is missing here. I am not sure what the impact is, but it may be related to some unjustified heartbeat notifications we are receiving sometimes (we are currently testing the fix, but it is to soon to draw conclusions).