### PR TITLE
use right signalfx unit when available

### DIFF
--- a/modules/integration_aws-alb/conf/01-latency.yaml
+++ b/modules/integration_aws-alb/conf/01-latency.yaml
@@ -5,7 +5,7 @@ id: latency
 transformation: true
 aggregation: true
 filtering: "filter('namespace', 'AWS/ApplicationELB')"
-value_unit: "s"
+value_unit: "Second"
 
 signals:
   signal:

--- a/modules/integration_aws-alb/detectors-gen.tf
+++ b/modules/integration_aws-alb/detectors-gen.tf
@@ -35,8 +35,8 @@ resource "signalfx_detector" "latency" {
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
   viz_options {
-    label        = "signal"
-    value_suffix = "s"
+    label      = "signal"
+    value_unit = "Second"
   }
 
   program_text = <<-EOF
@@ -47,7 +47,7 @@ resource "signalfx_detector" "latency" {
 EOF
 
   rule {
-    description           = "is too high > ${var.latency_threshold_critical}s"
+    description           = "is too high > ${var.latency_threshold_critical}Second"
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.latency_disabled_critical, var.latency_disabled, var.detectors_disabled)
@@ -59,7 +59,7 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.latency_threshold_major}s"
+    description           = "is too high > ${var.latency_threshold_major}Second"
     severity              = "Major"
     detect_label          = "MAJOR"
     disabled              = coalesce(var.latency_disabled_major, var.latency_disabled, var.detectors_disabled)

--- a/modules/integration_aws-alb/variables-gen.tf
+++ b/modules/integration_aws-alb/variables-gen.tf
@@ -87,7 +87,7 @@ variable "latency_disabled_major" {
 }
 
 variable "latency_threshold_critical" {
-  description = "Critical threshold for latency detector in s"
+  description = "Critical threshold for latency detector in Second"
   type        = number
   default     = 1
 }
@@ -104,7 +104,7 @@ variable "latency_at_least_percentage_critical" {
   default     = 0.9
 }
 variable "latency_threshold_major" {
-  description = "Major threshold for latency detector in s"
+  description = "Major threshold for latency detector in Second"
   type        = number
   default     = 3
 }

--- a/modules/integration_aws-apigateway/conf/01-latency.yaml
+++ b/modules/integration_aws-apigateway/conf/01-latency.yaml
@@ -4,7 +4,7 @@ name: latency
 transformation: true
 aggregation: true
 filtering: "filter('namespace', 'AWS/ApiGateway') and filter('stat', 'mean') and (not filter('Stage', '*')) and (not filter('Method', '*')) and (not filter('Resource', '*'))"
-value_unit: "ms"
+value_unit: "Millisecond"
 
 signals:
   signal:

--- a/modules/integration_aws-apigateway/detectors-gen.tf
+++ b/modules/integration_aws-apigateway/detectors-gen.tf
@@ -6,8 +6,8 @@ resource "signalfx_detector" "latency" {
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
   viz_options {
-    label        = "signal"
-    value_suffix = "ms"
+    label      = "signal"
+    value_unit = "Millisecond"
   }
 
   program_text = <<-EOF
@@ -18,7 +18,7 @@ resource "signalfx_detector" "latency" {
 EOF
 
   rule {
-    description           = "is too high > ${var.latency_threshold_critical}ms"
+    description           = "is too high > ${var.latency_threshold_critical}Millisecond"
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.latency_disabled_critical, var.latency_disabled, var.detectors_disabled)
@@ -30,7 +30,7 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.latency_threshold_major}ms"
+    description           = "is too high > ${var.latency_threshold_major}Millisecond"
     severity              = "Major"
     detect_label          = "MAJOR"
     disabled              = coalesce(var.latency_disabled_major, var.latency_disabled, var.detectors_disabled)

--- a/modules/integration_aws-apigateway/variables-gen.tf
+++ b/modules/integration_aws-apigateway/variables-gen.tf
@@ -49,7 +49,7 @@ variable "latency_disabled_major" {
 }
 
 variable "latency_threshold_critical" {
-  description = "Critical threshold for latency detector in ms"
+  description = "Critical threshold for latency detector in Millisecond"
   type        = number
   default     = 1000
 }
@@ -66,7 +66,7 @@ variable "latency_at_least_percentage_critical" {
   default     = 0.9
 }
 variable "latency_threshold_major" {
-  description = "Major threshold for latency detector in ms"
+  description = "Major threshold for latency detector in Millisecond"
   type        = number
   default     = 3000
 }

--- a/modules/integration_aws-elasticache-redis/conf/03-replication-lag.yaml
+++ b/modules/integration_aws-elasticache-redis/conf/03-replication-lag.yaml
@@ -4,7 +4,7 @@ name: replication lag
 transformation: true
 aggregation: true
 filtering: "filter('namespace', 'AWS/ElastiCache') and filter('stat', 'upper') and filter('CacheNodeId', '*')"
-value_unit: s
+value_unit: "Second"
 
 signals:
   signal:

--- a/modules/integration_aws-elasticache-redis/detectors-gen.tf
+++ b/modules/integration_aws-elasticache-redis/detectors-gen.tf
@@ -96,8 +96,8 @@ resource "signalfx_detector" "replication_lag" {
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
   viz_options {
-    label        = "signal"
-    value_suffix = "s"
+    label      = "signal"
+    value_unit = "Second"
   }
 
   program_text = <<-EOF
@@ -108,7 +108,7 @@ resource "signalfx_detector" "replication_lag" {
 EOF
 
   rule {
-    description           = "is too high > ${var.replication_lag_threshold_critical}s"
+    description           = "is too high > ${var.replication_lag_threshold_critical}Second"
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.replication_lag_disabled_critical, var.replication_lag_disabled, var.detectors_disabled)
@@ -120,7 +120,7 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.replication_lag_threshold_major}s"
+    description           = "is too high > ${var.replication_lag_threshold_major}Second"
     severity              = "Major"
     detect_label          = "MAJOR"
     disabled              = coalesce(var.replication_lag_disabled_major, var.replication_lag_disabled, var.detectors_disabled)

--- a/modules/integration_aws-elasticache-redis/variables-gen.tf
+++ b/modules/integration_aws-elasticache-redis/variables-gen.tf
@@ -217,7 +217,7 @@ variable "replication_lag_disabled_major" {
 }
 
 variable "replication_lag_threshold_critical" {
-  description = "Critical threshold for replication_lag detector in s"
+  description = "Critical threshold for replication_lag detector in Second"
   type        = number
   default     = 180
 }
@@ -234,7 +234,7 @@ variable "replication_lag_at_least_percentage_critical" {
   default     = 1
 }
 variable "replication_lag_threshold_major" {
-  description = "Major threshold for replication_lag detector in s"
+  description = "Major threshold for replication_lag detector in Second"
   type        = number
   default     = 90
 }

--- a/modules/integration_aws-elb/conf/01-latency.yaml
+++ b/modules/integration_aws-elb/conf/01-latency.yaml
@@ -4,7 +4,7 @@ name: backend latency
 transformation: true
 aggregation: true
 filtering: "filter('namespace', 'AWS/ApplicationELB')"
-value_unit: "s"
+value_unit: "Second"
 
 signals:
   signal:

--- a/modules/integration_aws-elb/detectors-gen.tf
+++ b/modules/integration_aws-elb/detectors-gen.tf
@@ -35,8 +35,8 @@ resource "signalfx_detector" "backend_latency" {
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
   viz_options {
-    label        = "signal"
-    value_suffix = "s"
+    label      = "signal"
+    value_unit = "Second"
   }
 
   program_text = <<-EOF
@@ -47,7 +47,7 @@ resource "signalfx_detector" "backend_latency" {
 EOF
 
   rule {
-    description           = "is too high > ${var.backend_latency_threshold_critical}s"
+    description           = "is too high > ${var.backend_latency_threshold_critical}Second"
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.backend_latency_disabled_critical, var.backend_latency_disabled, var.detectors_disabled)
@@ -59,7 +59,7 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.backend_latency_threshold_major}s"
+    description           = "is too high > ${var.backend_latency_threshold_major}Second"
     severity              = "Major"
     detect_label          = "MAJOR"
     disabled              = coalesce(var.backend_latency_disabled_major, var.backend_latency_disabled, var.detectors_disabled)

--- a/modules/integration_aws-elb/variables-gen.tf
+++ b/modules/integration_aws-elb/variables-gen.tf
@@ -87,7 +87,7 @@ variable "backend_latency_disabled_major" {
 }
 
 variable "backend_latency_threshold_critical" {
-  description = "Critical threshold for backend_latency detector in s"
+  description = "Critical threshold for backend_latency detector in Second"
   type        = number
   default     = 1
 }
@@ -104,7 +104,7 @@ variable "backend_latency_at_least_percentage_critical" {
   default     = 0.9
 }
 variable "backend_latency_threshold_major" {
-  description = "Major threshold for backend_latency detector in s"
+  description = "Major threshold for backend_latency detector in Second"
   type        = number
   default     = 3
 }

--- a/modules/integration_azure-datafactory/conf/04-adf-integration-available-memory.yaml
+++ b/modules/integration_azure-datafactory/conf/04-adf-integration-available-memory.yaml
@@ -2,14 +2,14 @@ module: "Azure DataFactory"
 name: "Available Memory"
 filtering: "filter('resource_type', 'Microsoft.DataFactory/factories') and filter('primary_aggregation_type', 'true')"
 aggregation: ".sum(by=['azure_resource_name', 'azure_resource_group_name', 'azure_region'])"
-value_unit: "MB"
+value_unit: "Mebibyte"
 transformation: ".min(over='15m')"
 signals:
   memory:
     metric: "IntegrationRuntimeAvailableMemory"
   signal:
     formula:
-      memory.scale(0.000000953674316) # Scale to MB unit
+      memory.scale(1/1024**2) # Scale to MiB unit
 rules:
   critical:
     threshold: 256

--- a/modules/integration_azure-datafactory/variables-gen.tf
+++ b/modules/integration_azure-datafactory/variables-gen.tf
@@ -301,7 +301,7 @@ variable "available_memory_disabled_major" {
 }
 
 variable "available_memory_threshold_critical" {
-  description = "Critical threshold for available_memory detector in MB"
+  description = "Critical threshold for available_memory detector in Mebibyte"
   type        = number
   default     = 256
 }
@@ -318,7 +318,7 @@ variable "available_memory_at_least_percentage_critical" {
   default     = 1
 }
 variable "available_memory_threshold_major" {
-  description = "Major threshold for available_memory detector in MB"
+  description = "Major threshold for available_memory detector in Mebibyte"
   type        = number
   default     = 512
 }

--- a/modules/integration_azure-storage-account-blob/conf/02-latency-e2e.yaml
+++ b/modules/integration_azure-storage-account-blob/conf/02-latency-e2e.yaml
@@ -4,7 +4,7 @@ filtering: "filter('resource_type', 'Microsoft.Storage/storageAccounts') and fil
 aggregation: ".sum(by=['azure_resource_name', 'azure_resource_group_name', 'azure_region'])"
 transformation: ".min(over='15m')"
 disabled: true
-value_unit: "s"
+value_unit: "Second"
 signals:
   latency:
     metric: "SuccessE2ELatency"

--- a/modules/integration_azure-storage-account-blob/detectors-gen.tf
+++ b/modules/integration_azure-storage-account-blob/detectors-gen.tf
@@ -52,8 +52,8 @@ resource "signalfx_detector" "latency_e2e" {
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
   viz_options {
-    label        = "signal"
-    value_suffix = "s"
+    label      = "signal"
+    value_unit = "Second"
   }
 
   program_text = <<-EOF
@@ -65,7 +65,7 @@ resource "signalfx_detector" "latency_e2e" {
 EOF
 
   rule {
-    description           = "is too high > ${var.latency_e2e_threshold_critical}s"
+    description           = "is too high > ${var.latency_e2e_threshold_critical}Second"
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.latency_e2e_disabled_critical, var.latency_e2e_disabled, var.detectors_disabled)
@@ -77,7 +77,7 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.latency_e2e_threshold_major}s"
+    description           = "is too high > ${var.latency_e2e_threshold_major}Second"
     severity              = "Major"
     detect_label          = "MAJOR"
     disabled              = coalesce(var.latency_e2e_disabled_major, var.latency_e2e_disabled, var.detectors_disabled)

--- a/modules/integration_azure-storage-account-blob/variables-gen.tf
+++ b/modules/integration_azure-storage-account-blob/variables-gen.tf
@@ -133,7 +133,7 @@ variable "latency_e2e_disabled_major" {
 }
 
 variable "latency_e2e_threshold_critical" {
-  description = "Critical threshold for latency_e2e detector in s"
+  description = "Critical threshold for latency_e2e detector in Second"
   type        = number
   default     = 20
 }
@@ -150,7 +150,7 @@ variable "latency_e2e_at_least_percentage_critical" {
   default     = 1
 }
 variable "latency_e2e_threshold_major" {
-  description = "Major threshold for latency_e2e detector in s"
+  description = "Major threshold for latency_e2e detector in Second"
   type        = number
   default     = 10
 }

--- a/modules/integration_azure-storage-account/conf/02-capacity.yaml
+++ b/modules/integration_azure-storage-account/conf/02-capacity.yaml
@@ -3,13 +3,13 @@ name: "capacity"
 filtering: "filter('resource_type', 'Microsoft.Storage/storageAccounts') and filter('primary_aggregation_type', 'true')"
 aggregation: ".fill(None, duration='1d').sum(by=['azure_resource_name', 'azure_resource_group_name', 'azure_region'])"
 transformation: ".min(over='1d')"
-value_unit: PiB
+value_unit: "Pebibyte"
 signals:
   capacity:
     metric: "UsedCapacity"
   signal:
     formula:
-      capacity.scale(0.0000000000000008881784197001252) # Scale to PiB unit
+      capacity.scale(1/1024**5) # Scale to PiB unit
 rules:
   critical:
     threshold: 4.8

--- a/modules/integration_azure-storage-account/variables-gen.tf
+++ b/modules/integration_azure-storage-account/variables-gen.tf
@@ -133,7 +133,7 @@ variable "capacity_disabled_major" {
 }
 
 variable "capacity_threshold_critical" {
-  description = "Critical threshold for capacity detector in PiB"
+  description = "Critical threshold for capacity detector in Pebibyte"
   type        = number
   default     = 4.8
 }
@@ -150,7 +150,7 @@ variable "capacity_at_least_percentage_critical" {
   default     = 1
 }
 variable "capacity_threshold_major" {
-  description = "Major threshold for capacity detector in PiB"
+  description = "Major threshold for capacity detector in Pebibyte"
   type        = number
   default     = 4.5
 }

--- a/modules/integration_gcp-load-balancing/conf/03-latency-service.yaml
+++ b/modules/integration_gcp-load-balancing/conf/03-latency-service.yaml
@@ -5,7 +5,7 @@ id: backend_latency_service
 transformation: true
 aggregation: ".sum(by=['forwarding_rule_name', 'backend_target_name'])"
 filtering: "filter('service', 'loadbalancing')"
-value_unit: "ms"
+value_unit: "Millisecond"
 
 signals:
   signal:

--- a/modules/integration_gcp-load-balancing/conf/04-latency-bucket.yaml
+++ b/modules/integration_gcp-load-balancing/conf/04-latency-bucket.yaml
@@ -5,7 +5,7 @@ id: backend_latency_bucket
 transformation: true
 aggregation: ".sum(by=['forwarding_rule_name', 'backend_target_name'])"
 filtering: "filter('service', 'loadbalancing')"
-value_unit: "ms"
+value_unit: "Millisecond"
 
 signals:
   signal:

--- a/modules/integration_gcp-load-balancing/detectors-gen.tf
+++ b/modules/integration_gcp-load-balancing/detectors-gen.tf
@@ -98,8 +98,8 @@ resource "signalfx_detector" "backend_latency_service" {
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
   viz_options {
-    label        = "signal"
-    value_suffix = "ms"
+    label      = "signal"
+    value_unit = "Millisecond"
   }
 
   program_text = <<-EOF
@@ -110,7 +110,7 @@ resource "signalfx_detector" "backend_latency_service" {
 EOF
 
   rule {
-    description           = "is too high > ${var.backend_latency_service_threshold_critical}ms"
+    description           = "is too high > ${var.backend_latency_service_threshold_critical}Millisecond"
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.backend_latency_service_disabled_critical, var.backend_latency_service_disabled, var.detectors_disabled)
@@ -122,7 +122,7 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.backend_latency_service_threshold_major}ms"
+    description           = "is too high > ${var.backend_latency_service_threshold_major}Millisecond"
     severity              = "Major"
     detect_label          = "MAJOR"
     disabled              = coalesce(var.backend_latency_service_disabled_major, var.backend_latency_service_disabled, var.detectors_disabled)
@@ -142,8 +142,8 @@ resource "signalfx_detector" "backend_latency_bucket" {
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
   viz_options {
-    label        = "signal"
-    value_suffix = "ms"
+    label      = "signal"
+    value_unit = "Millisecond"
   }
 
   program_text = <<-EOF
@@ -154,7 +154,7 @@ resource "signalfx_detector" "backend_latency_bucket" {
 EOF
 
   rule {
-    description           = "is too high > ${var.backend_latency_bucket_threshold_critical}ms"
+    description           = "is too high > ${var.backend_latency_bucket_threshold_critical}Millisecond"
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.backend_latency_bucket_disabled_critical, var.backend_latency_bucket_disabled, var.detectors_disabled)
@@ -166,7 +166,7 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.backend_latency_bucket_threshold_major}ms"
+    description           = "is too high > ${var.backend_latency_bucket_threshold_major}Millisecond"
     severity              = "Major"
     detect_label          = "MAJOR"
     disabled              = coalesce(var.backend_latency_bucket_disabled_major, var.backend_latency_bucket_disabled, var.detectors_disabled)

--- a/modules/integration_gcp-load-balancing/variables-gen.tf
+++ b/modules/integration_gcp-load-balancing/variables-gen.tf
@@ -217,7 +217,7 @@ variable "backend_latency_service_disabled_major" {
 }
 
 variable "backend_latency_service_threshold_critical" {
-  description = "Critical threshold for backend_latency_service detector in ms"
+  description = "Critical threshold for backend_latency_service detector in Millisecond"
   type        = number
   default     = 3000
 }
@@ -234,7 +234,7 @@ variable "backend_latency_service_at_least_percentage_critical" {
   default     = 0.9
 }
 variable "backend_latency_service_threshold_major" {
-  description = "Major threshold for backend_latency_service detector in ms"
+  description = "Major threshold for backend_latency_service detector in Millisecond"
   type        = number
   default     = 1000
 }
@@ -301,7 +301,7 @@ variable "backend_latency_bucket_disabled_major" {
 }
 
 variable "backend_latency_bucket_threshold_critical" {
-  description = "Critical threshold for backend_latency_bucket detector in ms"
+  description = "Critical threshold for backend_latency_bucket detector in Millisecond"
   type        = number
   default     = 8000
 }
@@ -318,7 +318,7 @@ variable "backend_latency_bucket_at_least_percentage_critical" {
   default     = 0.9
 }
 variable "backend_latency_bucket_threshold_major" {
-  description = "Major threshold for backend_latency_bucket detector in ms"
+  description = "Major threshold for backend_latency_bucket detector in Millisecond"
   type        = number
   default     = 5000
 }

--- a/modules/smart-agent_cassandra/conf/01-read-latency-p99.yaml
+++ b/modules/smart-agent_cassandra/conf/01-read-latency-p99.yaml
@@ -3,7 +3,7 @@ name: read latency 99th percentile
 
 transformation: true
 aggregation: true
-value_unit: s
+value_unit: "Second"
 
 signals:
   signal:

--- a/modules/smart-agent_cassandra/conf/02-write-latency-p99.yaml
+++ b/modules/smart-agent_cassandra/conf/02-write-latency-p99.yaml
@@ -3,7 +3,7 @@ name: write latency 99th percentile
 
 transformation: true
 aggregation: true
-value_unit: s
+value_unit: "Second"
 
 signals:
   signal:

--- a/modules/smart-agent_cassandra/conf/03-read-latency-real-time.yaml
+++ b/modules/smart-agent_cassandra/conf/03-read-latency-real-time.yaml
@@ -3,7 +3,7 @@ name: read latency real time
 
 transformation: true
 aggregation: true
-value_unit: s
+value_unit: "Second"
 
 signals:
   A:

--- a/modules/smart-agent_cassandra/conf/04-write-latency-real-time.yaml
+++ b/modules/smart-agent_cassandra/conf/04-write-latency-real-time.yaml
@@ -3,7 +3,7 @@ name: write latency real time
 
 transformation: true
 aggregation: true
-value_unit: s
+value_unit: "Second"
 
 signals:
   A:

--- a/modules/smart-agent_cassandra/conf/05-transactional-read-latency-p99.yaml
+++ b/modules/smart-agent_cassandra/conf/05-transactional-read-latency-p99.yaml
@@ -3,7 +3,7 @@ name: transactional read latency 99th percentile
 
 transformation: true
 aggregation: true
-value_unit: s
+value_unit: "Second"
 
 signals:
   signal:

--- a/modules/smart-agent_cassandra/conf/06-transactional-write-latency-p99.yaml
+++ b/modules/smart-agent_cassandra/conf/06-transactional-write-latency-p99.yaml
@@ -3,7 +3,7 @@ name: transactional write latency 99th percentile
 
 transformation: true
 aggregation: true
-value_unit: s
+value_unit: "Second"
 
 signals:
   signal:

--- a/modules/smart-agent_cassandra/conf/07-transactional-read-latency-real-time.yaml
+++ b/modules/smart-agent_cassandra/conf/07-transactional-read-latency-real-time.yaml
@@ -3,7 +3,7 @@ name: transactional read latency real time
 
 transformation: true
 aggregation: true
-value_unit: s
+value_unit: "Second"
 
 signals:
   A:

--- a/modules/smart-agent_cassandra/conf/08-transactionl-write-latency-real-time.yaml
+++ b/modules/smart-agent_cassandra/conf/08-transactionl-write-latency-real-time.yaml
@@ -3,7 +3,7 @@ name: transactional write latency real time
 
 transformation: true
 aggregation: true
-value_unit: s
+value_unit: "Second"
 
 signals:
   A:

--- a/modules/smart-agent_cassandra/detectors-gen.tf
+++ b/modules/smart-agent_cassandra/detectors-gen.tf
@@ -34,8 +34,8 @@ resource "signalfx_detector" "read_latency_99th_percentile" {
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
   viz_options {
-    label        = "signal"
-    value_suffix = "s"
+    label      = "signal"
+    value_unit = "Second"
   }
 
   program_text = <<-EOF
@@ -45,7 +45,7 @@ resource "signalfx_detector" "read_latency_99th_percentile" {
 EOF
 
   rule {
-    description           = "is too high > ${var.read_latency_99th_percentile_threshold_critical}s"
+    description           = "is too high > ${var.read_latency_99th_percentile_threshold_critical}Second"
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.read_latency_99th_percentile_disabled_critical, var.read_latency_99th_percentile_disabled, var.detectors_disabled)
@@ -57,7 +57,7 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.read_latency_99th_percentile_threshold_major}s"
+    description           = "is too high > ${var.read_latency_99th_percentile_threshold_major}Second"
     severity              = "Major"
     detect_label          = "MAJOR"
     disabled              = coalesce(var.read_latency_99th_percentile_disabled_major, var.read_latency_99th_percentile_disabled, var.detectors_disabled)
@@ -77,8 +77,8 @@ resource "signalfx_detector" "write_latency_99th_percentile" {
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
   viz_options {
-    label        = "signal"
-    value_suffix = "s"
+    label      = "signal"
+    value_unit = "Second"
   }
 
   program_text = <<-EOF
@@ -88,7 +88,7 @@ resource "signalfx_detector" "write_latency_99th_percentile" {
 EOF
 
   rule {
-    description           = "is too high > ${var.write_latency_99th_percentile_threshold_critical}s"
+    description           = "is too high > ${var.write_latency_99th_percentile_threshold_critical}Second"
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.write_latency_99th_percentile_disabled_critical, var.write_latency_99th_percentile_disabled, var.detectors_disabled)
@@ -100,7 +100,7 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.write_latency_99th_percentile_threshold_major}s"
+    description           = "is too high > ${var.write_latency_99th_percentile_threshold_major}Second"
     severity              = "Major"
     detect_label          = "MAJOR"
     disabled              = coalesce(var.write_latency_99th_percentile_disabled_major, var.write_latency_99th_percentile_disabled, var.detectors_disabled)
@@ -120,8 +120,8 @@ resource "signalfx_detector" "read_latency_real_time" {
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
   viz_options {
-    label        = "signal"
-    value_suffix = "s"
+    label      = "signal"
+    value_unit = "Second"
   }
 
   program_text = <<-EOF
@@ -133,7 +133,7 @@ resource "signalfx_detector" "read_latency_real_time" {
 EOF
 
   rule {
-    description           = "is too high > ${var.read_latency_real_time_threshold_critical}s"
+    description           = "is too high > ${var.read_latency_real_time_threshold_critical}Second"
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.read_latency_real_time_disabled_critical, var.read_latency_real_time_disabled, var.detectors_disabled)
@@ -145,7 +145,7 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.read_latency_real_time_threshold_major}s"
+    description           = "is too high > ${var.read_latency_real_time_threshold_major}Second"
     severity              = "Major"
     detect_label          = "MAJOR"
     disabled              = coalesce(var.read_latency_real_time_disabled_major, var.read_latency_real_time_disabled, var.detectors_disabled)
@@ -165,8 +165,8 @@ resource "signalfx_detector" "write_latency_real_time" {
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
   viz_options {
-    label        = "signal"
-    value_suffix = "s"
+    label      = "signal"
+    value_unit = "Second"
   }
 
   program_text = <<-EOF
@@ -178,7 +178,7 @@ resource "signalfx_detector" "write_latency_real_time" {
 EOF
 
   rule {
-    description           = "is too high > ${var.write_latency_real_time_threshold_critical}s"
+    description           = "is too high > ${var.write_latency_real_time_threshold_critical}Second"
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.write_latency_real_time_disabled_critical, var.write_latency_real_time_disabled, var.detectors_disabled)
@@ -190,7 +190,7 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.write_latency_real_time_threshold_major}s"
+    description           = "is too high > ${var.write_latency_real_time_threshold_major}Second"
     severity              = "Major"
     detect_label          = "MAJOR"
     disabled              = coalesce(var.write_latency_real_time_disabled_major, var.write_latency_real_time_disabled, var.detectors_disabled)
@@ -210,8 +210,8 @@ resource "signalfx_detector" "transactional_read_latency_99th_percentile" {
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
   viz_options {
-    label        = "signal"
-    value_suffix = "s"
+    label      = "signal"
+    value_unit = "Second"
   }
 
   program_text = <<-EOF
@@ -221,7 +221,7 @@ resource "signalfx_detector" "transactional_read_latency_99th_percentile" {
 EOF
 
   rule {
-    description           = "is too high > ${var.transactional_read_latency_99th_percentile_threshold_critical}s"
+    description           = "is too high > ${var.transactional_read_latency_99th_percentile_threshold_critical}Second"
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.transactional_read_latency_99th_percentile_disabled_critical, var.transactional_read_latency_99th_percentile_disabled, var.detectors_disabled)
@@ -233,7 +233,7 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.transactional_read_latency_99th_percentile_threshold_major}s"
+    description           = "is too high > ${var.transactional_read_latency_99th_percentile_threshold_major}Second"
     severity              = "Major"
     detect_label          = "MAJOR"
     disabled              = coalesce(var.transactional_read_latency_99th_percentile_disabled_major, var.transactional_read_latency_99th_percentile_disabled, var.detectors_disabled)
@@ -253,8 +253,8 @@ resource "signalfx_detector" "transactional_write_latency_99th_percentile" {
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
   viz_options {
-    label        = "signal"
-    value_suffix = "s"
+    label      = "signal"
+    value_unit = "Second"
   }
 
   program_text = <<-EOF
@@ -264,7 +264,7 @@ resource "signalfx_detector" "transactional_write_latency_99th_percentile" {
 EOF
 
   rule {
-    description           = "is too high > ${var.transactional_write_latency_99th_percentile_threshold_critical}s"
+    description           = "is too high > ${var.transactional_write_latency_99th_percentile_threshold_critical}Second"
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.transactional_write_latency_99th_percentile_disabled_critical, var.transactional_write_latency_99th_percentile_disabled, var.detectors_disabled)
@@ -276,7 +276,7 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.transactional_write_latency_99th_percentile_threshold_major}s"
+    description           = "is too high > ${var.transactional_write_latency_99th_percentile_threshold_major}Second"
     severity              = "Major"
     detect_label          = "MAJOR"
     disabled              = coalesce(var.transactional_write_latency_99th_percentile_disabled_major, var.transactional_write_latency_99th_percentile_disabled, var.detectors_disabled)
@@ -296,8 +296,8 @@ resource "signalfx_detector" "transactional_read_latency_real_time" {
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
   viz_options {
-    label        = "signal"
-    value_suffix = "s"
+    label      = "signal"
+    value_unit = "Second"
   }
 
   program_text = <<-EOF
@@ -309,7 +309,7 @@ resource "signalfx_detector" "transactional_read_latency_real_time" {
 EOF
 
   rule {
-    description           = "is too high > ${var.transactional_read_latency_real_time_threshold_critical}s"
+    description           = "is too high > ${var.transactional_read_latency_real_time_threshold_critical}Second"
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.transactional_read_latency_real_time_disabled_critical, var.transactional_read_latency_real_time_disabled, var.detectors_disabled)
@@ -321,7 +321,7 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.transactional_read_latency_real_time_threshold_major}s"
+    description           = "is too high > ${var.transactional_read_latency_real_time_threshold_major}Second"
     severity              = "Major"
     detect_label          = "MAJOR"
     disabled              = coalesce(var.transactional_read_latency_real_time_disabled_major, var.transactional_read_latency_real_time_disabled, var.detectors_disabled)
@@ -341,8 +341,8 @@ resource "signalfx_detector" "transactional_write_latency_real_time" {
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
   viz_options {
-    label        = "signal"
-    value_suffix = "s"
+    label      = "signal"
+    value_unit = "Second"
   }
 
   program_text = <<-EOF
@@ -354,7 +354,7 @@ resource "signalfx_detector" "transactional_write_latency_real_time" {
 EOF
 
   rule {
-    description           = "is too high > ${var.transactional_write_latency_real_time_threshold_critical}s"
+    description           = "is too high > ${var.transactional_write_latency_real_time_threshold_critical}Second"
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.transactional_write_latency_real_time_disabled_critical, var.transactional_write_latency_real_time_disabled, var.detectors_disabled)
@@ -366,7 +366,7 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.transactional_write_latency_real_time_threshold_major}s"
+    description           = "is too high > ${var.transactional_write_latency_real_time_threshold_major}Second"
     severity              = "Major"
     detect_label          = "MAJOR"
     disabled              = coalesce(var.transactional_write_latency_real_time_disabled_major, var.transactional_write_latency_real_time_disabled, var.detectors_disabled)

--- a/modules/smart-agent_cassandra/variables-gen.tf
+++ b/modules/smart-agent_cassandra/variables-gen.tf
@@ -93,7 +93,7 @@ variable "read_latency_99th_percentile_disabled_major" {
 }
 
 variable "read_latency_99th_percentile_threshold_critical" {
-  description = "Critical threshold for read_latency_99th_percentile detector in s"
+  description = "Critical threshold for read_latency_99th_percentile detector in Second"
   type        = number
   default     = 2
 }
@@ -110,7 +110,7 @@ variable "read_latency_99th_percentile_at_least_percentage_critical" {
   default     = 1
 }
 variable "read_latency_99th_percentile_threshold_major" {
-  description = "Major threshold for read_latency_99th_percentile detector in s"
+  description = "Major threshold for read_latency_99th_percentile detector in Second"
   type        = number
   default     = 1
 }
@@ -177,7 +177,7 @@ variable "write_latency_99th_percentile_disabled_major" {
 }
 
 variable "write_latency_99th_percentile_threshold_critical" {
-  description = "Critical threshold for write_latency_99th_percentile detector in s"
+  description = "Critical threshold for write_latency_99th_percentile detector in Second"
   type        = number
   default     = 1
 }
@@ -194,7 +194,7 @@ variable "write_latency_99th_percentile_at_least_percentage_critical" {
   default     = 1
 }
 variable "write_latency_99th_percentile_threshold_major" {
-  description = "Major threshold for write_latency_99th_percentile detector in s"
+  description = "Major threshold for write_latency_99th_percentile detector in Second"
   type        = number
   default     = 0.5
 }
@@ -261,7 +261,7 @@ variable "read_latency_real_time_disabled_major" {
 }
 
 variable "read_latency_real_time_threshold_critical" {
-  description = "Critical threshold for read_latency_real_time detector in s"
+  description = "Critical threshold for read_latency_real_time detector in Second"
   type        = number
   default     = 2
 }
@@ -278,7 +278,7 @@ variable "read_latency_real_time_at_least_percentage_critical" {
   default     = 1
 }
 variable "read_latency_real_time_threshold_major" {
-  description = "Major threshold for read_latency_real_time detector in s"
+  description = "Major threshold for read_latency_real_time detector in Second"
   type        = number
   default     = 1
 }
@@ -345,7 +345,7 @@ variable "write_latency_real_time_disabled_major" {
 }
 
 variable "write_latency_real_time_threshold_critical" {
-  description = "Critical threshold for write_latency_real_time detector in s"
+  description = "Critical threshold for write_latency_real_time detector in Second"
   type        = number
   default     = 1
 }
@@ -362,7 +362,7 @@ variable "write_latency_real_time_at_least_percentage_critical" {
   default     = 1
 }
 variable "write_latency_real_time_threshold_major" {
-  description = "Major threshold for write_latency_real_time detector in s"
+  description = "Major threshold for write_latency_real_time detector in Second"
   type        = number
   default     = 0.5
 }
@@ -429,7 +429,7 @@ variable "transactional_read_latency_99th_percentile_disabled_major" {
 }
 
 variable "transactional_read_latency_99th_percentile_threshold_critical" {
-  description = "Critical threshold for transactional_read_latency_99th_percentile detector in s"
+  description = "Critical threshold for transactional_read_latency_99th_percentile detector in Second"
   type        = number
   default     = 2
 }
@@ -446,7 +446,7 @@ variable "transactional_read_latency_99th_percentile_at_least_percentage_critica
   default     = 1
 }
 variable "transactional_read_latency_99th_percentile_threshold_major" {
-  description = "Major threshold for transactional_read_latency_99th_percentile detector in s"
+  description = "Major threshold for transactional_read_latency_99th_percentile detector in Second"
   type        = number
   default     = 1
 }
@@ -513,7 +513,7 @@ variable "transactional_write_latency_99th_percentile_disabled_major" {
 }
 
 variable "transactional_write_latency_99th_percentile_threshold_critical" {
-  description = "Critical threshold for transactional_write_latency_99th_percentile detector in s"
+  description = "Critical threshold for transactional_write_latency_99th_percentile detector in Second"
   type        = number
   default     = 1
 }
@@ -530,7 +530,7 @@ variable "transactional_write_latency_99th_percentile_at_least_percentage_critic
   default     = 1
 }
 variable "transactional_write_latency_99th_percentile_threshold_major" {
-  description = "Major threshold for transactional_write_latency_99th_percentile detector in s"
+  description = "Major threshold for transactional_write_latency_99th_percentile detector in Second"
   type        = number
   default     = 0.5
 }
@@ -597,7 +597,7 @@ variable "transactional_read_latency_real_time_disabled_major" {
 }
 
 variable "transactional_read_latency_real_time_threshold_critical" {
-  description = "Critical threshold for transactional_read_latency_real_time detector in s"
+  description = "Critical threshold for transactional_read_latency_real_time detector in Second"
   type        = number
   default     = 2
 }
@@ -614,7 +614,7 @@ variable "transactional_read_latency_real_time_at_least_percentage_critical" {
   default     = 1
 }
 variable "transactional_read_latency_real_time_threshold_major" {
-  description = "Major threshold for transactional_read_latency_real_time detector in s"
+  description = "Major threshold for transactional_read_latency_real_time detector in Second"
   type        = number
   default     = 1
 }
@@ -681,7 +681,7 @@ variable "transactional_write_latency_real_time_disabled_major" {
 }
 
 variable "transactional_write_latency_real_time_threshold_critical" {
-  description = "Critical threshold for transactional_write_latency_real_time detector in s"
+  description = "Critical threshold for transactional_write_latency_real_time detector in Second"
   type        = number
   default     = 1
 }
@@ -698,7 +698,7 @@ variable "transactional_write_latency_real_time_at_least_percentage_critical" {
   default     = 1
 }
 variable "transactional_write_latency_real_time_threshold_major" {
-  description = "Major threshold for transactional_write_latency_real_time detector in s"
+  description = "Major threshold for transactional_write_latency_real_time detector in Second"
   type        = number
   default     = 0.5
 }

--- a/modules/smart-agent_http/conf/04-content-length.yaml
+++ b/modules/smart-agent_http/conf/04-content-length.yaml
@@ -4,7 +4,7 @@ id: http_content_length
 
 transformation: true
 aggregation: true
-value_unit: bytes
+value_unit: "Byte"
 disabled: true
 
 signals:

--- a/modules/smart-agent_http/detectors-gen.tf
+++ b/modules/smart-agent_http/detectors-gen.tf
@@ -122,8 +122,8 @@ resource "signalfx_detector" "http_content_length" {
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
   viz_options {
-    label        = "signal"
-    value_suffix = "bytes"
+    label      = "signal"
+    value_unit = "Byte"
   }
 
   program_text = <<-EOF
@@ -132,7 +132,7 @@ resource "signalfx_detector" "http_content_length" {
 EOF
 
   rule {
-    description           = "is too low < ${var.http_content_length_threshold_warning}bytes"
+    description           = "is too low < ${var.http_content_length_threshold_warning}Byte"
     severity              = "Warning"
     detect_label          = "WARN"
     disabled              = coalesce(var.http_content_length_disabled, var.detectors_disabled)

--- a/modules/smart-agent_http/variables-gen.tf
+++ b/modules/smart-agent_http/variables-gen.tf
@@ -269,7 +269,7 @@ variable "http_content_length_disabled" {
 }
 
 variable "http_content_length_threshold_warning" {
-  description = "Warning threshold for http_content_length detector in bytes"
+  description = "Warning threshold for http_content_length detector in Byte"
   type        = number
   default     = 10
 }

--- a/modules/smart-agent_nginx-ingress/conf/01-latency.yaml
+++ b/modules/smart-agent_nginx-ingress/conf/01-latency.yaml
@@ -3,7 +3,7 @@ name: latency
 
 transformation: true
 aggregation: ".sum(by=['controller_namespace', 'controller_class', 'ingress'])"
-value_unit: "s"
+value_unit: "Second"
 
 signals:
   signal:

--- a/modules/smart-agent_nginx-ingress/detectors-gen.tf
+++ b/modules/smart-agent_nginx-ingress/detectors-gen.tf
@@ -6,8 +6,8 @@ resource "signalfx_detector" "latency" {
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
   viz_options {
-    label        = "signal"
-    value_suffix = "s"
+    label      = "signal"
+    value_unit = "Second"
   }
 
   program_text = <<-EOF
@@ -17,7 +17,7 @@ resource "signalfx_detector" "latency" {
 EOF
 
   rule {
-    description           = "is too high > ${var.latency_threshold_critical}s"
+    description           = "is too high > ${var.latency_threshold_critical}Second"
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.latency_disabled_critical, var.latency_disabled, var.detectors_disabled)
@@ -29,7 +29,7 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.latency_threshold_major}s"
+    description           = "is too high > ${var.latency_threshold_major}Second"
     severity              = "Major"
     detect_label          = "MAJOR"
     disabled              = coalesce(var.latency_disabled_major, var.latency_disabled, var.detectors_disabled)

--- a/modules/smart-agent_nginx-ingress/variables-gen.tf
+++ b/modules/smart-agent_nginx-ingress/variables-gen.tf
@@ -49,7 +49,7 @@ variable "latency_disabled_major" {
 }
 
 variable "latency_threshold_critical" {
-  description = "Critical threshold for latency detector in s"
+  description = "Critical threshold for latency detector in Second"
   type        = number
   default     = 1
 }
@@ -66,7 +66,7 @@ variable "latency_at_least_percentage_critical" {
   default     = 0.9
 }
 variable "latency_threshold_major" {
-  description = "Major threshold for latency detector in s"
+  description = "Major threshold for latency detector in Second"
   type        = number
   default     = 3
 }


### PR DESCRIPTION
Signalfx provides reserved units (list available here https://github.com/claranet/terraform-signalfx-detectors/blob/8397e28fc218ae717a41bed7717a465c16b559d9/scripts/templates/detector.tf.j2) we must use these `value_unit` when available and avoid using custom `value_prefix` / `value_suffix` as much as possible