### PR TITLE
improve original detectors config after conversion to generator

### DIFF
--- a/docs/severity.md
+++ b/docs/severity.md
@@ -180,14 +180,14 @@
 |Detector|Critical|Major|Minor|Warning|Info|
 |---|---|---|---|---|---|
 |AWS Elasticache memcached cpu|X|X|-|-|-|
-|AWS Elasticache memcached hit ratio|X|X|-|-|-|
+|AWS Elasticache memcached hit ratio|-|X|X|-|-|
 
 
 ## aws-elasticache-redis
 
 |Detector|Critical|Major|Minor|Warning|Info|
 |---|---|---|---|---|---|
-|AWS ElastiCache redis cache hit ratio|X|X|-|-|-|
+|AWS ElastiCache redis cache hit ratio|-|X|X|-|-|
 |AWS ElastiCache redis cpu|X|X|-|-|-|
 |AWS ElastiCache redis replication lag|X|X|-|-|-|
 |AWS ElastiCache redis commands|-|X|-|-|-|

--- a/modules/integration_aws-alb/conf/00-heartbeat.yaml
+++ b/modules/integration_aws-alb/conf/00-heartbeat.yaml
@@ -2,7 +2,7 @@ module: AWS ALB
 name: heartbeat
 
 transformation: false
-aggregation: true
+aggregation: ".mean(by=['LoadBalancer'])"
 filtering: "filter('namespace', 'AWS/ApplicationELB')"
 
 signals:

