### PR TITLE
smart-agent_processes: fix metric transformation

### DIFF
--- a/modules/smart-agent_processes/variables.tf
+++ b/modules/smart-agent_processes/variables.tf
@@ -47,7 +47,7 @@ variable "processes_aggregation_function" {
 variable "processes_transformation_function" {
   description = "Transformation function for processes detector (i.e. \".mean(over='5m')\")"
   type        = string
-  default     = ".min(over='15m')"
+  default     = ".max(over='15m')"
 }
 
 variable "processes_threshold_major" {


### PR DESCRIPTION
Metric transformation is inverted. Currently alert is triggered right after process number is too low and takes 15m to recover.