### PR TITLE
service bus fix entityname dimension

### DIFF
--- a/modules/integration_azure-service-bus/variables.tf
+++ b/modules/integration_azure-service-bus/variables.tf
@@ -35,7 +35,7 @@ variable "heartbeat_timeframe" {
 variable "heartbeat_aggregation_function" {
   description = "Aggregation function and group by for heartbeat detector (i.e. \".mean(by=['host'])\")"
   type        = string
-  default     = ".mean(by=['entityname', 'azure_resource_name', 'azure_resource_group_name'])"
+  default     = ".mean(by=['EntityName', 'azure_resource_name', 'azure_resource_group_name'])"
 }
 
 # Active_connections detector
@@ -129,7 +129,7 @@ variable "user_errors_notifications" {
 variable "user_errors_aggregation_function" {
   description = "Aggregation function and group by for user_errors detector (i.e. \".mean(by=['host'])\")"
   type        = string
-  default     = ".mean(by=['entityname', 'azure_resource_name', 'azure_resource_group_name', 'azure_region'])"
+  default     = ".mean(by=['EntityName', 'azure_resource_name', 'azure_resource_group_name', 'azure_region'])"
 }
 
 variable "user_errors_lasting_duration_critical" {
@@ -197,7 +197,7 @@ variable "server_errors_notifications" {
 variable "server_errors_aggregation_function" {
   description = "Aggregation function and group by for server_errors detector (i.e. \".mean(by=['host'])\")"
   type        = string
-  default     = ".mean(by=['entityname', 'azure_resource_name', 'azure_resource_group_name', 'azure_region'])"
+  default     = ".mean(by=['EntityName', 'azure_resource_name', 'azure_resource_group_name', 'azure_region'])"
 }
 
 variable "server_errors_lasting_duration_critical" {


### PR DESCRIPTION
after https://github.com/claranet/terraform-signalfx-detectors/pull/356 thanks to @Davidh-claranet 

according to the official doc https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftservicebusnamespaces it seems that `EntityName` fix concerns all metrics from Service Bus.

I don't have access to a real dataset to confirm or not so I will let this PR open until someone can.