### PR TITLE
allow load per cpu option to be optional

### DIFF
--- a/.github/workflows/generator.yml
+++ b/.github/workflows/generator.yml
@@ -54,7 +54,7 @@ jobs:
           done
         done
         ./scripts/stack/bootstrap.sh
-        echo -e "module \"generated\" {\nsource=\"../../modules/internal_generator-${TF_VAR_environment}\"\n$(cat common/modules-args.txt)\n}" >> examples/stack/detectors.tf
+        echo -e "module \"generated\" {\nsource=\"../../modules/internal_generator-${TF_VAR_environment}\"\n$(cat common/modules-args.txt)\n}" > examples/stack/detectors.tf
 
     - name: Terraform init
       if: env.SFX_AUTH_TOKEN != null

--- a/modules/smart-agent_system-common/README.md
+++ b/modules/smart-agent_system-common/README.md
@@ -117,6 +117,7 @@ the corresponding monitor configuration:
     datapointsToExclude:
       - metricNames:
         - '*'
+        - '!cpu.num_processors'
         - '!cpu.utilization'
         - '!disk.utilization'
         - '!load.midterm'

--- a/modules/smart-agent_system-common/README.md
+++ b/modules/smart-agent_system-common/README.md
@@ -98,12 +98,20 @@ all useful metrics from `cpu`, `load`, `filesystems` and `memory`.
 
 ### Monitors
 
-You have to enable the `inodes` group in `extraGroups` parameter of the `filesystems` monitor configuration (only 
-available for `Linux`) to work with the inodes detector.
+#### Inodes
 
-It is highly recommended to define `perCPU: true` in the `load` monitor configuration to get the __ratio__ of load 
-per CPU/core which makes more sens for the generic load detector.
-For `Helm` deployment on `Kubernetes`, you can use `loadPerCPU` option available from `1.2.0` version.
+To use inodes based detectors you must enable the `inodes` group in `extraGroups` parameter of the `filesystems` monitor configuration
+
+Inodes metrics areonly available for `Linux`).
+
+#### Load
+
+You have two choices to use load based detectors:
+  - either keep the `per_cpu_enabled` enabled (variable default value) __and__ define `perCPU: true` in the [load monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/load.html) configuration (for Kubernetes, you can use `loadPerCPU` option from the Helm chart available from `1.2.0` version).
+  - or override the `per_cpu_enabled` to `false` __and__ keep the default configuration for the [load monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/load.html) with `perCPU: false` or not defined
+
+In both cases, the goal is to get alerts based on the __ratio__ of load by dividing the original load per the number of CPU/cores which is the only way to get generic and relevant alerts for load.
+It mainly depends if you want to collect 2 metrics instead of 1 and if you want the load one to be raw or already averaged.
 
 
 ### Metrics

--- a/modules/smart-agent_system-common/conf/02-load.yaml
+++ b/modules/smart-agent_system-common/conf/02-load.yaml
@@ -3,8 +3,12 @@ name: "load 5m ratio"
 id: load
 transformation: ".min(over='30m')"
 signals:
-  signal:
+  load:
     metric: load.midterm
+  num_processors:
+    metric: cpu.num_processors
+  signal:
+    formula: '(${var.per_cpu_enabled ? "load / num_processors" : "load"})'
 rules:
   critical:
     threshold: 2.5

--- a/modules/smart-agent_system-common/conf/02-load.yaml
+++ b/modules/smart-agent_system-common/conf/02-load.yaml
@@ -8,7 +8,7 @@ signals:
   num_processors:
     metric: cpu.num_processors
   signal:
-    formula: '(${var.per_cpu_enabled ? "load / num_processors" : "load"})'
+    formula: '(${var.per_cpu_enabled ? "load" : "load/num_processors"})'
 rules:
   critical:
     threshold: 2.5

