### PR TITLE
fix storage unit scaling

### DIFF
--- a/modules/integration_aws-efs/conf/01-used-space.yaml
+++ b/modules/integration_aws-efs/conf/01-used-space.yaml
@@ -1,7 +1,7 @@
 module: "AWS EFS"
 name: "Used Space"
 filtering: "filter('namespace', 'AWS/EFS')"
-value_unit: "GB"
+value_unit: "Gigibyte"
 transformation: ".max(over='15m')"
 signals:
   used_space:
@@ -9,7 +9,7 @@ signals:
     filter: "filter('StorageClass', 'Total') and filter('stat', 'mean')"
   signal:
     formula:
-      used_space.scale(0.000000000931323) # 1/1024^3
+      used_space.scale(1/1024**3)
 rules:
   critical:
     comparator: ">"

--- a/modules/integration_aws-efs/variables-gen.tf
+++ b/modules/integration_aws-efs/variables-gen.tf
@@ -49,7 +49,7 @@ variable "used_space_disabled_major" {
 }
 
 variable "used_space_threshold_critical" {
-  description = "Critical threshold for used_space detector in GB"
+  description = "Critical threshold for used_space detector in Gigibyte"
   type        = number
 }
 
@@ -65,7 +65,7 @@ variable "used_space_at_least_percentage_critical" {
   default     = 1
 }
 variable "used_space_threshold_major" {
-  description = "Major threshold for used_space detector in GB"
+  description = "Major threshold for used_space detector in Gigibyte"
   type        = number
 }
 

--- a/modules/integration_aws-elasticsearch/variables.tf
+++ b/modules/integration_aws-elasticsearch/variables.tf
@@ -141,13 +141,13 @@ variable "free_space_transformation_function" {
 variable "free_space_threshold_critical" {
   description = "Critical threshold for free_space detector"
   type        = number
-  default     = 20480
+  default     = 20
 }
 
 variable "free_space_threshold_major" {
   description = "Major threshold for free_space detector"
   type        = number
-  default     = 40960
+  default     = 40
 }
 
 # CPU_90_15min detector

--- a/modules/integration_aws-rds-common/detectors-rds-common.tf
+++ b/modules/integration_aws-rds-common/detectors-rds-common.tf
@@ -71,6 +71,11 @@ resource "signalfx_detector" "free_space_low" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
+  viz_options {
+    label        = "signal"
+    value_unit   = "Gigibyte"
+  }
+
   program_text = <<-EOF
     free = data('FreeStorageSpace', filter=filter('namespace', 'AWS/RDS') and filter('stat', 'mean') and filter('DBInstanceIdentifier', '*') and ${module.filtering.signalflow})${var.free_space_low_aggregation_function}${var.free_space_low_transformation_function}
     signal = free.scale(1/1024**3).publish('signal') # Bytes to Gigibytes

--- a/modules/integration_aws-rds-common/detectors-rds-common.tf
+++ b/modules/integration_aws-rds-common/detectors-rds-common.tf
@@ -72,7 +72,8 @@ resource "signalfx_detector" "free_space_low" {
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
   program_text = <<-EOF
-    signal = data('FreeStorageSpace', filter=filter('namespace', 'AWS/RDS') and filter('stat', 'mean') and filter('DBInstanceIdentifier', '*') and ${module.filtering.signalflow})${var.free_space_low_aggregation_function}${var.free_space_low_transformation_function}.publish('signal')
+    free = data('FreeStorageSpace', filter=filter('namespace', 'AWS/RDS') and filter('stat', 'mean') and filter('DBInstanceIdentifier', '*') and ${module.filtering.signalflow})${var.free_space_low_aggregation_function}${var.free_space_low_transformation_function}
+    signal = free.scale(1/1024**3).publish('signal') # Bytes to Gigibytes
     detect(when(signal < ${var.free_space_low_threshold_critical})).publish('CRIT')
     detect(when(signal < ${var.free_space_low_threshold_major}) and (not when(signal < ${var.free_space_low_threshold_critical}))).publish('MAJOR')
 EOF

--- a/modules/integration_aws-rds-common/detectors-rds-common.tf
+++ b/modules/integration_aws-rds-common/detectors-rds-common.tf
@@ -72,8 +72,8 @@ resource "signalfx_detector" "free_space_low" {
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
   viz_options {
-    label        = "signal"
-    value_unit   = "Gigibyte"
+    label      = "signal"
+    value_unit = "Gigibyte"
   }
 
   program_text = <<-EOF


### PR DESCRIPTION
according to https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/monitoring-cloudwatch.html, `FreeStorageSpace` is in `Bytes`. Threshold are currently defined in Giga which is more convenient than Bytes so it seems fine to keep.
SignalFx available unit are Gigibyte, not Gigabyte so we scale the unit to convert Bytes to Gigibyte and define the right unit into signalfx.