### PR TITLE
Fix deadlettered message queue detector

### DIFF
--- a/modules/integration_azure-service-bus/conf/01-deadlettered-messages.yaml
+++ b/modules/integration_azure-service-bus/conf/01-deadlettered-messages.yaml
@@ -15,7 +15,7 @@ rules:
     threshold: 10
     comparator: ">"
   major:
-    threshold: 5
+    threshold: 0
     comparator: ">"
     dependency: critical
 ...

--- a/modules/integration_azure-service-bus/conf/01-deadlettered-messages.yaml
+++ b/modules/integration_azure-service-bus/conf/01-deadlettered-messages.yaml
@@ -4,7 +4,7 @@ name: "deadlettered messages count"
 id: deadlettered_messages
 
 filtering: "filter('resource_type', 'Microsoft.ServiceBus/namespaces') and filter('primary_aggregation_type', 'true')"
-aggregation: ".mean(by=['entityname', 'azure_resource_name', 'azure_resource_group_name', 'azure_region'])"
+aggregation: ".mean(by=['EntityName', 'azure_resource_name', 'azure_resource_group_name', 'azure_region'])"
 transformation: ".min(over='5m')"
 
 signals:

--- a/modules/integration_azure-service-bus/variables-gen.tf
+++ b/modules/integration_azure-service-bus/variables-gen.tf
@@ -9,7 +9,7 @@ variable "deadlettered_messages_notifications" {
 variable "deadlettered_messages_aggregation_function" {
   description = "Aggregation function and group by for deadlettered_messages detector (i.e. \".mean(by=['host'])\")"
   type        = string
-  default     = ".mean(by=['entityname', 'azure_resource_name', 'azure_resource_group_name', 'azure_region'])"
+  default     = ".mean(by=['EntityName', 'azure_resource_name', 'azure_resource_group_name', 'azure_region'])"
 }
 
 variable "deadlettered_messages_transformation_function" {

--- a/modules/integration_azure-service-bus/variables-gen.tf
+++ b/modules/integration_azure-service-bus/variables-gen.tf
@@ -68,7 +68,7 @@ variable "deadlettered_messages_at_least_percentage_critical" {
 variable "deadlettered_messages_threshold_major" {
   description = "Major threshold for deadlettered_messages detector"
   type        = number
-  default     = 5
+  default     = 0
 }
 
 variable "deadlettered_messages_lasting_duration_major" {


### PR DESCRIPTION
the "entityname" field has been renamed to "EntityName". (The detctor was broken)
The major threshold has been changed to 0.