--- a/modules/smart-agent_system-common/conf/readme.yaml
+++ b/modules/smart-agent_system-common/conf/readme.yaml
@@ -15,11 +15,19 @@ source_doc: |
   all useful metrics from `cpu`, `load`, `filesystems` and `memory`.
 
   ### Monitors
+  
+  #### Inodes
+  
+  To use inodes based detectors you must enable the `inodes` group in `extraGroups` parameter of the `filesystems` monitor configuration
 
-  You have to enable the `inodes` group in `extraGroups` parameter of the `filesystems` monitor configuration (only 
-  available for `Linux`) to work with the inodes detector.
+  Inodes metrics areonly available for `Linux`).
 
-  It is highly recommended to define `perCPU: true` in the `load` monitor configuration to get the __ratio__ of load 
-  per CPU/core which makes more sens for the generic load detector.
-  For `Helm` deployment on `Kubernetes`, you can use `loadPerCPU` option available from `1.2.0` version.
+  #### Load
+
+  You have two choices to use load based detectors:
+    - either keep the `per_cpu_enabled` enabled (variable default value) __and__ define `perCPU: true` in the [load monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/load.html) configuration (for Kubernetes, you can use `loadPerCPU` option from the Helm chart available from `1.2.0` version).
+    - or override the `per_cpu_enabled` to `false` __and__ keep the default configuration for the [load monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/load.html) with `perCPU: false` or not defined
+
+  In both cases, the goal is to get alerts based on the __ratio__ of load by dividing the original load per the number of CPU/cores which is the only way to get generic and relevant alerts for load.
+  It mainly depends if you want to collect 2 metrics instead of 1 and if you want the load one to be raw or already averaged.
 

--- a/modules/smart-agent_system-common/detectors-gen.tf
+++ b/modules/smart-agent_system-common/detectors-gen.tf
@@ -79,7 +79,7 @@ resource "signalfx_detector" "load" {
   program_text = <<-EOF
     load = data('load.midterm', filter=${module.filtering.signalflow})${var.load_aggregation_function}${var.load_transformation_function}
     num_processors = data('cpu.num_processors', filter=${module.filtering.signalflow})${var.load_aggregation_function}${var.load_transformation_function}
-    signal = (${var.per_cpu_enabled ? "load / num_processors" : "load"}).publish('signal')
+    signal = (${var.per_cpu_enabled ? "load" : "load/num_processors"}).publish('signal')
     detect(when(signal > ${var.load_threshold_critical}, lasting=%{if var.load_lasting_duration_critical == null}None%{else}'${var.load_lasting_duration_critical}'%{endif}, at_least=${var.load_at_least_percentage_critical})).publish('CRIT')
     detect(when(signal > ${var.load_threshold_major}, lasting=%{if var.load_lasting_duration_major == null}None%{else}'${var.load_lasting_duration_major}'%{endif}, at_least=${var.load_at_least_percentage_major}) and (not when(signal > ${var.load_threshold_critical}, lasting=%{if var.load_lasting_duration_critical == null}None%{else}'${var.load_lasting_duration_critical}'%{endif}, at_least=${var.load_at_least_percentage_critical}))).publish('MAJOR')
 EOF

--- a/modules/smart-agent_system-common/variables.tf
+++ b/modules/smart-agent_system-common/variables.tf
@@ -1,3 +1,11 @@
+# Module specific
+
+variable "per_cpu_enabled" {
+  description = "Is perCPU option is enabled for the load monitor of the agent"
+  type        = bool
+  default     = true
+}
+
 # disk_running_out detector
 
 variable "disk_running_out_tip" {


### PR DESCRIPTION
the [load monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/load.html) from smart agent allows to define `perCPU` option to automatically average load per cpu number.

before this was a mandatory config to set to use the load detector properly, it provides some advantages:
- more straightforward to use
- simpler signalflow
- load metric without cpu num correlation is rarely useful
- it needs only 1 metric instead of 2 (which ca have an impact on MTS plan)

that said, in some cases it could be useful to keep the original/raw information and make the division into the signalflow instead.
This PR adds an option to make this possible.