### PR TITLE
fix wallix bastion encryption status auto resolve

### DIFF
--- a/modules/prometheus-exporter_wallix-bastion/conf/03-encryption.yaml
+++ b/modules/prometheus-exporter_wallix-bastion/conf/03-encryption.yaml
@@ -5,8 +5,10 @@ transformation: true
 aggregation: true
 
 signals:
-  signal:
+  status:
     metric: wallix_bastion_encryption_status
+  signal:
+    formula: status.fill(value=1)
 
 rules:
   critical:

--- a/modules/prometheus-exporter_wallix-bastion/detectors-gen.tf
+++ b/modules/prometheus-exporter_wallix-bastion/detectors-gen.tf
@@ -97,7 +97,8 @@ resource "signalfx_detector" "encryption_status" {
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
   program_text = <<-EOF
-    signal = data('wallix_bastion_encryption_status', filter=${module.filtering.signalflow})${var.encryption_status_aggregation_function}${var.encryption_status_transformation_function}.publish('signal')
+    status = data('wallix_bastion_encryption_status', filter=${module.filtering.signalflow})${var.encryption_status_aggregation_function}${var.encryption_status_transformation_function}
+    signal = status.fill(value=1).publish('signal')
     detect(when(signal != ${var.encryption_status_threshold_critical}, lasting=%{if var.encryption_status_lasting_duration_critical == null}None%{else}'${var.encryption_status_lasting_duration_critical}'%{endif}, at_least=${var.encryption_status_at_least_percentage_critical})).publish('CRIT')
 EOF
 


### PR DESCRIPTION
given that the prometheus exporter https://github.com/claranet/wallix_bastion_exporter#metrics send the status as metadata (which correspond to the metric value: 1 = ready, 2 = need_pasphrase ..) here are the steps before this PR:
1. status metric for a wallix bastion is ready (1)
2. after wallix bastion reboot for example, the status becomes need_passphrase (2)
3. so signalfx triggers a new alert: ok
4. after filling the passphrase on wallix the metric value becomes ready again (1)

however, because the metadata `status` associated to the metric has change, signalfx consider:
- both values as 2 different MTS (where metadta status changes ready/need_passhprase)
- so the old MTS leading to alert never decrease to 1 (ready status) and the alert remains

Adding a fill(1) will allow this old MTS to come back to nominal value when no data come.
Another solutions could be:
- to not send the status metadata from the prometheus exporter
- to configure otel collector to drop this metadata from the exporter
- give the context (status as string) inside the detector's rule description and split into 1 rule per anomalous status
but I think it is useful to have the "string" status meaning attached to the metric and directly available in signalfx instead of having to read the documentation to understand to which status string corresponds the number