--- a/modules/integration_aws-alb/variables-gen.tf
+++ b/modules/integration_aws-alb/variables-gen.tf
@@ -9,7 +9,7 @@ variable "heartbeat_notifications" {
 variable "heartbeat_aggregation_function" {
   description = "Aggregation function and group by for heartbeat detector (i.e. \".mean(by=['host'])\")"
   type        = string
-  default     = ""
+  default     = ".mean(by=['LoadBalancer'])"
 }
 
 variable "heartbeat_tip" {

--- a/modules/integration_aws-elasticache-memcached/README.md
+++ b/modules/integration_aws-elasticache-memcached/README.md
@@ -76,7 +76,7 @@ This module creates the following SignalFx detectors which could contain one or 
 |Detector|Critical|Major|Minor|Warning|Info|
 |---|---|---|---|---|---|
 |AWS Elasticache memcached cpu|X|X|-|-|-|
-|AWS Elasticache memcached hit ratio|X|X|-|-|-|
+|AWS Elasticache memcached hit ratio|-|X|X|-|-|
 
 ## How to collect required metrics?
 

--- a/modules/integration_aws-elasticache-memcached/conf/02-hit-ratio.yaml
+++ b/modules/integration_aws-elasticache-memcached/conf/02-hit-ratio.yaml
@@ -18,12 +18,12 @@ signals:
   signal:
     formula: (hits/(hits+misses)).scale(100).fill(value=0)
 rules:
-  critical:
-    threshold: 80
-    comparator: ">"
-    lasting_duration: 5m
   major:
     threshold: 60
-    comparator: ">"
-    dependency: critical
+    comparator: "<"
+    lasting_duration: 5m
+  minor:
+    threshold: 80
+    comparator: "<"
+    dependency: major
     lasting_duration: 5m

--- a/modules/integration_aws-elasticache-memcached/variables-gen.tf
+++ b/modules/integration_aws-elasticache-memcached/variables-gen.tf
@@ -120,35 +120,18 @@ variable "hit_ratio_disabled" {
   default     = null
 }
 
-variable "hit_ratio_disabled_critical" {
-  description = "Disable critical alerting rule for hit_ratio detector"
-  type        = bool
-  default     = null
-}
-
 variable "hit_ratio_disabled_major" {
   description = "Disable major alerting rule for hit_ratio detector"
   type        = bool
   default     = null
 }
 
-variable "hit_ratio_threshold_critical" {
-  description = "Critical threshold for hit_ratio detector in %"
-  type        = number
-  default     = 80
+variable "hit_ratio_disabled_minor" {
+  description = "Disable minor alerting rule for hit_ratio detector"
+  type        = bool
+  default     = null
 }
 
-variable "hit_ratio_lasting_duration_critical" {
-  description = "Minimum duration that conditions must be true before raising alert"
-  type        = string
-  default     = "5m"
-}
-
-variable "hit_ratio_at_least_percentage_critical" {
-  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
-  type        = number
-  default     = 1
-}
 variable "hit_ratio_threshold_major" {
   description = "Major threshold for hit_ratio detector in %"
   type        = number
@@ -162,6 +145,23 @@ variable "hit_ratio_lasting_duration_major" {
 }
 
 variable "hit_ratio_at_least_percentage_major" {
+  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
+  type        = number
+  default     = 1
+}
+variable "hit_ratio_threshold_minor" {
+  description = "Minor threshold for hit_ratio detector in %"
+  type        = number
+  default     = 80
+}
+
+variable "hit_ratio_lasting_duration_minor" {
+  description = "Minimum duration that conditions must be true before raising alert"
+  type        = string
+  default     = "5m"
+}
+
+variable "hit_ratio_at_least_percentage_minor" {
   description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
   type        = number
   default     = 1

--- a/modules/integration_aws-elasticache-redis/README.md
+++ b/modules/integration_aws-elasticache-redis/README.md
@@ -75,7 +75,7 @@ This module creates the following SignalFx detectors which could contain one or 
 
 |Detector|Critical|Major|Minor|Warning|Info|
 |---|---|---|---|---|---|
-|AWS ElastiCache redis cache hit ratio|X|X|-|-|-|
+|AWS ElastiCache redis cache hit ratio|-|X|X|-|-|
 |AWS ElastiCache redis cpu|X|X|-|-|-|
 |AWS ElastiCache redis replication lag|X|X|-|-|-|
 |AWS ElastiCache redis commands|-|X|-|-|-|

--- a/modules/integration_aws-elasticache-redis/conf/01-hit-ratio.yaml
+++ b/modules/integration_aws-elasticache-redis/conf/01-hit-ratio.yaml
@@ -10,20 +10,24 @@ value_unit: "%"
 signals:
   hits:
     metric: CacheHits
+    extrapolation: zero
+    rollup: sum
   misses:
     metric: CacheMisses
+    extrapolation: zero
+    rollup: sum
   signal:
     formula: (hits/(hits+misses)).fill(value=1).scale(100)
 
 rules:
-  critical:
+  major:
     threshold: 60
     comparator: "<"
     lasting_duration: 5m
     lasting_at_least: 0.9
-  major:
+  minor:
     threshold: 80
     comparator: "<"
-    dependency: critical
+    dependency: major
     lasting_duration: 5m
     lasting_at_least: 0.9

--- a/modules/integration_aws-elasticache-redis/conf/04-commands-min.yaml
+++ b/modules/integration_aws-elasticache-redis/conf/04-commands-min.yaml
@@ -1,7 +1,7 @@
 module: AWS ElastiCache redis
 name: commands
 
-transformation: true
+transformation: ".sum(over='15m')"
 aggregation: true
 filtering: "filter('namespace', 'AWS/ElastiCache') and filter('stat', 'lower') and filter('CacheNodeId', '*')"
 
@@ -17,4 +17,3 @@ rules:
   major:
     threshold: 0
     comparator: "<="
-    lasting_duration: 15m

--- a/modules/integration_aws-elasticache-redis/detectors-gen.tf
+++ b/modules/integration_aws-elasticache-redis/detectors-gen.tf
@@ -12,24 +12,12 @@ resource "signalfx_detector" "cache_hits" {
 
   program_text = <<-EOF
     base_filtering = filter('namespace', 'AWS/ElastiCache') and filter('stat', 'mean') and filter('CacheNodeId', '*')
-    hits = data('CacheHits', filter=base_filtering and ${module.filtering.signalflow})${var.cache_hits_aggregation_function}${var.cache_hits_transformation_function}
-    misses = data('CacheMisses', filter=base_filtering and ${module.filtering.signalflow})${var.cache_hits_aggregation_function}${var.cache_hits_transformation_function}
+    hits = data('CacheHits', filter=base_filtering and ${module.filtering.signalflow}, rollup='sum', extrapolation='zero')${var.cache_hits_aggregation_function}${var.cache_hits_transformation_function}
+    misses = data('CacheMisses', filter=base_filtering and ${module.filtering.signalflow}, rollup='sum', extrapolation='zero')${var.cache_hits_aggregation_function}${var.cache_hits_transformation_function}
     signal = (hits/(hits+misses)).fill(value=1).scale(100).publish('signal')
-    detect(when(signal < ${var.cache_hits_threshold_critical}, lasting=%{if var.cache_hits_lasting_duration_critical == null}None%{else}'${var.cache_hits_lasting_duration_critical}'%{endif}, at_least=${var.cache_hits_at_least_percentage_critical})).publish('CRIT')
-    detect(when(signal < ${var.cache_hits_threshold_major}, lasting=%{if var.cache_hits_lasting_duration_major == null}None%{else}'${var.cache_hits_lasting_duration_major}'%{endif}, at_least=${var.cache_hits_at_least_percentage_major}) and (not when(signal < ${var.cache_hits_threshold_critical}, lasting=%{if var.cache_hits_lasting_duration_critical == null}None%{else}'${var.cache_hits_lasting_duration_critical}'%{endif}, at_least=${var.cache_hits_at_least_percentage_critical}))).publish('MAJOR')
+    detect(when(signal < ${var.cache_hits_threshold_major}, lasting=%{if var.cache_hits_lasting_duration_major == null}None%{else}'${var.cache_hits_lasting_duration_major}'%{endif}, at_least=${var.cache_hits_at_least_percentage_major})).publish('MAJOR')
+    detect(when(signal < ${var.cache_hits_threshold_minor}, lasting=%{if var.cache_hits_lasting_duration_minor == null}None%{else}'${var.cache_hits_lasting_duration_minor}'%{endif}, at_least=${var.cache_hits_at_least_percentage_minor}) and (not when(signal < ${var.cache_hits_threshold_major}, lasting=%{if var.cache_hits_lasting_duration_major == null}None%{else}'${var.cache_hits_lasting_duration_major}'%{endif}, at_least=${var.cache_hits_at_least_percentage_major}))).publish('MINOR')
 EOF
-
-  rule {
-    description           = "is too low < ${var.cache_hits_threshold_critical}%"
-    severity              = "Critical"
-    detect_label          = "CRIT"
-    disabled              = coalesce(var.cache_hits_disabled_critical, var.cache_hits_disabled, var.detectors_disabled)
-    notifications         = coalescelist(lookup(var.cache_hits_notifications, "critical", []), var.notifications.critical)
-    runbook_url           = try(coalesce(var.cache_hits_runbook_url, var.runbook_url), "")
-    tip                   = var.cache_hits_tip
-    parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
-    parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
-  }
 
   rule {
     description           = "is too low < ${var.cache_hits_threshold_major}%"
@@ -37,6 +25,18 @@ EOF
     detect_label          = "MAJOR"
     disabled              = coalesce(var.cache_hits_disabled_major, var.cache_hits_disabled, var.detectors_disabled)
     notifications         = coalescelist(lookup(var.cache_hits_notifications, "major", []), var.notifications.major)
+    runbook_url           = try(coalesce(var.cache_hits_runbook_url, var.runbook_url), "")
+    tip                   = var.cache_hits_tip
+    parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
+    parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
+  }
+
+  rule {
+    description           = "is too low < ${var.cache_hits_threshold_minor}%"
+    severity              = "Minor"
+    detect_label          = "MINOR"
+    disabled              = coalesce(var.cache_hits_disabled_minor, var.cache_hits_disabled, var.detectors_disabled)
+    notifications         = coalescelist(lookup(var.cache_hits_notifications, "minor", []), var.notifications.minor)
     runbook_url           = try(coalesce(var.cache_hits_runbook_url, var.runbook_url), "")
     tip                   = var.cache_hits_tip
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject

--- a/modules/integration_aws-elasticache-redis/variables-gen.tf
+++ b/modules/integration_aws-elasticache-redis/variables-gen.tf
@@ -36,39 +36,22 @@ variable "cache_hits_disabled" {
   default     = null
 }
 
-variable "cache_hits_disabled_critical" {
-  description = "Disable critical alerting rule for cache_hits detector"
-  type        = bool
-  default     = null
-}
-
 variable "cache_hits_disabled_major" {
   description = "Disable major alerting rule for cache_hits detector"
   type        = bool
   default     = null
 }
 
-variable "cache_hits_threshold_critical" {
-  description = "Critical threshold for cache_hits detector in %"
-  type        = number
-  default     = 60
+variable "cache_hits_disabled_minor" {
+  description = "Disable minor alerting rule for cache_hits detector"
+  type        = bool
+  default     = null
 }
 
-variable "cache_hits_lasting_duration_critical" {
-  description = "Minimum duration that conditions must be true before raising alert"
-  type        = string
-  default     = "5m"
-}
-
-variable "cache_hits_at_least_percentage_critical" {
-  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
-  type        = number
-  default     = 0.9
-}
 variable "cache_hits_threshold_major" {
   description = "Major threshold for cache_hits detector in %"
   type        = number
-  default     = 80
+  default     = 60
 }
 
 variable "cache_hits_lasting_duration_major" {
@@ -78,6 +61,23 @@ variable "cache_hits_lasting_duration_major" {
 }
 
 variable "cache_hits_at_least_percentage_major" {
+  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
+  type        = number
+  default     = 0.9
+}
+variable "cache_hits_threshold_minor" {
+  description = "Minor threshold for cache_hits detector in %"
+  type        = number
+  default     = 80
+}
+
+variable "cache_hits_lasting_duration_minor" {
+  description = "Minimum duration that conditions must be true before raising alert"
+  type        = string
+  default     = "5m"
+}
+
+variable "cache_hits_at_least_percentage_minor" {
   description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
   type        = number
   default     = 0.9
@@ -267,7 +267,7 @@ variable "commands_aggregation_function" {
 variable "commands_transformation_function" {
   description = "Transformation function for commands detector (i.e. \".mean(over='5m')\")"
   type        = string
-  default     = ""
+  default     = ".sum(over='15m')"
 }
 
 variable "commands_tip" {
@@ -297,7 +297,7 @@ variable "commands_threshold_major" {
 variable "commands_lasting_duration_major" {
   description = "Minimum duration that conditions must be true before raising alert"
   type        = string
-  default     = "15m"
+  default     = null
 }
 
 variable "commands_at_least_percentage_major" {

--- a/modules/integration_aws-elb/conf/00-heartbeat.yaml
+++ b/modules/integration_aws-elb/conf/00-heartbeat.yaml
@@ -2,7 +2,7 @@ module: AWS ELB
 name: heartbeat
 
 transformation: false
-aggregation: true
+aggregation: ".mean(by=['LoadBalancerName'])"
 filtering: "filter('namespace', 'AWS/ELB')"
 
 signals:

--- a/modules/integration_aws-elb/variables-gen.tf
+++ b/modules/integration_aws-elb/variables-gen.tf
@@ -9,7 +9,7 @@ variable "heartbeat_notifications" {
 variable "heartbeat_aggregation_function" {
   description = "Aggregation function and group by for heartbeat detector (i.e. \".mean(by=['host'])\")"
   type        = string
-  default     = ""
+  default     = ".mean(by=['LoadBalancerName'])"
 }
 
 variable "heartbeat_tip" {

--- a/modules/integration_aws-lambda/conf/01-errors-percentage.yaml
+++ b/modules/integration_aws-lambda/conf/01-errors-percentage.yaml
@@ -27,4 +27,4 @@ rules:
     threshold: 0
     comparator: ">"
     dependency: critical
-    lasting_duration: 5m
+    lasting_duration: 15m

--- a/modules/integration_aws-lambda/variables-gen.tf
+++ b/modules/integration_aws-lambda/variables-gen.tf
@@ -74,7 +74,7 @@ variable "pct_errors_threshold_major" {
 variable "pct_errors_lasting_duration_major" {
   description = "Minimum duration that conditions must be true before raising alert"
   type        = string
-  default     = "5m"
+  default     = "15m"
 }
 
 variable "pct_errors_at_least_percentage_major" {

--- a/modules/smart-agent_http/conf/04-content-length.yaml
+++ b/modules/smart-agent_http/conf/04-content-length.yaml
@@ -5,6 +5,7 @@ id: http_content_length
 transformation: true
 aggregation: true
 value_unit: bytes
+disabled: true
 
 signals:
   signal:

--- a/modules/smart-agent_http/variables-gen.tf
+++ b/modules/smart-agent_http/variables-gen.tf
@@ -265,7 +265,7 @@ variable "http_content_length_runbook_url" {
 variable "http_content_length_disabled" {
   description = "Disable all alerting rules for http_content_length detector"
   type        = bool
-  default     = null
+  default     = true
 }
 
 variable "http_content_length_threshold_warning" {

--- a/modules/smart-agent_kubernetes-common/conf/01-hpa-scale-capacity.yaml
+++ b/modules/smart-agent_kubernetes-common/conf/01-hpa-scale-capacity.yaml
@@ -18,4 +18,4 @@ rules:
   major:
     threshold: 0
     comparator: ">="
-    lasting_duration: 300s
+    lasting_duration: 5m

--- a/modules/smart-agent_kubernetes-common/conf/04-termination.yaml
+++ b/modules/smart-agent_kubernetes-common/conf/04-termination.yaml
@@ -14,4 +14,4 @@ rules:
   major:
     threshold: 0
     comparator: ">"
-    lasting_duration: 5m
+    lasting_duration: 10m

--- a/modules/smart-agent_kubernetes-common/variables-gen.tf
+++ b/modules/smart-agent_kubernetes-common/variables-gen.tf
@@ -85,7 +85,7 @@ variable "hpa_capacity_threshold_major" {
 variable "hpa_capacity_lasting_duration_major" {
   description = "Minimum duration that conditions must be true before raising alert"
   type        = string
-  default     = "300s"
+  default     = "5m"
 }
 
 variable "hpa_capacity_at_least_percentage_major" {
@@ -331,7 +331,7 @@ variable "terminated_threshold_major" {
 variable "terminated_lasting_duration_major" {
   description = "Minimum duration that conditions must be true before raising alert"
   type        = string
-  default     = "5m"
+  default     = "10m"
 }
 
 variable "terminated_at_least_percentage_major" {

--- a/modules/smart-agent_nginx-ingress/conf/01-latency.yaml
+++ b/modules/smart-agent_nginx-ingress/conf/01-latency.yaml
@@ -2,7 +2,7 @@ module: Ingress Nginx
 name: latency
 
 transformation: true
-aggregation: true
+aggregation: ".sum(by=['controller_namespace', 'controller_class', 'ingress'])"
 value_unit: "s"
 
 signals:

--- a/modules/smart-agent_nginx-ingress/conf/02-lb-5xx.yaml
+++ b/modules/smart-agent_nginx-ingress/conf/02-lb-5xx.yaml
@@ -3,7 +3,7 @@ name: 5xx errors ratio
 id: http_5xx
 
 transformation: true
-aggregation: true
+aggregation: ".sum(by=['controller_namespace', 'controller_class', 'ingress'])"
 value_unit: "%"
 
 signals:

--- a/modules/smart-agent_nginx-ingress/conf/03-lb-4xx.yaml
+++ b/modules/smart-agent_nginx-ingress/conf/03-lb-4xx.yaml
@@ -3,7 +3,7 @@ name: 4xx errors ratio
 id: http_4xx
 
 transformation: true
-aggregation: true
+aggregation: ".sum(by=['controller_namespace', 'controller_class', 'ingress'])"
 value_unit: "%"
 
 signals:

--- a/modules/smart-agent_nginx-ingress/variables-gen.tf
+++ b/modules/smart-agent_nginx-ingress/variables-gen.tf
@@ -9,7 +9,7 @@ variable "latency_notifications" {
 variable "latency_aggregation_function" {
   description = "Aggregation function and group by for latency detector (i.e. \".mean(by=['host'])\")"
   type        = string
-  default     = ""
+  default     = ".sum(by=['controller_namespace', 'controller_class', 'ingress'])"
 }
 
 variable "latency_transformation_function" {
@@ -93,7 +93,7 @@ variable "http_5xx_notifications" {
 variable "http_5xx_aggregation_function" {
   description = "Aggregation function and group by for http_5xx detector (i.e. \".mean(by=['host'])\")"
   type        = string
-  default     = ""
+  default     = ".sum(by=['controller_namespace', 'controller_class', 'ingress'])"
 }
 
 variable "http_5xx_transformation_function" {
@@ -177,7 +177,7 @@ variable "http_4xx_notifications" {
 variable "http_4xx_aggregation_function" {
   description = "Aggregation function and group by for http_4xx detector (i.e. \".mean(by=['host'])\")"
   type        = string
-  default     = ""
+  default     = ".sum(by=['controller_namespace', 'controller_class', 'ingress'])"
 }
 
 variable "http_4xx_transformation_function" {

--- a/modules/smart-agent_rabbitmq-queue/conf/01-messages-ready.yaml
+++ b/modules/smart-agent_rabbitmq-queue/conf/01-messages-ready.yaml
@@ -1,7 +1,7 @@
 module: RabbitMQ Queue
 name: messages ready
 
-transformation: ".min(over='20m')"
+transformation: true
 aggregation: true
 filtering: "filter('plugin', 'rabbitmq')"
 
@@ -13,7 +13,9 @@ rules:
   critical:
     threshold: 15000
     comparator: ">"
+    lasting_duration: 20m
   major:
     threshold: 10000
     comparator: ">"
+    lasting_duration: 20m
     dependency: critical

--- a/modules/smart-agent_rabbitmq-queue/conf/02-messages-unacknowledged.yaml
+++ b/modules/smart-agent_rabbitmq-queue/conf/02-messages-unacknowledged.yaml
@@ -1,7 +1,7 @@
 module: RabbitMQ Queue
 name: messages unacknowledged
 
-transformation: ".min(over='20m')"
+transformation: true
 aggregation: true
 filtering: "filter('plugin', 'rabbitmq')"
 disabled: true
@@ -14,7 +14,9 @@ rules:
   critical:
     threshold: 15000
     comparator: ">"
+    lasting_duration: 20m
   major:
     threshold: 10000
     comparator: ">"
+    lasting_duration: 20m
     dependency: critical

--- a/modules/smart-agent_rabbitmq-queue/conf/03-messages-ack-rate.yaml
+++ b/modules/smart-agent_rabbitmq-queue/conf/03-messages-ack-rate.yaml
@@ -1,7 +1,7 @@
 module: RabbitMQ Queue
 name: messages ack rate
 
-transformation: ".min(over='20m')"
+transformation: true
 aggregation: true
 filtering: "filter('plugin', 'rabbitmq')"
 disabled: true

--- a/modules/smart-agent_rabbitmq-queue/conf/04-consumer-use.yaml
+++ b/modules/smart-agent_rabbitmq-queue/conf/04-consumer-use.yaml
@@ -1,7 +1,7 @@
 module: RabbitMQ Queue
 name: consumer use
 
-transformation: ".min(over='20m')"
+transformation: true
 aggregation: true
 filtering: "filter('plugin', 'rabbitmq')"
 disabled: true

--- a/modules/smart-agent_rabbitmq-queue/variables-gen.tf
+++ b/modules/smart-agent_rabbitmq-queue/variables-gen.tf
@@ -15,7 +15,7 @@ variable "messages_ready_aggregation_function" {
 variable "messages_ready_transformation_function" {
   description = "Transformation function for messages_ready detector (i.e. \".mean(over='5m')\")"
   type        = string
-  default     = ".min(over='20m')"
+  default     = ""
 }
 
 variable "messages_ready_tip" {
@@ -57,7 +57,7 @@ variable "messages_ready_threshold_critical" {
 variable "messages_ready_lasting_duration_critical" {
   description = "Minimum duration that conditions must be true before raising alert"
   type        = string
-  default     = null
+  default     = "20m"
 }
 
 variable "messages_ready_at_least_percentage_critical" {
@@ -74,7 +74,7 @@ variable "messages_ready_threshold_major" {
 variable "messages_ready_lasting_duration_major" {
   description = "Minimum duration that conditions must be true before raising alert"
   type        = string
-  default     = null
+  default     = "20m"
 }
 
 variable "messages_ready_at_least_percentage_major" {
@@ -99,7 +99,7 @@ variable "messages_unacknowledged_aggregation_function" {
 variable "messages_unacknowledged_transformation_function" {
   description = "Transformation function for messages_unacknowledged detector (i.e. \".mean(over='5m')\")"
   type        = string
-  default     = ".min(over='20m')"
+  default     = ""
 }
 
 variable "messages_unacknowledged_tip" {
@@ -141,7 +141,7 @@ variable "messages_unacknowledged_threshold_critical" {
 variable "messages_unacknowledged_lasting_duration_critical" {
   description = "Minimum duration that conditions must be true before raising alert"
   type        = string
-  default     = null
+  default     = "20m"
 }
 
 variable "messages_unacknowledged_at_least_percentage_critical" {
@@ -158,7 +158,7 @@ variable "messages_unacknowledged_threshold_major" {
 variable "messages_unacknowledged_lasting_duration_major" {
   description = "Minimum duration that conditions must be true before raising alert"
   type        = string
-  default     = null
+  default     = "20m"
 }
 
 variable "messages_unacknowledged_at_least_percentage_major" {
@@ -183,7 +183,7 @@ variable "messages_ack_rate_aggregation_function" {
 variable "messages_ack_rate_transformation_function" {
   description = "Transformation function for messages_ack_rate detector (i.e. \".mean(over='5m')\")"
   type        = string
-  default     = ".min(over='20m')"
+  default     = ""
 }
 
 variable "messages_ack_rate_tip" {
@@ -267,7 +267,7 @@ variable "consumer_use_aggregation_function" {
 variable "consumer_use_transformation_function" {
   description = "Transformation function for consumer_use detector (i.e. \".mean(over='5m')\")"
   type        = string
-  default     = ".min(over='20m')"
+  default     = ""
 }
 
 variable "consumer_use_tip" {


### PR DESCRIPTION
This PR improve some detectors recently converted to generator from https://github.com/claranet/terraform-signalfx-detectors/pull/316 and https://github.com/claranet/terraform-signalfx-detectors/pull/318 compared to the general implementation, see these PRs for a list of all detectors now using generator.