### PR TITLE
Bumped spellcheck GitHub action to version 0.20.0

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -100,7 +100,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Run PySpelling
-      uses: rojopolis/spellcheck-github-actions@0.14.0
+      uses: rojopolis/spellcheck-github-actions@0.20.0
 
   dead_links:
     needs: pre_job


### PR DESCRIPTION
I have recently released 0.20.0 of the spellcheck GitHub action, I can see that you are using 0.14.0, so an update could be useful to you. Let me know if you have any issues with the proposal and I will try to accommodate.

I can recommend [Dependabot](https://github.com/dependabot) for keeping your GitHub actions up to date, if you want a PR proposing a basic configuration, please let me know.