### PR TITLE
Add aggregation by subscription_id on GCP Pub/Sub Subscription heartbeat

### DIFF
--- a/modules/integration_gcp-pubsub-subscription/detectors-subscription.tf
+++ b/modules/integration_gcp-pubsub-subscription/detectors-subscription.tf
@@ -6,7 +6,7 @@ resource "signalfx_detector" "heartbeat" {
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
-    signal = data('subscription/pull_request_count', filter=${module.filter-tags.filter_custom}).sum(by=['subscription_id'])${var.heartbeat_aggregation_function}.publish('signal')
+    signal = data('subscription/pull_request_count', filter=${module.filter-tags.filter_custom})${var.heartbeat_aggregation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}').publish('CRIT')
 EOF
 

--- a/modules/integration_gcp-pubsub-subscription/detectors-subscription.tf
+++ b/modules/integration_gcp-pubsub-subscription/detectors-subscription.tf
@@ -6,7 +6,7 @@ resource "signalfx_detector" "heartbeat" {
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
-    signal = data('subscription/pull_request_count', filter=${module.filter-tags.filter_custom})${var.heartbeat_aggregation_function}.publish('signal')
+    signal = data('subscription/pull_request_count', filter=${module.filter-tags.filter_custom}).sum(by=['subscription_id'])${var.heartbeat_aggregation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}').publish('CRIT')
 EOF
 

--- a/modules/integration_gcp-pubsub-subscription/variables.tf
+++ b/modules/integration_gcp-pubsub-subscription/variables.tf
@@ -40,7 +40,7 @@ variable "heartbeat_timeframe" {
 variable "heartbeat_aggregation_function" {
   description = "Aggregation function and group by for heartbeat detector (i.e. \".mean(by=['host'])\")"
   type        = string
-  default     = ""
+  default     = ".mean(by=['subscription_id'])"
 }
 
 # Oldest_unacked_message detector


### PR DESCRIPTION
Aggregation by subscription_id on the detector GCP Pub/Sub Subscription heartbeat for avoiding the false positives when we have a request with response_code=cancelled