### PR TITLE
upgrade signalfx provider to v6.7.3

### DIFF
--- a/common/stack/versions.tf
+++ b/common/stack/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     signalfx = {
       source  = "splunk-terraform/signalfx"
-      version = ">= 4.26.4"
+      version = ">= 6.7.3"
     }
   }
   required_version = ">= 0.12.26"

--- a/examples/stack/versions.tf
+++ b/examples/stack/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     signalfx = {
       source  = "splunk-terraform/signalfx"
-      version = ">= 4.26.4"
+      version = ">= 6.7.3"
     }
   }
   required_version = ">= 0.12.26"


### PR DESCRIPTION
to prevent usage of v5 version which remove `teams` arguement