### PR TITLE
auto resolve heartbeat alerts after mts is considered as inactive

### DIFF
--- a/common/module/locals.tf
+++ b/common/module/locals.tf
@@ -1,4 +1,5 @@
 locals {
+  heartbeat_auto_resolve_after = "1s"
   not_running_vm_filters_gcp   = "(not filter('gcp_status', '{Code=3, Name=STOPPING}', '{Code=4, Name=TERMINATED}'))"
   not_running_vm_filters_aws   = "(not filter('aws_state', '{Code: 32,Name: shutting-down}', '{Code: 48,Name: terminated}', '{Code: 62,Name: stopping}', '{Code: 80,Name: stopped}'))"
   not_running_vm_filters_azure = "(not filter('azure_power_state', 'PowerState/stopping', 'PowerState/stopped', 'PowerState/deallocating', 'PowerState/deallocated'))"

--- a/modules/integration_aws-alb/detectors-alb.tf
+++ b/modules/integration_aws-alb/detectors-alb.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('RequestCount', filter=filter('stat', 'sum') and filter('namespace', 'AWS/ApplicationELB') and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
-    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}').publish('CRIT')
+    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 
   rule {

--- a/modules/integration_aws-beanstalk/detectors-beanstalk.tf
+++ b/modules/integration_aws-beanstalk/detectors-beanstalk.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('EnvironmentHealth', filter=filter('stat', 'mean') and filter('namespace', 'AWS/ElasticBeanstalk') and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
-    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}').publish('CRIT')
+    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 
   rule {

--- a/modules/integration_aws-ecs-cluster/detectors-ecs-cluster.tf
+++ b/modules/integration_aws-ecs-cluster/detectors-ecs-cluster.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('CPUReservation', filter=filter('namespace', 'AWS/ECS') and filter('stat', 'mean') and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
-    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}').publish('CRIT')
+    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 
   rule {

--- a/modules/integration_aws-ecs-service/detectors-ecs-service.tf
+++ b/modules/integration_aws-ecs-service/detectors-ecs-service.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('CPUUtilization', filter=filter('namespace', 'AWS/ECS') and filter('stat', 'mean') and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
-    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}').publish('CRIT')
+    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 
   rule {

--- a/modules/integration_aws-elasticache-common/detectors-elasticache.tf
+++ b/modules/integration_aws-elasticache-common/detectors-elasticache.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('CPUUtilization', filter=filter('stat', 'mean') and filter('namespace', 'AWS/ElastiCache') and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
-    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}').publish('CRIT')
+    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 
   rule {

--- a/modules/integration_aws-elasticsearch/detectors-elasticsearch.tf
+++ b/modules/integration_aws-elasticsearch/detectors-elasticsearch.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('Nodes', filter=filter('namespace', 'AWS/ES') and filter('stat', 'mean') and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
-    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}').publish('CRIT')
+    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 
   rule {

--- a/modules/integration_aws-elb/detectors-elb.tf
+++ b/modules/integration_aws-elb/detectors-elb.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('HealthyHostCount', filter=filter('stat', 'mean') and filter('namespace', 'AWS/ELB') and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
-    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}').publish('CRIT')
+    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 
   rule {

--- a/modules/integration_aws-kinesis-firehose/detectors-kinesis-firehose.tf
+++ b/modules/integration_aws-kinesis-firehose/detectors-kinesis-firehose.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('ResourceCount', filter=filter('stat', 'mean') and filter('namespace', 'AWS/Kinesis') and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
-    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}').publish('CRIT')
+    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 
   rule {

--- a/modules/integration_aws-nlb/detectors-nlb.tf
+++ b/modules/integration_aws-nlb/detectors-nlb.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('ConsumedLCUs', filter=filter('stat', 'mean') and filter('namespace', 'AWS/NetworkELB') and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
-    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}').publish('CRIT')
+    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 
   rule {

--- a/modules/integration_aws-rds-common/detectors-rds-common.tf
+++ b/modules/integration_aws-rds-common/detectors-rds-common.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('CPUUtilization', filter=filter('stat', 'mean') and filter('namespace', 'AWS/RDS') and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
-    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}').publish('CRIT')
+    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 
   rule {

--- a/modules/integration_aws-sqs/detectors-sqs.tf
+++ b/modules/integration_aws-sqs/detectors-sqs.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('NumberOfMessagesReceived', filter=filter('stat', 'mean') and filter('namespace', 'AWS/SQS') and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
-    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}').publish('CRIT')
+    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 
   rule {

--- a/modules/integration_aws-vpn/detectors-vpn.tf
+++ b/modules/integration_aws-vpn/detectors-vpn.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('TunnelState', filter=filter('stat', 'mean') and filter('namespace', 'AWS/VPN') and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
-    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}').publish('CRIT')
+    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 
   rule {

--- a/modules/integration_azure-api-management-service/detectors-api_management_service.tf
+++ b/modules/integration_azure-api-management-service/detectors-api_management_service.tf
@@ -5,7 +5,7 @@ resource "signalfx_detector" "heartbeat" {
         from signalfx.detectors.not_reporting import not_reporting
         base_filter = filter('resource_type', 'Microsoft.ApiManagement/service') and filter('primary_aggregation_type', 'true')
         signal = data('NetworkConnectivity', filter=base_filter and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
-        not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}').publish('CRIT')
+        not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
     EOF
 
   rule {

--- a/modules/integration_azure-app-service-plan/detectors-azure-app-service-plan.tf
+++ b/modules/integration_azure-app-service-plan/detectors-azure-app-service-plan.tf
@@ -8,7 +8,7 @@ resource "signalfx_detector" "heartbeat" {
         from signalfx.detectors.not_reporting import not_reporting
         base_filter = filter('resource_type', 'Microsoft.Web/serverFarms') and filter('primary_aggregation_type', 'true')
         signal = data('CpuPercentage', filter=base_filter and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
-        not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}').publish('CRIT')
+        not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
     EOF
 
   rule {

--- a/modules/integration_azure-app-service/detectors-app_services.tf
+++ b/modules/integration_azure-app-service/detectors-app_services.tf
@@ -8,7 +8,7 @@ resource "signalfx_detector" "heartbeat" {
         from signalfx.detectors.not_reporting import not_reporting
         base_filter = filter('resource_type', 'Microsoft.Web/sites') and filter('is_Azure_Function', 'false') and filter('primary_aggregation_type', 'true')
         signal = data('CpuTime', base_filter and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
-        not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}').publish('CRIT')
+        not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
     EOF
 
   rule {

--- a/modules/integration_azure-application-gateway/detectors-app-gateway.tf
+++ b/modules/integration_azure-application-gateway/detectors-app-gateway.tf
@@ -8,7 +8,7 @@ resource "signalfx_detector" "heartbeat" {
         from signalfx.detectors.not_reporting import not_reporting
         base_filter = filter('resource_type', 'Microsoft.Network/applicationGateways') and filter('primary_aggregation_type', 'true')
         signal = data('Throughput', filter=base_filter and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
-        not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}').publish('CRIT')
+        not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
     EOF
 
   rule {

--- a/modules/integration_azure-container-instance/detectors-gen.tf
+++ b/modules/integration_azure-container-instance/detectors-gen.tf
@@ -10,7 +10,7 @@ resource "signalfx_detector" "heartbeat" {
     from signalfx.detectors.not_reporting import not_reporting
     base_filtering = filter('resource_type', 'Microsoft.ContainerInstance/containerGroups') and filter('primary_aggregation_type', 'true')
     signal = data('CpuUsage', filter=base_filtering and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
-    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}').publish('CRIT')
+    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 
   rule {

--- a/modules/integration_azure-cosmos-db/detectors-cosmosdb.tf
+++ b/modules/integration_azure-cosmos-db/detectors-cosmosdb.tf
@@ -8,7 +8,7 @@ resource "signalfx_detector" "heartbeat" {
         from signalfx.detectors.not_reporting import not_reporting
         base_filter = filter('resource_type', 'Microsoft.DocumentDB/databaseAccounts') and filter('primary_aggregation_type', 'true')
         signal = data('AvailableStorage', filter=base_filter and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
-        not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}').publish('CRIT')
+        not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
     EOF
 
   rule {

--- a/modules/integration_azure-firewall/detectors-gen.tf
+++ b/modules/integration_azure-firewall/detectors-gen.tf
@@ -10,7 +10,7 @@ resource "signalfx_detector" "heartbeat" {
     from signalfx.detectors.not_reporting import not_reporting
     base_filtering = filter('resource_type', 'Microsoft.Network/azureFirewalls') and filter('primary_aggregation_type', 'true')
     signal = data('FirewallHealth', filter=base_filtering and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
-    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}').publish('CRIT')
+    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 
   rule {

--- a/modules/integration_azure-functions/detectors-functions.tf
+++ b/modules/integration_azure-functions/detectors-functions.tf
@@ -8,7 +8,7 @@ resource "signalfx_detector" "heartbeat" {
         from signalfx.detectors.not_reporting import not_reporting
         base_filter = filter('resource_type', 'Microsoft.Web/sites') and filter('is_Azure_Function', 'true') and filter('primary_aggregation_type', 'true')
         signal = data('AppConnections', filter=base_filter and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
-        not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}').publish('CRIT')
+        not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
     EOF
 
   rule {

--- a/modules/integration_azure-load-balancer/detectors-load-balancer.tf
+++ b/modules/integration_azure-load-balancer/detectors-load-balancer.tf
@@ -8,7 +8,7 @@ resource "signalfx_detector" "heartbeat" {
         from signalfx.detectors.not_reporting import not_reporting
         base_filter = filter('resource_type', 'Microsoft.Network/loadBalancers') and filter('primary_aggregation_type', 'true')
         signal = data('ByteCount', filter=base_filter and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
-        not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}').publish('CRIT')
+        not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
     EOF
 
   rule {

--- a/modules/integration_azure-mysql/detectors-mysql.tf
+++ b/modules/integration_azure-mysql/detectors-mysql.tf
@@ -8,7 +8,7 @@ resource "signalfx_detector" "heartbeat" {
         from signalfx.detectors.not_reporting import not_reporting
         base_filter = filter('resource_type', 'Microsoft.DBforMySQL/servers') and filter('primary_aggregation_type', 'true')
         signal = data('active_connections', filter=base_filter and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
-        not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}').publish('CRIT')
+        not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
     EOF
 
   rule {

--- a/modules/integration_azure-postgresql/detectors-postgresql.tf
+++ b/modules/integration_azure-postgresql/detectors-postgresql.tf
@@ -8,7 +8,7 @@ resource "signalfx_detector" "heartbeat" {
         from signalfx.detectors.not_reporting import not_reporting
         base_filter = filter('resource_type', 'Microsoft.DBforPostgreSQL/servers') and filter('primary_aggregation_type', 'true')
         signal = data('network_bytes_ingress', filter=base_filter and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
-        not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}').publish('CRIT')
+        not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
     EOF
 
   rule {

--- a/modules/integration_azure-redis/detectors-azure-redis.tf
+++ b/modules/integration_azure-redis/detectors-azure-redis.tf
@@ -8,7 +8,7 @@ resource "signalfx_detector" "heartbeat" {
         from signalfx.detectors.not_reporting import not_reporting
         base_filter = filter('resource_type', 'Microsoft.Cache/Redis') and filter('primary_aggregation_type', 'true')
         signal = data('usedmemory', filter=base_filter and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
-        not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}').publish('CRIT')
+        not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
     EOF
 
   rule {

--- a/modules/integration_azure-service-bus/detectors-service-bus.tf
+++ b/modules/integration_azure-service-bus/detectors-service-bus.tf
@@ -8,7 +8,7 @@ resource "signalfx_detector" "heartbeat" {
         from signalfx.detectors.not_reporting import not_reporting
         base_filter = filter('resource_type', 'Microsoft.ServiceBus/namespaces') and filter('primary_aggregation_type', 'true')
         signal = data('Size', filter=base_filter and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
-        not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}').publish('CRIT')
+        not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
     EOF
 
   rule {

--- a/modules/integration_azure-sql-database/detectors-sql-database.tf
+++ b/modules/integration_azure-sql-database/detectors-sql-database.tf
@@ -8,7 +8,7 @@ resource "signalfx_detector" "heartbeat" {
         from signalfx.detectors.not_reporting import not_reporting
         base_filter = filter('resource_type', 'Microsoft.Sql/servers/databases') and filter('primary_aggregation_type', 'true')
         signal = data('connection_successful', filter=base_filter and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
-        not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}').publish('CRIT')
+        not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
     EOF
 
   rule {

--- a/modules/integration_azure-sql-elastic-pool/detectors-sql-elasticpool.tf
+++ b/modules/integration_azure-sql-elastic-pool/detectors-sql-elasticpool.tf
@@ -8,7 +8,7 @@ resource "signalfx_detector" "heartbeat" {
         from signalfx.detectors.not_reporting import not_reporting
         base_filter = filter('resource_type', 'Microsoft.Sql/servers/elasticpools') and filter('primary_aggregation_type', 'true')
         signal = data('cpu_percent', filter=base_filter and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
-        not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}').publish('CRIT')
+        not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
     EOF
 
   rule {

--- a/modules/integration_azure-stream-analytics/detectors-stream-analytics.tf
+++ b/modules/integration_azure-stream-analytics/detectors-stream-analytics.tf
@@ -8,7 +8,7 @@ resource "signalfx_detector" "heartbeat" {
         from signalfx.detectors.not_reporting import not_reporting
         base_filter = filter('resource_type', 'Microsoft.StreamAnalytics/streamingjobs') and filter('primary_aggregation_type', 'true')
         signal = data('ResourceUtilization', filter=base_filter and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
-        not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}').publish('CRIT')
+        not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
     EOF
 
   rule {

--- a/modules/integration_azure-virtual-machine-scaleset/detectors-virtual-machine-scaleset.tf
+++ b/modules/integration_azure-virtual-machine-scaleset/detectors-virtual-machine-scaleset.tf
@@ -8,7 +8,7 @@ resource "signalfx_detector" "heartbeat" {
         from signalfx.detectors.not_reporting import not_reporting
         base_filter = filter('resource_type', 'Microsoft.Compute/virtualMachineScaleSets') and filter('primary_aggregation_type', 'true')
         signal = data('Percentage CPU', filter=base_filter and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
-        not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}').publish('CRIT')
+        not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
     EOF
 
   rule {

--- a/modules/integration_azure-virtual-machine/detectors-virtual-machine.tf
+++ b/modules/integration_azure-virtual-machine/detectors-virtual-machine.tf
@@ -8,7 +8,7 @@ resource "signalfx_detector" "heartbeat" {
         from signalfx.detectors.not_reporting import not_reporting
         base_filter = filter('resource_type', 'Microsoft.Compute/virtualMachines') and filter('primary_aggregation_type', 'true') and ${local.not_running_vm_filters_azure}
         signal = data('Percentage CPU', filter=base_filter and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
-        not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}').publish('CRIT')
+        not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
     EOF
 
   rule {

--- a/modules/integration_gcp-cloud-sql-common/detectors-cloud-sql-common.tf
+++ b/modules/integration_gcp-cloud-sql-common/detectors-cloud-sql-common.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('database/cpu/usage_time', filter=${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
-    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}').publish('CRIT')
+    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 
   rule {

--- a/modules/integration_gcp-compute-engine/detectors-gce-instance.tf
+++ b/modules/integration_gcp-compute-engine/detectors-gce-instance.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('instance/cpu/usage_time', filter=${local.not_running_vm_filters_gcp} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
-    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}').publish('CRIT')
+    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 
   rule {

--- a/modules/integration_gcp-pubsub-subscription/detectors-subscription.tf
+++ b/modules/integration_gcp-pubsub-subscription/detectors-subscription.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('subscription/pull_request_count', filter=${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
-    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}').publish('CRIT')
+    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 
   rule {

--- a/modules/integration_newrelic-apm/detectors-new-relic.tf
+++ b/modules/integration_newrelic-apm/detectors-new-relic.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('Apdex/score/*', ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
-    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}').publish('MAJOR')
+    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('MAJOR')
 EOF
 
   rule {

--- a/modules/smart-agent_apache/detectors-apache.tf
+++ b/modules/smart-agent_apache/detectors-apache.tf
@@ -9,7 +9,7 @@ resource "signalfx_detector" "heartbeat" {
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('apache_connections', filter=${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
-    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}').publish('CRIT')
+    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 
   rule {

--- a/modules/smart-agent_cassandra/detectors-cassandra.tf
+++ b/modules/smart-agent_cassandra/detectors-cassandra.tf
@@ -9,7 +9,7 @@ resource "signalfx_detector" "heartbeat" {
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('counter.cassandra.Storage.Load.Count', filter=${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
-    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}').publish('CRIT')
+    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 
   rule {

--- a/modules/smart-agent_dns/detectors-dns.tf
+++ b/modules/smart-agent_dns/detectors-dns.tf
@@ -9,7 +9,7 @@ resource "signalfx_detector" "heartbeat" {
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('dns.result_code', filter=${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
-    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}').publish('CRIT')
+    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 
   rule {

--- a/modules/smart-agent_docker/detectors-docker.tf
+++ b/modules/smart-agent_docker/detectors-docker.tf
@@ -9,7 +9,7 @@ resource "signalfx_detector" "heartbeat" {
   program_text = <<-EOF
 		from signalfx.detectors.not_reporting import not_reporting
 		signal = data('cpu.usage.system', filter=filter('plugin', 'docker') and ${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
-		not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}').publish('CRIT')
+		not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 
   rule {

--- a/modules/smart-agent_elasticsearch/detectors-elasticsearch.tf
+++ b/modules/smart-agent_elasticsearch/detectors-elasticsearch.tf
@@ -9,7 +9,7 @@ resource "signalfx_detector" "heartbeat" {
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('elasticsearch.cluster.number-of-nodes', filter=filter('plugin', 'elasticsearch') and ${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
-    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}').publish('CRIT')
+    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 
   rule {

--- a/modules/smart-agent_haproxy/detectors-haproxy.tf
+++ b/modules/smart-agent_haproxy/detectors-haproxy.tf
@@ -9,7 +9,7 @@ resource "signalfx_detector" "heartbeat" {
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('haproxy_session_current', filter=${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
-    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}').publish('CRIT')
+    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 
   rule {

--- a/modules/smart-agent_http/detectors-http.tf
+++ b/modules/smart-agent_http/detectors-http.tf
@@ -9,7 +9,7 @@ resource "signalfx_detector" "heartbeat" {
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('http.status_code', filter=${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
-    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}').publish('CRIT')
+    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 
   rule {

--- a/modules/smart-agent_kong/detectors-kong.tf
+++ b/modules/smart-agent_kong/detectors-kong.tf
@@ -9,7 +9,7 @@ resource "signalfx_detector" "heartbeat" {
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('counter.kong.requests.count', filter=${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
-    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}').publish('CRIT')
+    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 
   rule {

--- a/modules/smart-agent_kubernetes-apiserver/detectors-k8s-cluster.tf
+++ b/modules/smart-agent_kubernetes-apiserver/detectors-k8s-cluster.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('apiserver_request_total', filter=${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
-    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}').publish('CRIT')
+    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 
   rule {

--- a/modules/smart-agent_kubernetes-common/detectors-kubernetes-common.tf
+++ b/modules/smart-agent_kubernetes-common/detectors-kubernetes-common.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('kubernetes.node_ready', filter=${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
-    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}').publish('CRIT')
+    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 
   rule {

--- a/modules/smart-agent_memcached/detectors-memcached.tf
+++ b/modules/smart-agent_memcached/detectors-memcached.tf
@@ -9,7 +9,7 @@ resource "signalfx_detector" "heartbeat" {
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('memcached_items.current', filter=${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
-    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}').publish('CRIT')
+    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 
   rule {

--- a/modules/smart-agent_mongodb/detectors-mongo.tf
+++ b/modules/smart-agent_mongodb/detectors-mongo.tf
@@ -9,7 +9,7 @@ resource "signalfx_detector" "heartbeat" {
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('gauge.connections.available', filter=${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
-    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}').publish('CRIT')
+    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 
   rule {

--- a/modules/smart-agent_mysql/detectors-mysql.tf
+++ b/modules/smart-agent_mysql/detectors-mysql.tf
@@ -9,7 +9,7 @@ resource "signalfx_detector" "heartbeat" {
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('mysql_octets.rx', filter=filter('plugin', 'mysql') and ${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
-    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}').publish('CRIT')
+    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 
   rule {

--- a/modules/smart-agent_nginx/detectors-nginx.tf
+++ b/modules/smart-agent_nginx/detectors-nginx.tf
@@ -9,7 +9,7 @@ resource "signalfx_detector" "heartbeat" {
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('nginx_connections.reading', filter=${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
-    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}').publish('CRIT')
+    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 
   rule {

--- a/modules/smart-agent_ntp/detectors-ntp.tf
+++ b/modules/smart-agent_ntp/detectors-ntp.tf
@@ -9,7 +9,7 @@ resource "signalfx_detector" "heartbeat" {
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('ntp.offset_seconds', filter=${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
-    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}').publish('CRIT')
+    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 
   rule {

--- a/modules/smart-agent_php-fpm/detectors-fpm.tf
+++ b/modules/smart-agent_php-fpm/detectors-fpm.tf
@@ -9,7 +9,7 @@ resource "signalfx_detector" "heartbeat" {
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('phpfpm_requests.accepted', filter=${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
-    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}').publish('CRIT')
+    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 
   rule {

--- a/modules/smart-agent_postgresql/detectors-postgresql.tf
+++ b/modules/smart-agent_postgresql/detectors-postgresql.tf
@@ -9,7 +9,7 @@ resource "signalfx_detector" "heartbeat" {
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('postgres_database_size', filter=${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
-    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}').publish('CRIT')
+    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 
   rule {

--- a/modules/smart-agent_rabbitmq-node/detectors-rabbitmq-node.tf
+++ b/modules/smart-agent_rabbitmq-node/detectors-rabbitmq-node.tf
@@ -9,7 +9,7 @@ resource "signalfx_detector" "heartbeat" {
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('gauge.node.uptime', filter=${local.not_running_vm_filters} and filter('plugin', 'rabbitmq') and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
-    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}').publish('CRIT')
+    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 
   rule {

--- a/modules/smart-agent_redis/detectors-redis.tf
+++ b/modules/smart-agent_redis/detectors-redis.tf
@@ -9,7 +9,7 @@ resource "signalfx_detector" "heartbeat" {
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('bytes.used_memory', filter=filter('plugin', 'redis_info') and ${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
-    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}').publish('CRIT')
+    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 
   rule {

--- a/modules/smart-agent_solr/detectors-solr.tf
+++ b/modules/smart-agent_solr/detectors-solr.tf
@@ -9,7 +9,7 @@ resource "signalfx_detector" "heartbeat" {
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('counter.solr.http_requests', filter=${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
-    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}').publish('CRIT')
+    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 
   rule {

--- a/modules/smart-agent_supervisor/detectors-supervisor.tf
+++ b/modules/smart-agent_supervisor/detectors-supervisor.tf
@@ -9,7 +9,7 @@ resource "signalfx_detector" "heartbeat" {
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('supervisor.state', filter=${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
-    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}').publish('CRIT')
+    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 
   rule {

--- a/modules/smart-agent_system-common/detectors-gen.tf
+++ b/modules/smart-agent_system-common/detectors-gen.tf
@@ -9,7 +9,7 @@ resource "signalfx_detector" "heartbeat" {
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('cpu.utilization', filter=${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
-    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}').publish('CRIT')
+    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 
   rule {

--- a/modules/smart-agent_tomcat/detectors-tomcat.tf
+++ b/modules/smart-agent_tomcat/detectors-tomcat.tf
@@ -9,7 +9,7 @@ resource "signalfx_detector" "heartbeat" {
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data(' gauge.tomcat.ThreadPool.maxThreads ', filter=${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
-    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}').publish('CRIT')
+    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 
   rule {

--- a/modules/smart-agent_varnish/detectors-varnish.tf
+++ b/modules/smart-agent_varnish/detectors-varnish.tf
@@ -9,7 +9,7 @@ resource "signalfx_detector" "heartbeat" {
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('varnish.threads', filter=${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
-    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}').publish('CRIT')
+    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 
   rule {

--- a/modules/smart-agent_zookeeper/detectors-zookeeper.tf
+++ b/modules/smart-agent_zookeeper/detectors-zookeeper.tf
@@ -9,7 +9,7 @@ resource "signalfx_detector" "heartbeat" {
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('gauge.zk_max_file_descriptor_count', filter=filter('plugin', 'zookeeper') and ${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
-    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}').publish('CRIT')
+    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 
   rule {

--- a/scripts/templates/detector.tf.j2
+++ b/scripts/templates/detector.tf.j2
@@ -64,7 +64,7 @@ resource "signalfx_detector" "{{ id }}" {
       {%- if type == 'heartbeat' -%}
         {%- for key, signal in signals.items() -%}
           {%- if loop.last %}
-    not_reporting.detector(stream={{ key }}, resource_identifier=None, duration='${var.heartbeat_timeframe}')
+    not_reporting.detector(stream={{ key }}, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}')
           {%- endif -%}
         {%- endfor -%}
       {%- else %}


### PR DESCRIPTION
when a mts does not report during 36h it is considered as inactive by Splunk but the possible triggered alerts will not be auto cleared.

it seems not relevant to keep these alerts while they have no chance to be resolved normally one day without an active mts.

Splunk just has released a feature to auto resolve alert so using it with `36h`  delay should auto clear inactive mts related alerts.

it mainly concern heartbeat detectors but it can also be useful to rare others but for non heartbeat detector it seems better to use `fill()` or extrapolation function when we meet the case (as we already do).

See official documentation https://docs.signalfx.com/en/latest/detect-alert/zombie-alerts.html