### PR TITLE
Update documentation links

### DIFF
--- a/.mlc_config.json
+++ b/.mlc_config.json
@@ -1,7 +1,7 @@
 {
-  "timeout": "20s",
+  "timeout": "60s",
   "retryOn429": true,
-  "retryCount": 30,
+  "retryCount": 4,
   "fallbackRetryDelay": "120s",
   "aliveStatusCodes": [200, 206]
 }

--- a/modules/integration_aws-alb/README.md
+++ b/modules/integration_aws-alb/README.md
@@ -48,8 +48,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -85,10 +85,12 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-the [AWS integration](https://docs.signalfx.com/en/latest/integrations/amazon-web-services.html) configurable
-with this Terraform [module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/aws).
+This module deploys detectors using metrics reported by the
+[AWS integration](https://docs.splunk.com/Observability/gdi/get-data-in/connect/aws/aws.html) configurable
+with [this Terraform module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/aws).
 
+
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 
 
@@ -113,4 +115,6 @@ Here is the list of required metrics for detectors in this module.
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
 * [CloudWatch metrics](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-cloudwatch-metrics.html)
+* [Splunk Observability metrics](https://docs.splunk.com/Observability/gdi/get-data-in/connect/aws/aws-metrics.html#aws-application-load-balancer-alb)

--- a/modules/integration_aws-alb/README.md
+++ b/modules/integration_aws-alb/README.md
@@ -15,7 +15,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -32,7 +32,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -48,7 +48,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -59,7 +59,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf) and [variables-gen.tf](variables-gen.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/integration_aws-alb/conf/readme.yaml
+++ b/modules/integration_aws-alb/conf/readme.yaml
@@ -1,3 +1,5 @@
 documentations:
   - name: CloudWatch metrics
     url: 'https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-cloudwatch-metrics.html'
+  - name: Splunk Observability metrics
+    url: 'https://docs.splunk.com/Observability/gdi/get-data-in/connect/aws/aws-metrics.html#aws-application-load-balancer-alb'

--- a/modules/integration_aws-apigateway/README.md
+++ b/modules/integration_aws-apigateway/README.md
@@ -48,8 +48,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -81,10 +81,12 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-the [AWS integration](https://docs.signalfx.com/en/latest/integrations/amazon-web-services.html) configurable
-with this Terraform [module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/aws).
+This module deploys detectors using metrics reported by the
+[AWS integration](https://docs.splunk.com/Observability/gdi/get-data-in/connect/aws/aws.html) configurable
+with [this Terraform module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/aws).
 
+
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 
 
@@ -105,4 +107,6 @@ Here is the list of required metrics for detectors in this module.
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
 * [CloudWatch metrics](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-metrics-and-dimensions.html)
+* [Splunk Observability metrics](https://docs.splunk.com/Observability/gdi/get-data-in/connect/aws/aws-metrics.html#aws-api-gateway)

--- a/modules/integration_aws-apigateway/README.md
+++ b/modules/integration_aws-apigateway/README.md
@@ -15,7 +15,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -32,7 +32,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -48,7 +48,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -59,7 +59,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf) and [variables-gen.tf](variables-gen.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/integration_aws-apigateway/conf/readme.yaml
+++ b/modules/integration_aws-apigateway/conf/readme.yaml
@@ -1,3 +1,5 @@
 documentations:
   - name: CloudWatch metrics
     url: 'https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-metrics-and-dimensions.html'
+  - name: Splunk Observability metrics
+    url: 'https://docs.splunk.com/Observability/gdi/get-data-in/connect/aws/aws-metrics.html#aws-api-gateway'

--- a/modules/integration_aws-beanstalk/README.md
+++ b/modules/integration_aws-beanstalk/README.md
@@ -48,8 +48,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -83,10 +83,12 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-the [AWS integration](https://docs.signalfx.com/en/latest/integrations/amazon-web-services.html) configurable
-with this Terraform [module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/aws).
+This module deploys detectors using metrics reported by the
+[AWS integration](https://docs.splunk.com/Observability/gdi/get-data-in/connect/aws/aws.html) configurable
+with [this Terraform module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/aws).
 
+
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 
 
@@ -108,4 +110,5 @@ Here is the list of required metrics for detectors in this module.
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
 * [CloudWatch metrics](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/health-enhanced-cloudwatch.html)

--- a/modules/integration_aws-beanstalk/README.md
+++ b/modules/integration_aws-beanstalk/README.md
@@ -15,7 +15,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -32,7 +32,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -48,7 +48,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -59,7 +59,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/integration_aws-ecs-cluster/README.md
+++ b/modules/integration_aws-ecs-cluster/README.md
@@ -48,8 +48,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -81,10 +81,12 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-the [AWS integration](https://docs.signalfx.com/en/latest/integrations/amazon-web-services.html) configurable
-with this Terraform [module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/aws).
+This module deploys detectors using metrics reported by the
+[AWS integration](https://docs.splunk.com/Observability/gdi/get-data-in/connect/aws/aws.html) configurable
+with [this Terraform module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/aws).
 
+
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 
 
@@ -104,4 +106,6 @@ Here is the list of required metrics for detectors in this module.
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
 * [CloudWatch metrics](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/cloudwatch-metrics.html)
+* [Splunk Observability metrics](https://docs.splunk.com/Observability/gdi/get-data-in/connect/aws/aws-metrics.html#aws-ecs)

--- a/modules/integration_aws-ecs-cluster/README.md
+++ b/modules/integration_aws-ecs-cluster/README.md
@@ -15,7 +15,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -32,7 +32,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -48,7 +48,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -59,7 +59,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/integration_aws-ecs-cluster/conf/readme.yaml
+++ b/modules/integration_aws-ecs-cluster/conf/readme.yaml
@@ -1,3 +1,5 @@
 documentations:
   - name: CloudWatch metrics
     url: 'https://docs.aws.amazon.com/AmazonECS/latest/developerguide/cloudwatch-metrics.html'
+  - name: Splunk Observability metrics
+    url: 'https://docs.splunk.com/Observability/gdi/get-data-in/connect/aws/aws-metrics.html#aws-ecs'

--- a/modules/integration_aws-ecs-service/README.md
+++ b/modules/integration_aws-ecs-service/README.md
@@ -48,8 +48,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -81,10 +81,12 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-the [AWS integration](https://docs.signalfx.com/en/latest/integrations/amazon-web-services.html) configurable
-with this Terraform [module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/aws).
+This module deploys detectors using metrics reported by the
+[AWS integration](https://docs.splunk.com/Observability/gdi/get-data-in/connect/aws/aws.html) configurable
+with [this Terraform module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/aws).
 
+
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 
 
@@ -103,4 +105,5 @@ Here is the list of required metrics for detectors in this module.
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
 * [CloudWatch metrics](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/cloudwatch-metrics.html)

--- a/modules/integration_aws-ecs-service/README.md
+++ b/modules/integration_aws-ecs-service/README.md
@@ -15,7 +15,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -32,7 +32,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -48,7 +48,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -59,7 +59,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/integration_aws-efs/README.md
+++ b/modules/integration_aws-efs/README.md
@@ -20,7 +20,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -43,7 +43,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -59,7 +59,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -70,7 +70,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf) and [variables-gen.tf](variables-gen.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/integration_aws-efs/README.md
+++ b/modules/integration_aws-efs/README.md
@@ -59,8 +59,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -95,12 +95,14 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-the [AWS integration](https://docs.signalfx.com/en/latest/integrations/amazon-web-services.html) configurable
-with this Terraform [module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/aws).
+This module deploys detectors using metrics reported by the
+[AWS integration](https://docs.splunk.com/Observability/gdi/get-data-in/connect/aws/aws.html) configurable
+with [this Terraform module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/aws).
 
 
-We are using metrics from the [AWS/EFS](https://docs.aws.amazon.com/efs/latest/ug/efs-metrics.html) namespace
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
+
+
 
 ### Metrics
 
@@ -154,4 +156,6 @@ See CloudWatch to determine values.
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [CloudWatch metrics](https://docs.aws.amazon.com/efs/latest/ug/monitoring-cloudwatch.html)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [CloudWatch metrics](https://docs.aws.amazon.com/efs/latest/ug/efs-metrics.html)
+* [CloudWatch guide](https://docs.aws.amazon.com/efs/latest/ug/monitoring-cloudwatch.html)

--- a/modules/integration_aws-efs/conf/readme.yaml
+++ b/modules/integration_aws-efs/conf/readme.yaml
@@ -1,9 +1,8 @@
 documentations:
   - name: CloudWatch metrics
+    url: 'https://docs.aws.amazon.com/efs/latest/ug/efs-metrics.html'
+  - name: CloudWatch guide
     url: 'https://docs.aws.amazon.com/efs/latest/ug/monitoring-cloudwatch.html'
-source_doc: >-
-  We are using metrics from the
-  [AWS/EFS](https://docs.aws.amazon.com/efs/latest/ug/efs-metrics.html) namespace
 notes: |
   ### About filtering
 

--- a/modules/integration_aws-elasticache-common/README.md
+++ b/modules/integration_aws-elasticache-common/README.md
@@ -48,8 +48,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -85,10 +85,12 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-the [AWS integration](https://docs.signalfx.com/en/latest/integrations/amazon-web-services.html) configurable
-with this Terraform [module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/aws).
+This module deploys detectors using metrics reported by the
+[AWS integration](https://docs.splunk.com/Observability/gdi/get-data-in/connect/aws/aws.html) configurable
+with [this Terraform module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/aws).
 
+
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 
 
@@ -110,5 +112,7 @@ Here is the list of required metrics for detectors in this module.
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
 * [CloudWatch host-level metrics for Memcached](https://docs.aws.amazon.com/AmazonElastiCache/latest/mem-ug/CacheMetrics.HostLevel.html)
 * [Cloudwatch host-level metrics for Redis](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheMetrics.HostLevel.html)
+* [Splunk Observability metrics](https://docs.splunk.com/Observability/gdi/get-data-in/connect/aws/aws-metrics.html#amazon-elasticache)

--- a/modules/integration_aws-elasticache-common/README.md
+++ b/modules/integration_aws-elasticache-common/README.md
@@ -15,7 +15,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -32,7 +32,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -48,7 +48,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -59,7 +59,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/integration_aws-elasticache-common/conf/readme.yaml
+++ b/modules/integration_aws-elasticache-common/conf/readme.yaml
@@ -3,3 +3,5 @@ documentations:
     url: 'https://docs.aws.amazon.com/AmazonElastiCache/latest/mem-ug/CacheMetrics.HostLevel.html'
   - name: Cloudwatch host-level metrics for Redis
     url: 'https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheMetrics.HostLevel.html'
+  - name: Splunk Observability metrics
+    url: 'https://docs.splunk.com/Observability/gdi/get-data-in/connect/aws/aws-metrics.html#amazon-elasticache'

--- a/modules/integration_aws-elasticache-memcached/README.md
+++ b/modules/integration_aws-elasticache-memcached/README.md
@@ -15,7 +15,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -32,7 +32,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -48,7 +48,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -59,7 +59,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables-gen.tf](variables-gen.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/integration_aws-elasticache-memcached/README.md
+++ b/modules/integration_aws-elasticache-memcached/README.md
@@ -48,8 +48,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -80,10 +80,12 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-the [AWS integration](https://docs.signalfx.com/en/latest/integrations/amazon-web-services.html) configurable
-with this Terraform [module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/aws).
+This module deploys detectors using metrics reported by the
+[AWS integration](https://docs.splunk.com/Observability/gdi/get-data-in/connect/aws/aws.html) configurable
+with [this Terraform module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/aws).
 
+
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 
 
@@ -103,4 +105,5 @@ Here is the list of required metrics for detectors in this module.
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
 * [CloudWatch metrics](https://docs.aws.amazon.com/AmazonElastiCache/latest/mem-ug/CacheMetrics.Memcached.html)

--- a/modules/integration_aws-elasticache-redis/README.md
+++ b/modules/integration_aws-elasticache-redis/README.md
@@ -48,8 +48,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -82,10 +82,12 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-the [AWS integration](https://docs.signalfx.com/en/latest/integrations/amazon-web-services.html) configurable
-with this Terraform [module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/aws).
+This module deploys detectors using metrics reported by the
+[AWS integration](https://docs.splunk.com/Observability/gdi/get-data-in/connect/aws/aws.html) configurable
+with [this Terraform module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/aws).
 
+
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 
 
@@ -108,4 +110,5 @@ Here is the list of required metrics for detectors in this module.
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
 * [CloudWatch metrics](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheMetrics.Redis.html)

--- a/modules/integration_aws-elasticache-redis/README.md
+++ b/modules/integration_aws-elasticache-redis/README.md
@@ -15,7 +15,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -32,7 +32,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -48,7 +48,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -59,7 +59,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables-gen.tf](variables-gen.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/integration_aws-elasticsearch/README.md
+++ b/modules/integration_aws-elasticsearch/README.md
@@ -48,8 +48,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -83,10 +83,12 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-the [AWS integration](https://docs.signalfx.com/en/latest/integrations/amazon-web-services.html) configurable
-with this Terraform [module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/aws).
+This module deploys detectors using metrics reported by the
+[AWS integration](https://docs.splunk.com/Observability/gdi/get-data-in/connect/aws/aws.html) configurable
+with [this Terraform module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/aws).
 
+
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 
 
@@ -109,4 +111,5 @@ Here is the list of required metrics for detectors in this module.
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
 * [CloudWatch metrics](https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-managedomains-cloudwatchmetrics.html)

--- a/modules/integration_aws-elasticsearch/README.md
+++ b/modules/integration_aws-elasticsearch/README.md
@@ -15,7 +15,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -32,7 +32,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -48,7 +48,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -59,7 +59,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf) and [variables-gen.tf](variables-gen.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/integration_aws-elb/README.md
+++ b/modules/integration_aws-elb/README.md
@@ -48,8 +48,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -85,10 +85,12 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-the [AWS integration](https://docs.signalfx.com/en/latest/integrations/amazon-web-services.html) configurable
-with this Terraform [module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/aws).
+This module deploys detectors using metrics reported by the
+[AWS integration](https://docs.splunk.com/Observability/gdi/get-data-in/connect/aws/aws.html) configurable
+with [this Terraform module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/aws).
 
+
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 
 
@@ -113,4 +115,6 @@ Here is the list of required metrics for detectors in this module.
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
 * [CloudWatch metrics](https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-cloudwatch-metrics.html)
+* [Splunk Observability metrics](https://docs.splunk.com/Observability/gdi/get-data-in/connect/aws/aws-metrics.html#aws-elb)

--- a/modules/integration_aws-elb/README.md
+++ b/modules/integration_aws-elb/README.md
@@ -15,7 +15,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -32,7 +32,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -48,7 +48,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -59,7 +59,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf) and [variables-gen.tf](variables-gen.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/integration_aws-elb/conf/readme.yaml
+++ b/modules/integration_aws-elb/conf/readme.yaml
@@ -1,3 +1,5 @@
 documentations:
   - name: CloudWatch metrics
     url: 'https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-cloudwatch-metrics.html'
+  - name: Splunk Observability metrics
+    url: 'https://docs.splunk.com/Observability/gdi/get-data-in/connect/aws/aws-metrics.html#aws-elb'

--- a/modules/integration_aws-kinesis-firehose/README.md
+++ b/modules/integration_aws-kinesis-firehose/README.md
@@ -48,8 +48,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -80,10 +80,12 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-the [AWS integration](https://docs.signalfx.com/en/latest/integrations/amazon-web-services.html) configurable
-with this Terraform [module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/aws).
+This module deploys detectors using metrics reported by the
+[AWS integration](https://docs.splunk.com/Observability/gdi/get-data-in/connect/aws/aws.html) configurable
+with [this Terraform module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/aws).
 
+
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 
 
@@ -102,4 +104,5 @@ Here is the list of required metrics for detectors in this module.
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
 * [CloudWatch metrics](https://docs.aws.amazon.com/firehose/latest/dev/monitoring-with-cloudwatch-metrics.html)

--- a/modules/integration_aws-kinesis-firehose/README.md
+++ b/modules/integration_aws-kinesis-firehose/README.md
@@ -15,7 +15,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -32,7 +32,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -48,7 +48,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -59,7 +59,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/integration_aws-lambda/README.md
+++ b/modules/integration_aws-lambda/README.md
@@ -48,8 +48,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -81,10 +81,12 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-the [AWS integration](https://docs.signalfx.com/en/latest/integrations/amazon-web-services.html) configurable
-with this Terraform [module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/aws).
+This module deploys detectors using metrics reported by the
+[AWS integration](https://docs.splunk.com/Observability/gdi/get-data-in/connect/aws/aws.html) configurable
+with [this Terraform module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/aws).
 
+
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 
 
@@ -104,4 +106,6 @@ Here is the list of required metrics for detectors in this module.
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
 * [CloudWatch metrics](https://docs.aws.amazon.com/lambda/latest/dg/monitoring-metrics.html)
+* [Splunk Observability metrics](https://docs.splunk.com/Observability/gdi/get-data-in/connect/aws/aws-metrics.html#aws-lambda)

--- a/modules/integration_aws-lambda/README.md
+++ b/modules/integration_aws-lambda/README.md
@@ -15,7 +15,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -32,7 +32,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -48,7 +48,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -59,7 +59,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables-gen.tf](variables-gen.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/integration_aws-lambda/conf/readme.yaml
+++ b/modules/integration_aws-lambda/conf/readme.yaml
@@ -1,3 +1,5 @@
 documentations:
   - name: CloudWatch metrics
     url: 'https://docs.aws.amazon.com/lambda/latest/dg/monitoring-metrics.html'
+  - name: Splunk Observability metrics
+    url: 'https://docs.splunk.com/Observability/gdi/get-data-in/connect/aws/aws-metrics.html#aws-lambda'

--- a/modules/integration_aws-nlb/README.md
+++ b/modules/integration_aws-nlb/README.md
@@ -15,7 +15,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -32,7 +32,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -48,7 +48,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -59,7 +59,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/integration_aws-nlb/README.md
+++ b/modules/integration_aws-nlb/README.md
@@ -48,8 +48,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -80,10 +80,12 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-the [AWS integration](https://docs.signalfx.com/en/latest/integrations/amazon-web-services.html) configurable
-with this Terraform [module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/aws).
+This module deploys detectors using metrics reported by the
+[AWS integration](https://docs.splunk.com/Observability/gdi/get-data-in/connect/aws/aws.html) configurable
+with [this Terraform module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/aws).
 
+
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 
 
@@ -103,4 +105,5 @@ Here is the list of required metrics for detectors in this module.
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
 * [CloudWatch metrics](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-cloudwatch-metrics.html)

--- a/modules/integration_aws-rds-aurora-mysql/README.md
+++ b/modules/integration_aws-rds-aurora-mysql/README.md
@@ -15,7 +15,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -32,7 +32,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -48,7 +48,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -59,7 +59,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/integration_aws-rds-aurora-mysql/README.md
+++ b/modules/integration_aws-rds-aurora-mysql/README.md
@@ -48,8 +48,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -79,10 +79,12 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-the [AWS integration](https://docs.signalfx.com/en/latest/integrations/amazon-web-services.html) configurable
-with this Terraform [module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/aws).
+This module deploys detectors using metrics reported by the
+[AWS integration](https://docs.splunk.com/Observability/gdi/get-data-in/connect/aws/aws.html) configurable
+with [this Terraform module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/aws).
 
+
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 
 
@@ -100,4 +102,6 @@ Here is the list of required metrics for detectors in this module.
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [CloudWatch metrics](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.Monitoring.html)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [CloudWatch metrics](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.AuroraMySQL.Monitoring.Metrics.html)
+* [CloudWatch guide](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/MonitoringAurora.html)

--- a/modules/integration_aws-rds-aurora-mysql/conf/readme.yaml
+++ b/modules/integration_aws-rds-aurora-mysql/conf/readme.yaml
@@ -1,3 +1,5 @@
 documentations:
   - name: CloudWatch metrics
-    url: 'https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.Monitoring.html'
+    url: 'https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.AuroraMySQL.Monitoring.Metrics.html'
+  - name: CloudWatch guide
+    url: 'https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/MonitoringAurora.html'

--- a/modules/integration_aws-rds-aurora-postgresql/README.md
+++ b/modules/integration_aws-rds-aurora-postgresql/README.md
@@ -15,7 +15,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -32,7 +32,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -48,7 +48,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -59,7 +59,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/integration_aws-rds-aurora-postgresql/README.md
+++ b/modules/integration_aws-rds-aurora-postgresql/README.md
@@ -48,8 +48,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -79,10 +79,12 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-the [AWS integration](https://docs.signalfx.com/en/latest/integrations/amazon-web-services.html) configurable
-with this Terraform [module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/aws).
+This module deploys detectors using metrics reported by the
+[AWS integration](https://docs.splunk.com/Observability/gdi/get-data-in/connect/aws/aws.html) configurable
+with [this Terraform module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/aws).
 
+
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 
 
@@ -100,4 +102,6 @@ Here is the list of required metrics for detectors in this module.
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [CloudWatch metrics](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.Monitoring.html)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [CloudWatch metrics](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.AuroraMySQL.Monitoring.Metrics.html)
+* [CloudWatch guide](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/MonitoringAurora.html)

--- a/modules/integration_aws-rds-aurora-postgresql/conf/readme.yaml
+++ b/modules/integration_aws-rds-aurora-postgresql/conf/readme.yaml
@@ -1,3 +1,5 @@
 documentations:
   - name: CloudWatch metrics
-    url: 'https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.Monitoring.html'
+    url: 'https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.AuroraMySQL.Monitoring.Metrics.html'
+  - name: CloudWatch guide
+    url: 'https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/MonitoringAurora.html'

--- a/modules/integration_aws-rds-common/README.md
+++ b/modules/integration_aws-rds-common/README.md
@@ -48,8 +48,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -82,10 +82,12 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-the [AWS integration](https://docs.signalfx.com/en/latest/integrations/amazon-web-services.html) configurable
-with this Terraform [module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/aws).
+This module deploys detectors using metrics reported by the
+[AWS integration](https://docs.splunk.com/Observability/gdi/get-data-in/connect/aws/aws.html) configurable
+with [this Terraform module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/aws).
 
+
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 
 
@@ -105,4 +107,7 @@ Here is the list of required metrics for detectors in this module.
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [CloudWatch metrics](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/MonitoringOverview.html)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [CloudWatch metrics](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-metrics.html)
+* [CloudWatch guide](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/MonitoringOverview.html)
+* [Splunk Observability metrics](https://docs.splunk.com/Observability/gdi/get-data-in/connect/aws/aws-metrics.html#amazon-rds)

--- a/modules/integration_aws-rds-common/README.md
+++ b/modules/integration_aws-rds-common/README.md
@@ -15,7 +15,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -32,7 +32,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -48,7 +48,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -59,7 +59,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/integration_aws-rds-common/conf/readme.yaml
+++ b/modules/integration_aws-rds-common/conf/readme.yaml
@@ -1,3 +1,7 @@
 documentations:
   - name: CloudWatch metrics
+    url: 'https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-metrics.html'
+  - name: CloudWatch guide
     url: 'https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/MonitoringOverview.html'
+  - name: Splunk Observability metrics
+    url: 'https://docs.splunk.com/Observability/gdi/get-data-in/connect/aws/aws-metrics.html#amazon-rds'

--- a/modules/integration_aws-redshift/README.md
+++ b/modules/integration_aws-redshift/README.md
@@ -48,8 +48,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -81,10 +81,12 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-the [AWS integration](https://docs.signalfx.com/en/latest/integrations/amazon-web-services.html) configurable
-with this Terraform [module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/aws).
+This module deploys detectors using metrics reported by the
+[AWS integration](https://docs.splunk.com/Observability/gdi/get-data-in/connect/aws/aws.html) configurable
+with [this Terraform module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/aws).
 
+
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 
 
@@ -103,5 +105,6 @@ Here is the list of required metrics for detectors in this module.
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [AWS metrics redshift](https://docs.aws.amazon.com/redshift/latest/mgmt/metrics-listing.html)
-* [Splunk metrics for AWS Redshift](https://docs.splunk.com/Observability/gdi/get-data-in/connect/aws/aws-metrics.html#amazon-redshift)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [CloudWatch metrics](https://docs.aws.amazon.com/redshift/latest/mgmt/metrics-listing.html)
+* [Splunk Observability metrics](https://docs.splunk.com/Observability/gdi/get-data-in/connect/aws/aws-metrics.html#amazon-redshift)

--- a/modules/integration_aws-redshift/README.md
+++ b/modules/integration_aws-redshift/README.md
@@ -15,7 +15,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -32,7 +32,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -48,7 +48,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -59,7 +59,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables-gen.tf](variables-gen.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/integration_aws-redshift/conf/readme.yaml
+++ b/modules/integration_aws-redshift/conf/readme.yaml
@@ -1,7 +1,7 @@
 documentations:
-  - name: AWS metrics redshift
+  - name: CloudWatch metrics
     url: 'https://docs.aws.amazon.com/redshift/latest/mgmt/metrics-listing.html'
-  - name: Splunk metrics for AWS Redshift
+  - name: Splunk Observability metrics
     url: 'https://docs.splunk.com/Observability/gdi/get-data-in/connect/aws/aws-metrics.html#amazon-redshift'
 
 source_doc:

--- a/modules/integration_aws-sqs/README.md
+++ b/modules/integration_aws-sqs/README.md
@@ -48,8 +48,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -81,10 +81,12 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-the [AWS integration](https://docs.signalfx.com/en/latest/integrations/amazon-web-services.html) configurable
-with this Terraform [module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/aws).
+This module deploys detectors using metrics reported by the
+[AWS integration](https://docs.splunk.com/Observability/gdi/get-data-in/connect/aws/aws.html) configurable
+with [this Terraform module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/aws).
 
+
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 
 
@@ -104,4 +106,5 @@ Here is the list of required metrics for detectors in this module.
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
 * [CloudWatch metrics](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-available-cloudwatch-metrics.html)

--- a/modules/integration_aws-sqs/README.md
+++ b/modules/integration_aws-sqs/README.md
@@ -15,7 +15,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -32,7 +32,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -48,7 +48,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -59,7 +59,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/integration_aws-vpn/README.md
+++ b/modules/integration_aws-vpn/README.md
@@ -48,8 +48,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -80,10 +80,12 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-the [AWS integration](https://docs.signalfx.com/en/latest/integrations/amazon-web-services.html) configurable
-with this Terraform [module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/aws).
+This module deploys detectors using metrics reported by the
+[AWS integration](https://docs.splunk.com/Observability/gdi/get-data-in/connect/aws/aws.html) configurable
+with [this Terraform module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/aws).
 
+
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 
 
@@ -101,4 +103,5 @@ Here is the list of required metrics for detectors in this module.
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
 * [CloudWatch metrics](https://docs.aws.amazon.com/vpn/latest/s2svpn/monitoring-cloudwatch-vpn.html)

--- a/modules/integration_aws-vpn/README.md
+++ b/modules/integration_aws-vpn/README.md
@@ -15,7 +15,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -32,7 +32,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -48,7 +48,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -59,7 +59,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/integration_azure-api-management-service/README.md
+++ b/modules/integration_azure-api-management-service/README.md
@@ -48,8 +48,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -82,10 +82,12 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-the [Azure integration](https://docs.signalfx.com/en/latest/integrations/azure-info.html) configurable
-with this Terraform [module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/azure).
+This module deploys detectors using metrics reported by the
+[Azure integration](https://docs.splunk.com/Observability/gdi/get-data-in/connect/azure/azure.html) configurable
+with [this Terraform module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/azure).
 
+
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 
 
@@ -106,4 +108,5 @@ Here is the list of required metrics for detectors in this module.
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [Azure Monitor metrics](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [Azure Monitor metrics](https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftapimanagementservice)

--- a/modules/integration_azure-api-management-service/README.md
+++ b/modules/integration_azure-api-management-service/README.md
@@ -15,7 +15,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -32,7 +32,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -48,7 +48,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -59,7 +59,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/integration_azure-api-management-service/conf/readme.yaml
+++ b/modules/integration_azure-api-management-service/conf/readme.yaml
@@ -1,3 +1,3 @@
 documentations:
   - name: Azure Monitor metrics
-    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftapimanagementservice'
+    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftapimanagementservice'

--- a/modules/integration_azure-api-management-service/conf/readme.yaml
+++ b/modules/integration_azure-api-management-service/conf/readme.yaml
@@ -1,3 +1,3 @@
 documentations:
   - name: Azure Monitor metrics
-    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported'
+    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftapimanagementservice'

--- a/modules/integration_azure-app-service-plan/README.md
+++ b/modules/integration_azure-app-service-plan/README.md
@@ -15,7 +15,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -32,7 +32,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -48,7 +48,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -59,7 +59,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/integration_azure-app-service-plan/README.md
+++ b/modules/integration_azure-app-service-plan/README.md
@@ -48,8 +48,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -81,10 +81,12 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-the [Azure integration](https://docs.signalfx.com/en/latest/integrations/azure-info.html) configurable
-with this Terraform [module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/azure).
+This module deploys detectors using metrics reported by the
+[Azure integration](https://docs.splunk.com/Observability/gdi/get-data-in/connect/azure/azure.html) configurable
+with [this Terraform module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/azure).
 
+
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 
 
@@ -103,4 +105,5 @@ Here is the list of required metrics for detectors in this module.
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [Azure Monitor metrics](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [Azure Monitor metrics](https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftwebserverfarms)

--- a/modules/integration_azure-app-service-plan/conf/readme.yaml
+++ b/modules/integration_azure-app-service-plan/conf/readme.yaml
@@ -1,3 +1,3 @@
 documentations:
   - name: Azure Monitor metrics
-    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftwebserverfarms'
+    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftwebserverfarms'

--- a/modules/integration_azure-app-service-plan/conf/readme.yaml
+++ b/modules/integration_azure-app-service-plan/conf/readme.yaml
@@ -1,3 +1,3 @@
 documentations:
   - name: Azure Monitor metrics
-    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftwebsitesslots'
+    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftwebserverfarms'

--- a/modules/integration_azure-app-service-plan/conf/readme.yaml
+++ b/modules/integration_azure-app-service-plan/conf/readme.yaml
@@ -1,3 +1,3 @@
 documentations:
   - name: Azure Monitor metrics
-    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported'
+    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftwebsitesslots'

--- a/modules/integration_azure-app-service/README.md
+++ b/modules/integration_azure-app-service/README.md
@@ -48,8 +48,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -84,10 +84,12 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-the [Azure integration](https://docs.signalfx.com/en/latest/integrations/azure-info.html) configurable
-with this Terraform [module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/azure).
+This module deploys detectors using metrics reported by the
+[Azure integration](https://docs.splunk.com/Observability/gdi/get-data-in/connect/azure/azure.html) configurable
+with [this Terraform module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/azure).
 
+
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 
 
@@ -112,4 +114,6 @@ Here is the list of required metrics for detectors in this module.
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [Azure Monitor metrics](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [Azure Monitor metrics](https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftwebsites)
+* [Splunk Observability metrics](https://docs.splunk.com/Observability/gdi/get-data-in/connect/azure/azure-metrics.html#azure-app-service-metrics)

--- a/modules/integration_azure-app-service/README.md
+++ b/modules/integration_azure-app-service/README.md
@@ -15,7 +15,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -32,7 +32,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -48,7 +48,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -59,7 +59,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/integration_azure-app-service/conf/readme.yaml
+++ b/modules/integration_azure-app-service/conf/readme.yaml
@@ -1,3 +1,5 @@
 documentations:
   - name: Azure Monitor metrics
-    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported'
+    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftwebsites'
+  - name: Splunk Observability metrics
+    url: 'https://docs.splunk.com/Observability/gdi/get-data-in/connect/azure/azure-metrics.html#azure-app-service-metrics'

--- a/modules/integration_azure-app-service/conf/readme.yaml
+++ b/modules/integration_azure-app-service/conf/readme.yaml
@@ -1,5 +1,5 @@
 documentations:
   - name: Azure Monitor metrics
-    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftwebsites'
+    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftwebsites'
   - name: Splunk Observability metrics
     url: 'https://docs.splunk.com/Observability/gdi/get-data-in/connect/azure/azure-metrics.html#azure-app-service-metrics'

--- a/modules/integration_azure-application-gateway/README.md
+++ b/modules/integration_azure-application-gateway/README.md
@@ -17,7 +17,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -35,7 +35,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -51,7 +51,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -62,7 +62,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf) and [variables-gen.tf](variables-gen.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/integration_azure-application-gateway/README.md
+++ b/modules/integration_azure-application-gateway/README.md
@@ -51,8 +51,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -91,12 +91,14 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-the [Azure integration](https://docs.signalfx.com/en/latest/integrations/azure-info.html) configurable
-with this Terraform [module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/azure).
+This module deploys detectors using metrics reported by the
+[Azure integration](https://docs.splunk.com/Observability/gdi/get-data-in/connect/azure/azure.html) configurable
+with [this Terraform module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/azure).
 
 
-We are using metrics from the [Microsoft.Network/applicationGateways](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftnetworkapplicationgateways) namespace.
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
+
+
 
 ### Metrics
 
@@ -131,4 +133,5 @@ If you're enabling autoscaling on your application gateway, default instance cou
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [Azure Monitor metrics](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [Azure Monitor metrics](https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftnetworkapplicationgateways)

--- a/modules/integration_azure-application-gateway/conf/readme.yaml
+++ b/modules/integration_azure-application-gateway/conf/readme.yaml
@@ -1,6 +1,6 @@
 documentations:
   - name: Azure Monitor metrics
-    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftnetworkapplicationgateways'
+    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftnetworkapplicationgateways'
 
 notes: |
   ### Capacity Units

--- a/modules/integration_azure-application-gateway/conf/readme.yaml
+++ b/modules/integration_azure-application-gateway/conf/readme.yaml
@@ -1,11 +1,6 @@
 documentations:
   - name: Azure Monitor metrics
-    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported'
-
-source_doc: >-
-  We are using metrics from the
-  [Microsoft.Network/applicationGateways](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftnetworkapplicationgateways)
-  namespace.
+    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftnetworkapplicationgateways'
 
 notes: |
   ### Capacity Units

--- a/modules/integration_azure-azure-search/README.md
+++ b/modules/integration_azure-azure-search/README.md
@@ -15,7 +15,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -32,7 +32,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -48,7 +48,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -59,7 +59,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/integration_azure-azure-search/README.md
+++ b/modules/integration_azure-azure-search/README.md
@@ -48,8 +48,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -80,10 +80,12 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-the [Azure integration](https://docs.signalfx.com/en/latest/integrations/azure-info.html) configurable
-with this Terraform [module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/azure).
+This module deploys detectors using metrics reported by the
+[Azure integration](https://docs.splunk.com/Observability/gdi/get-data-in/connect/azure/azure.html) configurable
+with [this Terraform module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/azure).
 
+
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 
 
@@ -102,4 +104,5 @@ Here is the list of required metrics for detectors in this module.
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [Azure Monitor metrics](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [Azure Monitor metrics](https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftsearchsearchservices)

--- a/modules/integration_azure-azure-search/conf/readme.yaml
+++ b/modules/integration_azure-azure-search/conf/readme.yaml
@@ -1,3 +1,3 @@
 documentations:
   - name: Azure Monitor metrics
-    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftsearchsearchservices'
+    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftsearchsearchservices'

--- a/modules/integration_azure-azure-search/conf/readme.yaml
+++ b/modules/integration_azure-azure-search/conf/readme.yaml
@@ -1,3 +1,3 @@
 documentations:
   - name: Azure Monitor metrics
-    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported'
+    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftsearchsearchservices'

--- a/modules/integration_azure-container-instance/README.md
+++ b/modules/integration_azure-container-instance/README.md
@@ -49,8 +49,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -80,12 +80,14 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-the [Azure integration](https://docs.signalfx.com/en/latest/integrations/azure-info.html) configurable
-with this Terraform [module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/azure).
+This module deploys detectors using metrics reported by the
+[Azure integration](https://docs.splunk.com/Observability/gdi/get-data-in/connect/azure/azure.html) configurable
+with [this Terraform module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/azure).
 
 
-We are using metrics from the [Microsoft.ContainerInstance/containerGroups](https://docs.microsoft.com/fr-fr/azure/azure-monitor/platform/metrics-supported#microsoftcontainerinstancecontainergroups) namespace.
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
+
+
 
 ### Metrics
 
@@ -104,4 +106,5 @@ Azure container instance provides the fastest and simplest way to run containers
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [Azure Monitor metrics](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [Azure Monitor metrics](https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftcontainerinstancecontainergroups)

--- a/modules/integration_azure-container-instance/README.md
+++ b/modules/integration_azure-container-instance/README.md
@@ -16,7 +16,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -33,7 +33,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -49,7 +49,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -60,7 +60,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables-gen.tf](variables-gen.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/integration_azure-container-instance/conf/readme.yaml
+++ b/modules/integration_azure-container-instance/conf/readme.yaml
@@ -1,11 +1,6 @@
 documentations:
   - name: Azure Monitor metrics
-    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported'
-
-source_doc: >-
-  We are using metrics from the
-  [Microsoft.ContainerInstance/containerGroups](https://docs.microsoft.com/fr-fr/azure/azure-monitor/platform/metrics-supported#microsoftcontainerinstancecontainergroups)
-  namespace.
+    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftcontainerinstancecontainergroups'
 
 notes: |
   Azure container instance provides the fastest and simplest way to run containers in Azure, you may encounter some false alerts due to short lived experiments.

--- a/modules/integration_azure-container-instance/conf/readme.yaml
+++ b/modules/integration_azure-container-instance/conf/readme.yaml
@@ -1,6 +1,6 @@
 documentations:
   - name: Azure Monitor metrics
-    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftcontainerinstancecontainergroups'
+    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftcontainerinstancecontainergroups'
 
 notes: |
   Azure container instance provides the fastest and simplest way to run containers in Azure, you may encounter some false alerts due to short lived experiments.

--- a/modules/integration_azure-cosmos-db/README.md
+++ b/modules/integration_azure-cosmos-db/README.md
@@ -48,8 +48,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -83,10 +83,12 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-the [Azure integration](https://docs.signalfx.com/en/latest/integrations/azure-info.html) configurable
-with this Terraform [module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/azure).
+This module deploys detectors using metrics reported by the
+[Azure integration](https://docs.splunk.com/Observability/gdi/get-data-in/connect/azure/azure.html) configurable
+with [this Terraform module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/azure).
 
+
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 
 
@@ -106,4 +108,5 @@ Here is the list of required metrics for detectors in this module.
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [Azure Monitor metrics](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [Azure Monitor metrics](https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftdocumentdbdatabaseaccounts)

--- a/modules/integration_azure-cosmos-db/README.md
+++ b/modules/integration_azure-cosmos-db/README.md
@@ -15,7 +15,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -32,7 +32,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -48,7 +48,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -59,7 +59,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/integration_azure-cosmos-db/conf/readme.yaml
+++ b/modules/integration_azure-cosmos-db/conf/readme.yaml
@@ -1,3 +1,3 @@
 documentations:
   - name: Azure Monitor metrics
-    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported'
+    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftdocumentdbdatabaseaccounts'

--- a/modules/integration_azure-cosmos-db/conf/readme.yaml
+++ b/modules/integration_azure-cosmos-db/conf/readme.yaml
@@ -1,3 +1,3 @@
 documentations:
   - name: Azure Monitor metrics
-    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftdocumentdbdatabaseaccounts'
+    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftdocumentdbdatabaseaccounts'

--- a/modules/integration_azure-datafactory/README.md
+++ b/modules/integration_azure-datafactory/README.md
@@ -17,7 +17,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -34,7 +34,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -50,7 +50,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -61,7 +61,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables-gen.tf](variables-gen.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/integration_azure-datafactory/README.md
+++ b/modules/integration_azure-datafactory/README.md
@@ -50,8 +50,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -85,12 +85,14 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-the [Azure integration](https://docs.signalfx.com/en/latest/integrations/azure-info.html) configurable
-with this Terraform [module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/azure).
+This module deploys detectors using metrics reported by the
+[Azure integration](https://docs.splunk.com/Observability/gdi/get-data-in/connect/azure/azure.html) configurable
+with [this Terraform module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/azure).
 
 
-We are using metrics from the [Microsoft.DataFactory/factories](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftdatafactoryfactories) namespace
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
+
+
 
 ### Metrics
 
@@ -110,13 +112,16 @@ Here is the list of required metrics for detectors in this module.
 ## Notes
 
 ### Available memory
+
 This metric doesn't have a max value. We must set a default value. The default threshold values are:
   * critical < 256MB
   * major > 256MB and < 512MB
 If those values are not relevants, please feel free to set your own threshold.
 
+
 ## Related documentation
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [Azure Monitor metrics](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [Azure Monitor metrics](https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftdatafactoryfactories)

--- a/modules/integration_azure-datafactory/conf/readme.yaml
+++ b/modules/integration_azure-datafactory/conf/readme.yaml
@@ -1,6 +1,6 @@
 documentations:
   - name: Azure Monitor metrics
-    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftdatafactoryfactories'
+    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftdatafactoryfactories'
 
 notes: |
   ### Available memory

--- a/modules/integration_azure-datafactory/conf/readme.yaml
+++ b/modules/integration_azure-datafactory/conf/readme.yaml
@@ -1,11 +1,10 @@
 documentations:
   - name: Azure Monitor metrics
-    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported'
-source_doc: >-
-  We are using metrics from the
-  [Microsoft.DataFactory/factories](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftdatafactoryfactories) namespace
+    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftdatafactoryfactories'
+
 notes: |
   ### Available memory
+
   This metric doesn't have a max value. We must set a default value. The default threshold values are:
     * critical < 256MB
     * major > 256MB and < 512MB

--- a/modules/integration_azure-event-hub/README.md
+++ b/modules/integration_azure-event-hub/README.md
@@ -50,8 +50,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -81,10 +81,12 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-the [Azure integration](https://docs.signalfx.com/en/latest/integrations/azure-info.html) configurable
-with this Terraform [module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/azure).
+This module deploys detectors using metrics reported by the
+[Azure integration](https://docs.splunk.com/Observability/gdi/get-data-in/connect/azure/azure.html) configurable
+with [this Terraform module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/azure).
 
+
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 
 
@@ -108,4 +110,6 @@ Basic customer's case seems to report values between 0 and 5% in a nominal situa
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [Azure Monitor metrics](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [Azure Monitor metrics](https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsofteventhubclusters)
+* [Splunk Observability metrics](https://docs.splunk.com/Observability/gdi/get-data-in/connect/azure/azure-metrics.html#azure-event-hubs-metrics)

--- a/modules/integration_azure-event-hub/README.md
+++ b/modules/integration_azure-event-hub/README.md
@@ -17,7 +17,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -34,7 +34,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -50,7 +50,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -61,7 +61,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables-gen.tf](variables-gen.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/integration_azure-event-hub/conf/readme.yaml
+++ b/modules/integration_azure-event-hub/conf/readme.yaml
@@ -1,6 +1,9 @@
 documentations:
   - name: Azure Monitor metrics
-    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported'
+    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsofteventhubclusters'
+  - name: Splunk Observability metrics
+    url: 'https://docs.splunk.com/Observability/gdi/get-data-in/connect/azure/azure-metrics.html#azure-event-hubs-metrics'
+
 notes: |
   ### About `throttled_requests` detector
 

--- a/modules/integration_azure-event-hub/conf/readme.yaml
+++ b/modules/integration_azure-event-hub/conf/readme.yaml
@@ -1,6 +1,6 @@
 documentations:
   - name: Azure Monitor metrics
-    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsofteventhubclusters'
+    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsofteventhubclusters'
   - name: Splunk Observability metrics
     url: 'https://docs.splunk.com/Observability/gdi/get-data-in/connect/azure/azure-metrics.html#azure-event-hubs-metrics'
 

--- a/modules/integration_azure-express-route/README.md
+++ b/modules/integration_azure-express-route/README.md
@@ -48,8 +48,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -81,10 +81,12 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-the [Azure integration](https://docs.signalfx.com/en/latest/integrations/azure-info.html) configurable
-with this Terraform [module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/azure).
+This module deploys detectors using metrics reported by the
+[Azure integration](https://docs.splunk.com/Observability/gdi/get-data-in/connect/azure/azure.html) configurable
+with [this Terraform module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/azure).
 
+
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 
 
@@ -103,4 +105,6 @@ Here is the list of required metrics for detectors in this module.
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [Azure Monitor metrics](https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftnetworkexpressroutecircuits)
 * [Verifying ExpressRoute connectivity](https://docs.microsoft.com/en-us/azure/expressroute/expressroute-troubleshooting-expressroute-overview)

--- a/modules/integration_azure-express-route/README.md
+++ b/modules/integration_azure-express-route/README.md
@@ -15,7 +15,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -32,7 +32,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -48,7 +48,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -59,7 +59,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables-gen.tf](variables-gen.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/integration_azure-express-route/conf/readme.yaml
+++ b/modules/integration_azure-express-route/conf/readme.yaml
@@ -1,5 +1,5 @@
 documentations:
   - name: Azure Monitor metrics
-    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftnetworkexpressroutecircuits'
+    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftnetworkexpressroutecircuits'
   - name: Verifying ExpressRoute connectivity
     url: https://docs.microsoft.com/en-us/azure/expressroute/expressroute-troubleshooting-expressroute-overview

--- a/modules/integration_azure-express-route/conf/readme.yaml
+++ b/modules/integration_azure-express-route/conf/readme.yaml
@@ -1,5 +1,5 @@
 documentations:
+  - name: Azure Monitor metrics
+    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftnetworkexpressroutecircuits'
   - name: Verifying ExpressRoute connectivity
     url: https://docs.microsoft.com/en-us/azure/expressroute/expressroute-troubleshooting-expressroute-overview
-
-source_doc:

--- a/modules/integration_azure-firewall/README.md
+++ b/modules/integration_azure-firewall/README.md
@@ -49,8 +49,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -83,10 +83,12 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-the [Azure integration](https://docs.signalfx.com/en/latest/integrations/azure-info.html) configurable
-with this Terraform [module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/azure).
+This module deploys detectors using metrics reported by the
+[Azure integration](https://docs.splunk.com/Observability/gdi/get-data-in/connect/azure/azure.html) configurable
+with [this Terraform module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/azure).
 
+
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 
 
@@ -113,5 +115,6 @@ Throughput unit is Mbps. Default thresolds are set to:
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [Azure Monitor Metrics](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported)
-* [Azure Firewall logs and metrics](https://docs.microsoft.com/en-us/azure/firewall/logs-and-metrics#metrics)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [Azure Monitor Metrics](https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftnetworkazurefirewalls)
+* [Azure Guide](https://docs.microsoft.com/en-us/azure/firewall/logs-and-metrics#metrics)

--- a/modules/integration_azure-firewall/README.md
+++ b/modules/integration_azure-firewall/README.md
@@ -16,7 +16,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -33,7 +33,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -49,7 +49,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -60,7 +60,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables-gen.tf](variables-gen.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/integration_azure-firewall/conf/readme.yaml
+++ b/modules/integration_azure-firewall/conf/readme.yaml
@@ -1,10 +1,8 @@
 documentations:
   - name: Azure Monitor Metrics
-    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported'
-  - name: Azure Firewall logs and metrics
+    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftnetworkazurefirewalls'
+  - name: Azure Guide
     url: 'https://docs.microsoft.com/en-us/azure/firewall/logs-and-metrics#metrics'
-
-source_doc:
 
 notes: |
   Throughput unit is Mbps. Default thresolds are set to:

--- a/modules/integration_azure-firewall/conf/readme.yaml
+++ b/modules/integration_azure-firewall/conf/readme.yaml
@@ -1,6 +1,6 @@
 documentations:
   - name: Azure Monitor Metrics
-    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftnetworkazurefirewalls'
+    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftnetworkazurefirewalls'
   - name: Azure Guide
     url: 'https://docs.microsoft.com/en-us/azure/firewall/logs-and-metrics#metrics'
 

--- a/modules/integration_azure-functions/README.md
+++ b/modules/integration_azure-functions/README.md
@@ -16,7 +16,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -33,7 +33,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -49,7 +49,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -60,7 +60,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf) and [variables-gen.tf](variables-gen.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/integration_azure-functions/README.md
+++ b/modules/integration_azure-functions/README.md
@@ -49,8 +49,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -84,10 +84,12 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-the [Azure integration](https://docs.signalfx.com/en/latest/integrations/azure-info.html) configurable
-with this Terraform [module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/azure).
+This module deploys detectors using metrics reported by the
+[Azure integration](https://docs.splunk.com/Observability/gdi/get-data-in/connect/azure/azure.html) configurable
+with [this Terraform module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/azure).
 
+
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 ### Serverless wrapper
 
@@ -102,6 +104,7 @@ The wrapper is available for following languages:
 * [Java](https://github.com/signalfx/azure-function-java)
 * [NodeJs](https://github.com/signalfx/azure-function-nodejs)
 * [Python](https://github.com/claranet/signalfx-azure-function-python)
+
 
 ### Metrics
 
@@ -122,5 +125,6 @@ Here is the list of required metrics for detectors in this module.
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [Azure Monitor metrics](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported)
-* [SignalFx Azure Functions](https://docs.signalfx.com/en/latest/integrations/azure-functions.html)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [Azure Monitor metrics](https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftwebsites)
+* [SignalFx Azure Functions](https://github.com/signalfx/integrations/tree/master/azure-functions)

--- a/modules/integration_azure-functions/conf/readme.yaml
+++ b/modules/integration_azure-functions/conf/readme.yaml
@@ -1,8 +1,6 @@
 documentations:
-  - name: Azure Monitor metrics
-    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported'
   - name: SignalFx Azure Functions
-    url: 'https://docs.signalfx.com/en/latest/integrations/azure-functions.html'
+    url: 'https://github.com/signalfx/integrations/tree/master/azure-functions'
 
 source_doc: |
   ### Serverless wrapper

--- a/modules/integration_azure-functions/conf/readme.yaml
+++ b/modules/integration_azure-functions/conf/readme.yaml
@@ -1,6 +1,6 @@
 documentations:
   - name: Azure Monitor metrics
-    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftwebsites'
+    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftwebsites'
   - name: SignalFx Azure Functions
     url: 'https://github.com/signalfx/integrations/tree/master/azure-functions'
 

--- a/modules/integration_azure-functions/conf/readme.yaml
+++ b/modules/integration_azure-functions/conf/readme.yaml
@@ -1,4 +1,6 @@
 documentations:
+  - name: Azure Monitor metrics
+    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftwebsites'
   - name: SignalFx Azure Functions
     url: 'https://github.com/signalfx/integrations/tree/master/azure-functions'
 

--- a/modules/integration_azure-key-vault/README.md
+++ b/modules/integration_azure-key-vault/README.md
@@ -15,7 +15,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -32,7 +32,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -48,7 +48,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -59,7 +59,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/integration_azure-key-vault/README.md
+++ b/modules/integration_azure-key-vault/README.md
@@ -48,8 +48,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -80,10 +80,12 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-the [Azure integration](https://docs.signalfx.com/en/latest/integrations/azure-info.html) configurable
-with this Terraform [module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/azure).
+This module deploys detectors using metrics reported by the
+[Azure integration](https://docs.splunk.com/Observability/gdi/get-data-in/connect/azure/azure.html) configurable
+with [this Terraform module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/azure).
 
+
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 
 
@@ -102,4 +104,5 @@ Here is the list of required metrics for detectors in this module.
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [Azure Monitor metrics](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [Azure Monitor metrics](https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftkeyvaultvaults)

--- a/modules/integration_azure-key-vault/conf/readme.yaml
+++ b/modules/integration_azure-key-vault/conf/readme.yaml
@@ -1,3 +1,3 @@
 documentations:
   - name: Azure Monitor metrics
-    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported'
+    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftkeyvaultvaults'

--- a/modules/integration_azure-key-vault/conf/readme.yaml
+++ b/modules/integration_azure-key-vault/conf/readme.yaml
@@ -1,3 +1,3 @@
 documentations:
   - name: Azure Monitor metrics
-    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftkeyvaultvaults'
+    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftkeyvaultvaults'

--- a/modules/integration_azure-load-balancer/README.md
+++ b/modules/integration_azure-load-balancer/README.md
@@ -48,8 +48,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -79,10 +79,12 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-the [Azure integration](https://docs.signalfx.com/en/latest/integrations/azure-info.html) configurable
-with this Terraform [module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/azure).
+This module deploys detectors using metrics reported by the
+[Azure integration](https://docs.splunk.com/Observability/gdi/get-data-in/connect/azure/azure.html) configurable
+with [this Terraform module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/azure).
 
+
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 
 
@@ -100,4 +102,5 @@ Here is the list of required metrics for detectors in this module.
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [Azure Monitor metrics](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [Azure Monitor metrics](https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftnetworkloadbalancers)

--- a/modules/integration_azure-load-balancer/README.md
+++ b/modules/integration_azure-load-balancer/README.md
@@ -15,7 +15,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -32,7 +32,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -48,7 +48,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -59,7 +59,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/integration_azure-load-balancer/conf/readme.yaml
+++ b/modules/integration_azure-load-balancer/conf/readme.yaml
@@ -1,3 +1,3 @@
 documentations:
   - name: Azure Monitor metrics
-    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftnetworkloadbalancers'
+    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftnetworkloadbalancers'

--- a/modules/integration_azure-load-balancer/conf/readme.yaml
+++ b/modules/integration_azure-load-balancer/conf/readme.yaml
@@ -1,3 +1,3 @@
 documentations:
   - name: Azure Monitor metrics
-    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported'
+    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftnetworkloadbalancers'

--- a/modules/integration_azure-mariadb/README.md
+++ b/modules/integration_azure-mariadb/README.md
@@ -48,8 +48,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -84,10 +84,12 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-the [Azure integration](https://docs.signalfx.com/en/latest/integrations/azure-info.html) configurable
-with this Terraform [module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/azure).
+This module deploys detectors using metrics reported by the
+[Azure integration](https://docs.splunk.com/Observability/gdi/get-data-in/connect/azure/azure.html) configurable
+with [this Terraform module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/azure).
 
+
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 
 
@@ -110,4 +112,5 @@ Here is the list of required metrics for detectors in this module.
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [Azure Monitor metrics for MariaDB](https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftdbformariadbservers)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [Azure Monitor metrics](https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftdbformariadbservers)

--- a/modules/integration_azure-mariadb/README.md
+++ b/modules/integration_azure-mariadb/README.md
@@ -15,7 +15,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -32,7 +32,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -48,7 +48,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -59,7 +59,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables-gen.tf](variables-gen.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/integration_azure-mariadb/conf/readme.yaml
+++ b/modules/integration_azure-mariadb/conf/readme.yaml
@@ -1,3 +1,3 @@
 documentations:
-  - name: Azure Monitor metrics for MariaDB
+  - name: Azure Monitor metrics
     url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftdbformariadbservers'

--- a/modules/integration_azure-mysql/README.md
+++ b/modules/integration_azure-mysql/README.md
@@ -48,8 +48,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -84,10 +84,12 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-the [Azure integration](https://docs.signalfx.com/en/latest/integrations/azure-info.html) configurable
-with this Terraform [module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/azure).
+This module deploys detectors using metrics reported by the
+[Azure integration](https://docs.splunk.com/Observability/gdi/get-data-in/connect/azure/azure.html) configurable
+with [this Terraform module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/azure).
 
+
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 
 
@@ -110,4 +112,5 @@ Here is the list of required metrics for detectors in this module.
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [Azure Monitor metrics](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [Azure Monitor metrics](https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftdbformysqlservers)

--- a/modules/integration_azure-mysql/README.md
+++ b/modules/integration_azure-mysql/README.md
@@ -15,7 +15,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -32,7 +32,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -48,7 +48,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -59,7 +59,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables-gen.tf](variables-gen.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/integration_azure-mysql/conf/readme.yaml
+++ b/modules/integration_azure-mysql/conf/readme.yaml
@@ -1,3 +1,3 @@
 documentations:
   - name: Azure Monitor metrics
-    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported'
+    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftdbformysqlservers'

--- a/modules/integration_azure-mysql/conf/readme.yaml
+++ b/modules/integration_azure-mysql/conf/readme.yaml
@@ -1,3 +1,3 @@
 documentations:
   - name: Azure Monitor metrics
-    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftdbformysqlservers'
+    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftdbformysqlservers'

--- a/modules/integration_azure-postgresql/README.md
+++ b/modules/integration_azure-postgresql/README.md
@@ -48,8 +48,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -85,10 +85,12 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-the [Azure integration](https://docs.signalfx.com/en/latest/integrations/azure-info.html) configurable
-with this Terraform [module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/azure).
+This module deploys detectors using metrics reported by the
+[Azure integration](https://docs.splunk.com/Observability/gdi/get-data-in/connect/azure/azure.html) configurable
+with [this Terraform module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/azure).
 
+
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 
 
@@ -112,4 +114,5 @@ Here is the list of required metrics for detectors in this module.
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [Azure Monitor metrics](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [Azure Monitor metrics](https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftdbforpostgresqlservers)

--- a/modules/integration_azure-postgresql/README.md
+++ b/modules/integration_azure-postgresql/README.md
@@ -15,7 +15,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -32,7 +32,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -48,7 +48,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -59,7 +59,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/integration_azure-postgresql/conf/readme.yaml
+++ b/modules/integration_azure-postgresql/conf/readme.yaml
@@ -1,3 +1,3 @@
 documentations:
   - name: Azure Monitor metrics
-    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftdbforpostgresqlservers'
+    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftdbforpostgresqlservers'

--- a/modules/integration_azure-postgresql/conf/readme.yaml
+++ b/modules/integration_azure-postgresql/conf/readme.yaml
@@ -1,3 +1,3 @@
 documentations:
   - name: Azure Monitor metrics
-    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported'
+    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftdbforpostgresqlservers'

--- a/modules/integration_azure-redis/README.md
+++ b/modules/integration_azure-redis/README.md
@@ -48,8 +48,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -82,10 +82,12 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-the [Azure integration](https://docs.signalfx.com/en/latest/integrations/azure-info.html) configurable
-with this Terraform [module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/azure).
+This module deploys detectors using metrics reported by the
+[Azure integration](https://docs.splunk.com/Observability/gdi/get-data-in/connect/azure/azure.html) configurable
+with [this Terraform module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/azure).
 
+
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 
 
@@ -106,4 +108,6 @@ Here is the list of required metrics for detectors in this module.
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [Azure Monitor metrics](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [Azure Monitor metrics](https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftcacheredis)
+* [Splunk Observability metrics](https://docs.splunk.com/Observability/gdi/get-data-in/connect/azure/azure-metrics.html#azure-redis-metrics)

--- a/modules/integration_azure-redis/README.md
+++ b/modules/integration_azure-redis/README.md
@@ -15,7 +15,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -32,7 +32,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -48,7 +48,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -59,7 +59,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/integration_azure-redis/conf/readme.yaml
+++ b/modules/integration_azure-redis/conf/readme.yaml
@@ -1,3 +1,5 @@
 documentations:
   - name: Azure Monitor metrics
-    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported'
+    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftcacheredis'
+  - name: Splunk Observability metrics
+    url: 'https://docs.splunk.com/Observability/gdi/get-data-in/connect/azure/azure-metrics.html#azure-redis-metrics'

--- a/modules/integration_azure-redis/conf/readme.yaml
+++ b/modules/integration_azure-redis/conf/readme.yaml
@@ -1,5 +1,5 @@
 documentations:
   - name: Azure Monitor metrics
-    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftcacheredis'
+    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftcacheredis'
   - name: Splunk Observability metrics
     url: 'https://docs.splunk.com/Observability/gdi/get-data-in/connect/azure/azure-metrics.html#azure-redis-metrics'

--- a/modules/integration_azure-service-bus/README.md
+++ b/modules/integration_azure-service-bus/README.md
@@ -48,8 +48,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -84,10 +84,12 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-the [Azure integration](https://docs.signalfx.com/en/latest/integrations/azure-info.html) configurable
-with this Terraform [module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/azure).
+This module deploys detectors using metrics reported by the
+[Azure integration](https://docs.splunk.com/Observability/gdi/get-data-in/connect/azure/azure.html) configurable
+with [this Terraform module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/azure).
 
+
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 
 
@@ -111,4 +113,5 @@ Here is the list of required metrics for detectors in this module.
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [Azure Monitor metrics](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [Azure Monitor metrics](https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftservicebusnamespaces)

--- a/modules/integration_azure-service-bus/README.md
+++ b/modules/integration_azure-service-bus/README.md
@@ -15,7 +15,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -32,7 +32,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -48,7 +48,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -59,7 +59,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf) and [variables-gen.tf](variables-gen.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/integration_azure-service-bus/conf/readme.yaml
+++ b/modules/integration_azure-service-bus/conf/readme.yaml
@@ -1,3 +1,3 @@
 documentations:
   - name: Azure Monitor metrics
-    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported'
+    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftservicebusnamespaces'

--- a/modules/integration_azure-service-bus/conf/readme.yaml
+++ b/modules/integration_azure-service-bus/conf/readme.yaml
@@ -1,3 +1,3 @@
 documentations:
   - name: Azure Monitor metrics
-    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftservicebusnamespaces'
+    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftservicebusnamespaces'

--- a/modules/integration_azure-sql-database/README.md
+++ b/modules/integration_azure-sql-database/README.md
@@ -15,7 +15,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -32,7 +32,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -48,7 +48,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -59,7 +59,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/integration_azure-sql-database/README.md
+++ b/modules/integration_azure-sql-database/README.md
@@ -48,8 +48,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -83,10 +83,12 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-the [Azure integration](https://docs.signalfx.com/en/latest/integrations/azure-info.html) configurable
-with this Terraform [module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/azure).
+This module deploys detectors using metrics reported by the
+[Azure integration](https://docs.splunk.com/Observability/gdi/get-data-in/connect/azure/azure.html) configurable
+with [this Terraform module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/azure).
 
+
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 
 
@@ -108,4 +110,6 @@ Here is the list of required metrics for detectors in this module.
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [Azure Monitor metrics](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [Azure Monitor metrics](https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftsqlserversdatabases)
+* [Splunk Observability metrics](https://docs.splunk.com/Observability/gdi/get-data-in/connect/azure/azure-metrics.html#azure-sql-databases-metrics)

--- a/modules/integration_azure-sql-database/conf/readme.yaml
+++ b/modules/integration_azure-sql-database/conf/readme.yaml
@@ -1,5 +1,5 @@
 documentations:
   - name: Azure Monitor metrics
-    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftsqlserversdatabases'
+    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftsqlserversdatabases'
   - name: Splunk Observability metrics
     url: 'https://docs.splunk.com/Observability/gdi/get-data-in/connect/azure/azure-metrics.html#azure-sql-databases-metrics'

--- a/modules/integration_azure-sql-database/conf/readme.yaml
+++ b/modules/integration_azure-sql-database/conf/readme.yaml
@@ -1,3 +1,5 @@
 documentations:
   - name: Azure Monitor metrics
-    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported'
+    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftsqlserversdatabases'
+  - name: Splunk Observability metrics
+    url: 'https://docs.splunk.com/Observability/gdi/get-data-in/connect/azure/azure-metrics.html#azure-sql-databases-metrics'

--- a/modules/integration_azure-sql-elastic-pool/README.md
+++ b/modules/integration_azure-sql-elastic-pool/README.md
@@ -48,8 +48,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -82,10 +82,12 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-the [Azure integration](https://docs.signalfx.com/en/latest/integrations/azure-info.html) configurable
-with this Terraform [module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/azure).
+This module deploys detectors using metrics reported by the
+[Azure integration](https://docs.splunk.com/Observability/gdi/get-data-in/connect/azure/azure.html) configurable
+with [this Terraform module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/azure).
 
+
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 
 
@@ -105,4 +107,6 @@ Here is the list of required metrics for detectors in this module.
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [Azure Monitor metrics](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [Azure Monitor metrics](https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftsqlserverselasticpools)
+* [Splunk Observability metrics](https://docs.splunk.com/Observability/gdi/get-data-in/connect/azure/azure-metrics.html#azure-sql-elastic-pools-metrics)

--- a/modules/integration_azure-sql-elastic-pool/README.md
+++ b/modules/integration_azure-sql-elastic-pool/README.md
@@ -15,7 +15,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -32,7 +32,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -48,7 +48,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -59,7 +59,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/integration_azure-sql-elastic-pool/conf/readme.yaml
+++ b/modules/integration_azure-sql-elastic-pool/conf/readme.yaml
@@ -1,5 +1,5 @@
 documentations:
   - name: Azure Monitor metrics
-    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftsqlserverselasticpools'
+    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftsqlserverselasticpools'
   - name: Splunk Observability metrics
     url: 'https://docs.splunk.com/Observability/gdi/get-data-in/connect/azure/azure-metrics.html#azure-sql-elastic-pools-metrics'

--- a/modules/integration_azure-sql-elastic-pool/conf/readme.yaml
+++ b/modules/integration_azure-sql-elastic-pool/conf/readme.yaml
@@ -1,3 +1,5 @@
 documentations:
   - name: Azure Monitor metrics
-    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported'
+    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftsqlserverselasticpools'
+  - name: Splunk Observability metrics
+    url: 'https://docs.splunk.com/Observability/gdi/get-data-in/connect/azure/azure-metrics.html#azure-sql-elastic-pools-metrics'

--- a/modules/integration_azure-storage-account-blob/README.md
+++ b/modules/integration_azure-storage-account-blob/README.md
@@ -17,7 +17,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -34,7 +34,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -50,7 +50,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -61,7 +61,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables-gen.tf](variables-gen.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/integration_azure-storage-account-blob/README.md
+++ b/modules/integration_azure-storage-account-blob/README.md
@@ -50,8 +50,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -82,12 +82,14 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-the [Azure integration](https://docs.signalfx.com/en/latest/integrations/azure-info.html) configurable
-with this Terraform [module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/azure).
+This module deploys detectors using metrics reported by the
+[Azure integration](https://docs.splunk.com/Observability/gdi/get-data-in/connect/azure/azure.html) configurable
+with [this Terraform module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/azure).
 
 
-We are using metrics from the [Microsoft.Storage/storageAccounts](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftclassicstoragestorageaccountsblobservices) namespace.
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
+
+
 
 ### Metrics
 
@@ -112,8 +114,10 @@ This is due to :
 
 Some customers may have the need to use these anymay.
 
+
 ## Related documentation
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [Azure Monitor metrics](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [Azure Monitor metrics](https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftstoragestorageaccountsblobservices)

--- a/modules/integration_azure-storage-account-blob/conf/readme.yaml
+++ b/modules/integration_azure-storage-account-blob/conf/readme.yaml
@@ -1,9 +1,7 @@
 documentations:
   - name: Azure Monitor metrics
-    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported'
-source_doc: >-
-  We are using metrics from the
-  [Microsoft.Storage/storageAccounts](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftclassicstoragestorageaccountsblobservices) namespace.
+    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftstoragestorageaccountsblobservices'
+
 notes: |
   ### Detectors disabled by default
   The following detectors are disabled by default:

--- a/modules/integration_azure-storage-account-blob/conf/readme.yaml
+++ b/modules/integration_azure-storage-account-blob/conf/readme.yaml
@@ -1,6 +1,6 @@
 documentations:
   - name: Azure Monitor metrics
-    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftstoragestorageaccountsblobservices'
+    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftstoragestorageaccountsblobservices'
 
 notes: |
   ### Detectors disabled by default

--- a/modules/integration_azure-storage-account-capacity/README.md
+++ b/modules/integration_azure-storage-account-capacity/README.md
@@ -50,8 +50,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -81,10 +81,12 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-the [Azure integration](https://docs.signalfx.com/en/latest/integrations/azure-info.html) configurable
-with this Terraform [module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/azure).
+This module deploys detectors using metrics reported by the
+[Azure integration](https://docs.splunk.com/Observability/gdi/get-data-in/connect/azure/azure.html) configurable
+with [this Terraform module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/azure).
 
+
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 
 
@@ -102,4 +104,6 @@ Here is the list of required metrics for detectors in this module.
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [Azure Monitor metrics](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [Azure Monitor metrics](https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftstoragestorageaccounts)
+* [Splunk Observability metrics](https://docs.splunk.com/Observability/gdi/get-data-in/connect/azure/azure-metrics.html#azure-storage-metrics)

--- a/modules/integration_azure-storage-account-capacity/README.md
+++ b/modules/integration_azure-storage-account-capacity/README.md
@@ -15,7 +15,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -34,7 +34,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -50,7 +50,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -61,7 +61,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/integration_azure-storage-account-capacity/conf/readme.yaml
+++ b/modules/integration_azure-storage-account-capacity/conf/readme.yaml
@@ -1,5 +1,5 @@
 documentations:
   - name: Azure Monitor metrics
-    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftstoragestorageaccounts'
+    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftstoragestorageaccounts'
   - name: Splunk Observability metrics
     url: 'https://docs.splunk.com/Observability/gdi/get-data-in/connect/azure/azure-metrics.html#azure-storage-metrics'

--- a/modules/integration_azure-storage-account-capacity/conf/readme.yaml
+++ b/modules/integration_azure-storage-account-capacity/conf/readme.yaml
@@ -1,3 +1,5 @@
 documentations:
   - name: Azure Monitor metrics
-    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported'
+    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftstoragestorageaccounts'
+  - name: Splunk Observability metrics
+    url: 'https://docs.splunk.com/Observability/gdi/get-data-in/connect/azure/azure-metrics.html#azure-storage-metrics'

--- a/modules/integration_azure-storage-account/README.md
+++ b/modules/integration_azure-storage-account/README.md
@@ -49,8 +49,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -84,10 +84,12 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-the [Azure integration](https://docs.signalfx.com/en/latest/integrations/azure-info.html) configurable
-with this Terraform [module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/azure).
+This module deploys detectors using metrics reported by the
+[Azure integration](https://docs.splunk.com/Observability/gdi/get-data-in/connect/azure/azure.html) configurable
+with [this Terraform module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/azure).
 
+
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 
 
@@ -112,5 +114,7 @@ Here is the list of required metrics for detectors in this module.
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [Azure Monitor metrics for Storage Accounts](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftstoragestorageaccounts)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [Azure Monitor metrics](https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftstoragestorageaccounts)
+* [Splunk Observability metrics](https://docs.splunk.com/Observability/gdi/get-data-in/connect/azure/azure-metrics.html#azure-storage-metrics)
 * [Azure Storage Account limits](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/azure-subscription-service-limits#storage-limits)

--- a/modules/integration_azure-storage-account/README.md
+++ b/modules/integration_azure-storage-account/README.md
@@ -16,7 +16,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -33,7 +33,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -49,7 +49,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -60,7 +60,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables-gen.tf](variables-gen.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/integration_azure-storage-account/conf/readme.yaml
+++ b/modules/integration_azure-storage-account/conf/readme.yaml
@@ -1,9 +1,11 @@
+documentations:
+  - name: Azure Monitor metrics
+    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftstoragestorageaccounts'
+  - name: Splunk Observability metrics
+    url: 'https://docs.splunk.com/Observability/gdi/get-data-in/connect/azure/azure-metrics.html#azure-storage-metrics'
+  - name: Azure Storage Account limits
+    url: 'https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/azure-subscription-service-limits#storage-limits'
+
 notes: |
   * Ingress default threshold value is set for US and Europe regions
   * Egress default threshold value is set for general-purpose v2 and Blob storage accounts
-
-documentations:
-  - name: Azure Monitor metrics for Storage Accounts
-    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftstoragestorageaccounts'
-  - name: Azure Storage Account limits
-    url: 'https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/azure-subscription-service-limits#storage-limits'

--- a/modules/integration_azure-storage-account/conf/readme.yaml
+++ b/modules/integration_azure-storage-account/conf/readme.yaml
@@ -1,6 +1,6 @@
 documentations:
   - name: Azure Monitor metrics
-    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftstoragestorageaccounts'
+    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftstoragestorageaccounts'
   - name: Splunk Observability metrics
     url: 'https://docs.splunk.com/Observability/gdi/get-data-in/connect/azure/azure-metrics.html#azure-storage-metrics'
   - name: Azure Storage Account limits

--- a/modules/integration_azure-stream-analytics/README.md
+++ b/modules/integration_azure-stream-analytics/README.md
@@ -15,7 +15,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -32,7 +32,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -48,7 +48,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -59,7 +59,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/integration_azure-stream-analytics/README.md
+++ b/modules/integration_azure-stream-analytics/README.md
@@ -48,8 +48,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -83,10 +83,12 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-the [Azure integration](https://docs.signalfx.com/en/latest/integrations/azure-info.html) configurable
-with this Terraform [module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/azure).
+This module deploys detectors using metrics reported by the
+[Azure integration](https://docs.splunk.com/Observability/gdi/get-data-in/connect/azure/azure.html) configurable
+with [this Terraform module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/azure).
 
+
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 
 
@@ -108,4 +110,5 @@ Here is the list of required metrics for detectors in this module.
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [Azure Monitor metrics](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [Azure Monitor metrics](https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftstreamanalyticsstreamingjobs)

--- a/modules/integration_azure-stream-analytics/conf/readme.yaml
+++ b/modules/integration_azure-stream-analytics/conf/readme.yaml
@@ -1,3 +1,3 @@
 documentations:
   - name: Azure Monitor metrics
-    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported'
+    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftstreamanalyticsstreamingjobs'

--- a/modules/integration_azure-stream-analytics/conf/readme.yaml
+++ b/modules/integration_azure-stream-analytics/conf/readme.yaml
@@ -1,3 +1,3 @@
 documentations:
   - name: Azure Monitor metrics
-    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftstreamanalyticsstreamingjobs'
+    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftstreamanalyticsstreamingjobs'

--- a/modules/integration_azure-virtual-machine-scaleset/README.md
+++ b/modules/integration_azure-virtual-machine-scaleset/README.md
@@ -49,8 +49,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -80,10 +80,12 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-the [Azure integration](https://docs.signalfx.com/en/latest/integrations/azure-info.html) configurable
-with this Terraform [module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/azure).
+This module deploys detectors using metrics reported by the
+[Azure integration](https://docs.splunk.com/Observability/gdi/get-data-in/connect/azure/azure.html) configurable
+with [this Terraform module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/azure).
 
+
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 
 
@@ -107,4 +109,5 @@ Next step will be to use signalFx outlier to, for example, check if all VMs in t
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [Azure Monitor metrics](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [Azure Monitor metrics](https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftcomputevirtualmachinescalesets)

--- a/modules/integration_azure-virtual-machine-scaleset/README.md
+++ b/modules/integration_azure-virtual-machine-scaleset/README.md
@@ -16,7 +16,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -33,7 +33,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -49,7 +49,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -60,7 +60,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/integration_azure-virtual-machine-scaleset/conf/readme.yaml
+++ b/modules/integration_azure-virtual-machine-scaleset/conf/readme.yaml
@@ -1,6 +1,6 @@
 documentations:
   - name: Azure Monitor metrics
-    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftcomputevirtualmachinescalesets'
+    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftcomputevirtualmachinescalesets'
 
 notes: |
   Not like the VirtualMachines module, we decided to not monitor CPU on ScaleSet because it's a non sense on something which should autoscale automatically.

--- a/modules/integration_azure-virtual-machine-scaleset/conf/readme.yaml
+++ b/modules/integration_azure-virtual-machine-scaleset/conf/readme.yaml
@@ -1,6 +1,6 @@
 documentations:
   - name: Azure Monitor metrics
-    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported'
+    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftcomputevirtualmachinescalesets'
 
 notes: |
   Not like the VirtualMachines module, we decided to not monitor CPU on ScaleSet because it's a non sense on something which should autoscale automatically.

--- a/modules/integration_azure-virtual-machine/README.md
+++ b/modules/integration_azure-virtual-machine/README.md
@@ -48,8 +48,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -81,10 +81,12 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-the [Azure integration](https://docs.signalfx.com/en/latest/integrations/azure-info.html) configurable
-with this Terraform [module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/azure).
+This module deploys detectors using metrics reported by the
+[Azure integration](https://docs.splunk.com/Observability/gdi/get-data-in/connect/azure/azure.html) configurable
+with [this Terraform module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/azure).
 
+
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 
 
@@ -104,4 +106,5 @@ Here is the list of required metrics for detectors in this module.
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [Azure Monitor metrics](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [Azure Monitor metrics](https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftcomputevirtualmachines)

--- a/modules/integration_azure-virtual-machine/README.md
+++ b/modules/integration_azure-virtual-machine/README.md
@@ -15,7 +15,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -32,7 +32,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -48,7 +48,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -59,7 +59,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/integration_azure-virtual-machine/conf/readme.yaml
+++ b/modules/integration_azure-virtual-machine/conf/readme.yaml
@@ -1,3 +1,3 @@
 documentations:
   - name: Azure Monitor metrics
-    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported'
+    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftcomputevirtualmachines'

--- a/modules/integration_azure-virtual-machine/conf/readme.yaml
+++ b/modules/integration_azure-virtual-machine/conf/readme.yaml
@@ -1,3 +1,3 @@
 documentations:
   - name: Azure Monitor metrics
-    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported#microsoftcomputevirtualmachines'
+    url: 'https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftcomputevirtualmachines'

--- a/modules/integration_gcp-bigquery/README.md
+++ b/modules/integration_gcp-bigquery/README.md
@@ -49,8 +49,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -88,10 +88,12 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-the [GCP integration](https://docs.signalfx.com/en/latest/integrations/google-cloud-platform.html) configurable
-with this Terraform [module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/gcp).
+This module deploys detectors using metrics reported by the
+[GCP integration](https://docs.splunk.com/Observability/gdi/get-data-in/connect/gcp.html) configurable
+with [this Terraform module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/gcp).
 
+
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 
 
@@ -117,4 +119,6 @@ Here is the list of required metrics for detectors in this module.
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
 * [Stackdriver metrics](https://cloud.google.com/monitoring/api/metrics_gcp#gcp-bigquery)
+* [Splunk Observability metrics](https://docs.splunk.com/Observability/gdi/get-data-in/connect/gcp.html#google-bigquery-metrics)

--- a/modules/integration_gcp-bigquery/README.md
+++ b/modules/integration_gcp-bigquery/README.md
@@ -15,7 +15,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -33,7 +33,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -49,7 +49,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -60,7 +60,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/integration_gcp-bigquery/conf/readme.yaml
+++ b/modules/integration_gcp-bigquery/conf/readme.yaml
@@ -1,3 +1,5 @@
 documentations:
   - name: Stackdriver metrics
     url: 'https://cloud.google.com/monitoring/api/metrics_gcp#gcp-bigquery'
+  - name: Splunk Observability metrics
+    url: 'https://docs.splunk.com/Observability/gdi/get-data-in/connect/gcp.html#google-bigquery-metrics'

--- a/modules/integration_gcp-cloud-sql-common/README.md
+++ b/modules/integration_gcp-cloud-sql-common/README.md
@@ -18,7 +18,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -36,7 +36,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -52,7 +52,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -63,7 +63,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/integration_gcp-cloud-sql-common/conf/readme.yaml
+++ b/modules/integration_gcp-cloud-sql-common/conf/readme.yaml
@@ -22,7 +22,7 @@ notes: |
 
   It is recommended to decrease these thresholds for instances where this option is disabled (or unavailable for first generation).
 
-  To achieve that, this is possible to source twice this module with `filter_custom_includes` to filter only relevant databases for each scenario:
+  To achieve that, this is possible to source twice this module with `filtering_custom` to filter only relevant databases for each scenario:
 
   ```hcl
   module "signalfx-detectors-cloud-gcp-cloud-sql-common-manual-storage" {
@@ -30,7 +30,14 @@ notes: |
 
     environment   = var.environment
     notifications = [var.slack_notification]
-    filter_custom_includes = ["project_id:${var.project_id}", "database_id:*first-gen*"]
+
+    # We define prefix to show the difference with the detectors of the other module in the ui
+    prefixes         = ["1st-gen"]
+    # We keep default filtering policy here, we just want to append additional filter to it
+    filtering_append = true
+    # We define the additional filter to include first gen sql instances
+    filtering_custom = "filter('database_id', '*first-gen*')"
+    # Now we are sure detectors only apply on first gen we can lower thresholds
     disk_utilization_threshold_critical = 90
     disk_utilization_threshold_warning = 80
   }
@@ -40,8 +47,11 @@ notes: |
 
     environment   = var.environment
     notifications = [var.slack_notification]
-    filter_custom_includes = ["project_id:${var.project_id}"]
-    filter_custom_excludes = ["database_id:*first-gen*"]
+
+    # We keep default filtering policy here, we just want to append additional filter to it
+    filtering_append = true
+    # We define the additional filter to exclude first gen sql instances
+    filtering_custom = "(not filter('database_id', '*first-gen*'))"
   }
 
   ```

--- a/modules/integration_gcp-cloud-sql-failover/README.md
+++ b/modules/integration_gcp-cloud-sql-failover/README.md
@@ -16,7 +16,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -34,7 +34,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -50,7 +50,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -61,7 +61,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/integration_gcp-cloud-sql-failover/README.md
+++ b/modules/integration_gcp-cloud-sql-failover/README.md
@@ -50,8 +50,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -81,10 +81,12 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-the [GCP integration](https://docs.signalfx.com/en/latest/integrations/google-cloud-platform.html) configurable
-with this Terraform [module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/gcp).
+This module deploys detectors using metrics reported by the
+[GCP integration](https://docs.splunk.com/Observability/gdi/get-data-in/connect/gcp.html) configurable
+with [this Terraform module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/gcp).
 
+
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 
 
@@ -111,8 +113,10 @@ module "signalfx-detectors-cloud-gcp-cloud-sql-common-failover" {
 
   environment   = var.environment
   notifications = [local.slack_notification]
-  filter_custom_includes = ["project_id:${var.project_id}"]
-  filter_custom_excludes = ["database_id:*-rr"]
+  # Given that the default policy exclude `-replica` we have to override id entirely
+  filtering_append = false
+  # We reuse `project_id` from the default policy but we change the read replica filter
+  filtering_custom = "filter('project_id', '${var.project_id}') and filter('database_id', '*-rr')"
 }
 ```
 
@@ -121,4 +125,5 @@ module "signalfx-detectors-cloud-gcp-cloud-sql-common-failover" {
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
 * [Stackdriver metrics](https://cloud.google.com/monitoring/api/metrics_gcp#gcp-cloudsql)

--- a/modules/integration_gcp-cloud-sql-failover/conf/readme.yaml
+++ b/modules/integration_gcp-cloud-sql-failover/conf/readme.yaml
@@ -16,7 +16,9 @@ notes: |
 
     environment   = var.environment
     notifications = [local.slack_notification]
-    filter_custom_includes = ["project_id:${var.project_id}"]
-    filter_custom_excludes = ["database_id:*-rr"]
+    # Given that the default policy exclude `-replica` we have to override id entirely
+    filtering_append = false
+    # We reuse `project_id` from the default policy but we change the read replica filter
+    filtering_custom = "filter('project_id', '${var.project_id}') and filter('database_id', '*-rr')"
   }
   ```

--- a/modules/integration_gcp-cloud-sql-mysql/README.md
+++ b/modules/integration_gcp-cloud-sql-mysql/README.md
@@ -49,8 +49,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -80,10 +80,12 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-the [GCP integration](https://docs.signalfx.com/en/latest/integrations/google-cloud-platform.html) configurable
-with this Terraform [module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/gcp).
+This module deploys detectors using metrics reported by the
+[GCP integration](https://docs.splunk.com/Observability/gdi/get-data-in/connect/gcp.html) configurable
+with [this Terraform module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/gcp).
 
+
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 
 
@@ -101,4 +103,5 @@ Here is the list of required metrics for detectors in this module.
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
 * [Stackdriver metrics](https://cloud.google.com/monitoring/api/metrics_gcp#gcp-cloudsql)

--- a/modules/integration_gcp-cloud-sql-mysql/README.md
+++ b/modules/integration_gcp-cloud-sql-mysql/README.md
@@ -15,7 +15,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -33,7 +33,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -49,7 +49,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -60,7 +60,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/integration_gcp-compute-engine/README.md
+++ b/modules/integration_gcp-compute-engine/README.md
@@ -51,8 +51,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -85,10 +85,12 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-the [GCP integration](https://docs.signalfx.com/en/latest/integrations/google-cloud-platform.html) configurable
-with this Terraform [module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/gcp).
+This module deploys detectors using metrics reported by the
+[GCP integration](https://docs.splunk.com/Observability/gdi/get-data-in/connect/gcp.html) configurable
+with [this Terraform module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/gcp).
 
+
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 
 
@@ -114,7 +116,7 @@ Here is the list of required metrics for detectors in this module.
 ### Metadata configuration for default filtering
 
 While SignalFx does not support `label` sync from GCE the default filtering policy relies on `metadata` instead.
-Therefore, if you keep the default filter (if you don't define `filter_custom_includes` or `filter_custom_excludes`) you **need** to add those metadata to your GCP computes instances :
+Therefore, if you keep the default filter (if you don't define `filtering_custom` variable) you **need** to add those metadata to your GCP computes instances :
 
 * sfx_env=true
 * sfx_monitored=true
@@ -129,7 +131,10 @@ For example:
 * via terraform, [at the instance level](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance#metadata)
 * via terraform, [at the project level](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_project_metadata)
 
-You also **need** to check if those metadata are in the metadata whitelist in your [SignalFx GCP integration](https://docs.signalfx.com/en/latest/integrations/google-cloud-platform.html#compute-engine-instance).
+You also **need** to check if those metadata are in the metadata `includeList` in your [SignalFx GCP
+integration](https://dev.splunk.com/observability/docs/integrations/gcp_integration_overview/#Optional-fields).
+You can configure this from [Claranet Terraform module for GCP
+integration](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/gcp#input_gcp_compute_metadata_whitelist).
 
 ### About disk detectors
 
@@ -145,4 +150,6 @@ Notice these detectors has a `device_name` dimension in addition to `instance_na
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
 * [Stackdriver metrics](https://cloud.google.com/monitoring/api/metrics_gcp#gcp-compute)
+* [Splunk Observability metrics](https://docs.splunk.com/Observability/gdi/get-data-in/connect/gcp.html#google-compute-engine-metrics)

--- a/modules/integration_gcp-compute-engine/README.md
+++ b/modules/integration_gcp-compute-engine/README.md
@@ -18,7 +18,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -35,7 +35,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -51,7 +51,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -62,7 +62,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/integration_gcp-compute-engine/conf/readme.yaml
+++ b/modules/integration_gcp-compute-engine/conf/readme.yaml
@@ -1,12 +1,14 @@
 documentations:
   - name: Stackdriver metrics
     url: 'https://cloud.google.com/monitoring/api/metrics_gcp#gcp-compute'
+  - name: Splunk Observability metrics
+    url: 'https://docs.splunk.com/Observability/gdi/get-data-in/connect/gcp.html#google-compute-engine-metrics'
 
 notes: |
   ### Metadata configuration for default filtering
 
   While SignalFx does not support `label` sync from GCE the default filtering policy relies on `metadata` instead.
-  Therefore, if you keep the default filter (if you don't define `filter_custom_includes` or `filter_custom_excludes`) you **need** to add those metadata to your GCP computes instances :
+  Therefore, if you keep the default filter (if you don't define `filtering_custom` variable) you **need** to add those metadata to your GCP computes instances :
 
   * sfx_env=true
   * sfx_monitored=true
@@ -21,7 +23,10 @@ notes: |
   * via terraform, [at the instance level](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance#metadata)
   * via terraform, [at the project level](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_project_metadata)
 
-  You also **need** to check if those metadata are in the metadata whitelist in your [SignalFx GCP integration](https://docs.signalfx.com/en/latest/integrations/google-cloud-platform.html#compute-engine-instance).
+  You also **need** to check if those metadata are in the metadata `includeList` in your [SignalFx GCP
+  integration](https://dev.splunk.com/observability/docs/integrations/gcp_integration_overview/#Optional-fields).
+  You can configure this from [Claranet Terraform module for GCP
+  integration](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/gcp#input_gcp_compute_metadata_whitelist).
 
   ### About disk detectors
 

--- a/modules/integration_gcp-load-balancing/README.md
+++ b/modules/integration_gcp-load-balancing/README.md
@@ -51,8 +51,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -86,10 +86,12 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-the [GCP integration](https://docs.signalfx.com/en/latest/integrations/google-cloud-platform.html) configurable
-with this Terraform [module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/gcp).
+This module deploys detectors using metrics reported by the
+[GCP integration](https://docs.splunk.com/Observability/gdi/get-data-in/connect/gcp.html) configurable
+with [this Terraform module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/gcp).
 
+
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 
 
@@ -110,7 +112,7 @@ When there is websocket going through your load balancer you will experiment ver
 To avoid false alerts, you may filter out them by using `101` http response code:
 
 ```
-filter_custom_excludes = ["response_code:101"]
+filtering_custom = "(not filter('response_code', '101'))"
 ```
 
 
@@ -118,4 +120,5 @@ filter_custom_excludes = ["response_code:101"]
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
 * [Stackdriver metrics](https://cloud.google.com/monitoring/api/metrics_gcp#gcp-loadbalancing)

--- a/modules/integration_gcp-load-balancing/README.md
+++ b/modules/integration_gcp-load-balancing/README.md
@@ -17,7 +17,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -35,7 +35,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -51,7 +51,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -62,7 +62,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf) and [variables-gen.tf](variables-gen.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/integration_gcp-load-balancing/conf/readme.yaml
+++ b/modules/integration_gcp-load-balancing/conf/readme.yaml
@@ -9,5 +9,5 @@ notes: |
   To avoid false alerts, you may filter out them by using `101` http response code:
 
   ```
-  filtering_custom = "not (filter('response_code', '101'))"
+  filtering_custom = "(not filter('response_code', '101'))"
   ```

--- a/modules/integration_gcp-load-balancing/conf/readme.yaml
+++ b/modules/integration_gcp-load-balancing/conf/readme.yaml
@@ -9,5 +9,5 @@ notes: |
   To avoid false alerts, you may filter out them by using `101` http response code:
 
   ```
-  filter_custom_excludes = ["response_code:101"]
+  filtering_custom = "not (filter('response_code', '101'))"
   ```

--- a/modules/integration_gcp-pubsub-subscription/README.md
+++ b/modules/integration_gcp-pubsub-subscription/README.md
@@ -49,8 +49,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -82,10 +82,12 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-the [GCP integration](https://docs.signalfx.com/en/latest/integrations/google-cloud-platform.html) configurable
-with this Terraform [module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/gcp).
+This module deploys detectors using metrics reported by the
+[GCP integration](https://docs.splunk.com/Observability/gdi/get-data-in/connect/gcp.html) configurable
+with [this Terraform module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/gcp).
 
+
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 
 
@@ -105,4 +107,6 @@ Here is the list of required metrics for detectors in this module.
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
 * [Stackdriver metrics](https://cloud.google.com/monitoring/api/metrics_gcp#gcp-pubsub)
+* [Splunk Observability metrics](https://docs.splunk.com/Observability/gdi/get-data-in/connect/gcp.html#google-cloud-pub-sub-metrics)

--- a/modules/integration_gcp-pubsub-subscription/README.md
+++ b/modules/integration_gcp-pubsub-subscription/README.md
@@ -15,7 +15,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -33,7 +33,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -49,7 +49,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -60,7 +60,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/integration_gcp-pubsub-subscription/conf/readme.yaml
+++ b/modules/integration_gcp-pubsub-subscription/conf/readme.yaml
@@ -1,3 +1,5 @@
 documentations:
   - name: Stackdriver metrics
     url: 'https://cloud.google.com/monitoring/api/metrics_gcp#gcp-pubsub'
+  - name: Splunk Observability metrics
+    url: 'https://docs.splunk.com/Observability/gdi/get-data-in/connect/gcp.html#google-cloud-pub-sub-metrics'

--- a/modules/integration_gcp-pubsub-topic/README.md
+++ b/modules/integration_gcp-pubsub-topic/README.md
@@ -49,8 +49,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -82,10 +82,12 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-the [GCP integration](https://docs.signalfx.com/en/latest/integrations/google-cloud-platform.html) configurable
-with this Terraform [module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/gcp).
+This module deploys detectors using metrics reported by the
+[GCP integration](https://docs.splunk.com/Observability/gdi/get-data-in/connect/gcp.html) configurable
+with [this Terraform module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/gcp).
 
+
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 
 
@@ -103,4 +105,6 @@ Here is the list of required metrics for detectors in this module.
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
 * [Stackdriver metrics](https://cloud.google.com/monitoring/api/metrics_gcp#gcp-pubsub)
+* [Splunk Observability metrics](https://docs.splunk.com/Observability/gdi/get-data-in/connect/gcp.html#google-cloud-pub-sub-metrics)

--- a/modules/integration_gcp-pubsub-topic/README.md
+++ b/modules/integration_gcp-pubsub-topic/README.md
@@ -15,7 +15,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -33,7 +33,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -49,7 +49,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -60,7 +60,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/integration_gcp-pubsub-topic/conf/readme.yaml
+++ b/modules/integration_gcp-pubsub-topic/conf/readme.yaml
@@ -1,3 +1,5 @@
 documentations:
   - name: Stackdriver metrics
     url: 'https://cloud.google.com/monitoring/api/metrics_gcp#gcp-pubsub'
+  - name: Splunk Observability metrics
+    url: 'https://docs.splunk.com/Observability/gdi/get-data-in/connect/gcp.html#google-cloud-pub-sub-metrics'

--- a/modules/integration_newrelic-apm/README.md
+++ b/modules/integration_newrelic-apm/README.md
@@ -49,8 +49,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -82,9 +82,11 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-the [NewRelic integration](https://docs.signalfx.com/en/latest/integrations/integrations-reference/integrations.new.relic.html)
+This module deploys detectors using metrics reported by the
+[NewRelic integration](https://github.com/signalfx/integrations/blob/master/newrelic/README.md).
 
+
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 
 
@@ -100,7 +102,7 @@ Here is the list of required metrics for detectors in this module.
 ## Notes
 
 * The NewRelic integration from SignalFx still uses the deprecated [REST API
-v1](https://docs.newrelic.com/docs/apis/rest-api-v1-deprecated/new-relic-rest-api-v1).
+v1](https://docs.newrelic.com/docs/apis/rest-api-v1-deprecated/new-relic-rest-api-v1/working-new-relic-rest-api-v1-deprecated/).
 * It also generate too many metrics all considered as custom which could have a big
 impact in the SignalFx billing so you have to filter as much as possible to avoid that.
 * Sadly, the `errors_per_minute` filter is not available so the `errors` detector will
@@ -115,4 +117,5 @@ too many metrics
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [Stackdriver metrics](https://cloud.google.com/monitoring/api/metrics_gcp#gcp-cloudsql)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [NewRelic integration](https://github.com/signalfx/integrations/blob/master/newrelic/README.md)

--- a/modules/integration_newrelic-apm/README.md
+++ b/modules/integration_newrelic-apm/README.md
@@ -16,7 +16,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -33,7 +33,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -49,7 +49,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -60,7 +60,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/integration_newrelic-apm/conf/readme.yaml
+++ b/modules/integration_newrelic-apm/conf/readme.yaml
@@ -4,7 +4,7 @@ documentations:
 
 notes: |
   * The NewRelic integration from SignalFx still uses the deprecated [REST API
-  v1](https://docs.newrelic.com/docs/apis/rest-api-v1-deprecated/new-relic-rest-api-v1).
+  v1](https://docs.newrelic.com/docs/apis/rest-api-v1-deprecated/new-relic-rest-api-v1/working-new-relic-rest-api-v1-deprecated/).
   * It also generate too many metrics all considered as custom which could have a big
   impact in the SignalFx billing so you have to filter as much as possible to avoid that.
   * Sadly, the `errors_per_minute` filter is not available so the `errors` detector will

--- a/modules/integration_newrelic-apm/conf/readme.yaml
+++ b/modules/integration_newrelic-apm/conf/readme.yaml
@@ -1,6 +1,6 @@
 documentations:
-  - name: Stackdriver metrics
-    url: 'https://cloud.google.com/monitoring/api/metrics_gcp#gcp-cloudsql'
+  - name: NewRelic integration
+    url: 'https://github.com/signalfx/integrations/blob/master/newrelic/README.md'
 
 notes: |
   * The NewRelic integration from SignalFx still uses the deprecated [REST API

--- a/modules/organization_usage/README.md
+++ b/modules/organization_usage/README.md
@@ -49,8 +49,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -84,10 +84,10 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-[SignalFx
-organization](https://docs.signalfx.com/en/latest/integrations/integrations-reference/integrations.signalfx.organization.metrics.html).
-There are always available and do not need any configuration to work.
+This module deploys detectors using metrics reported by the
+[Splunk Observability organization](https://docs.splunk.com/Observability/admin/org-metrics.html) always available out the box.
+
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 
 
@@ -130,3 +130,4 @@ module "signalfx-detectors-organization-usage" {
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)

--- a/modules/organization_usage/README.md
+++ b/modules/organization_usage/README.md
@@ -16,7 +16,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -33,7 +33,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -49,7 +49,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -60,7 +60,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/prometheus-exporter_kong/README.md
+++ b/modules/prometheus-exporter_kong/README.md
@@ -49,8 +49,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -81,14 +81,20 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-the scraping of a server following the [OpenMetrics convention](https://openmetrics.io/) based on and compatible with [the Prometheus
+This module deploys detectors using metrics reported by the
+scraping of a server following the [OpenMetrics convention](https://openmetrics.io/) based on and compatible with [the Prometheus
 exposition format](https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/exposition_formats.md#openmetrics-text-format).
-They are generally called "Prometheus Exporter" which can be fetched by both the [SignalFx Smart Agent](https://github.com/signalfx/signalfx-agent)
-thanks to its [prometheus exporter monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/prometheus-exporter.html) and the
+
+They are generally called `Prometheus Exporters` which can be fetched by both the [SignalFx Smart Agent](https://github.com/signalfx/signalfx-agent)
+thanks to its [prometheus exporter monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/prometheus-exporter.md) and the
 [OpenTelemetry Collector](https://github.com/signalfx/splunk-otel-collector) using its [prometheus
 receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/prometheusreceiver) or its derivates.
 
+These exporters could be embedded directly in the tool you want to monitor (e.g. nginx ingress) or must be installed next to it as
+a separate program configured to connect, create metrics and expose them as server.
+
+
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 Kong provides a [prometheus plugin](https://docs.konghq.com/hub/kong-inc/prometheus/).
 It must be enabled to expose its metrics in Prometheus exposition format which can be scraped by the agent.
@@ -113,7 +119,7 @@ Here is an example of SignalFx agent configuration using:
         - '!kong_nginx_http_current_connections'
 ```
 
-It uses whitelist [filtering](https://docs.signalfx.com/en/latest/integrations/agent/filtering.html)
+It uses whitelist [filtering](https://github.com/signalfx/signalfx-agent/blob/main/docs/filtering.md)
 to keep only interesting metrics. Only the last two are required by this module.
 
 
@@ -132,5 +138,6 @@ Here is the list of required metrics for detectors in this module.
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
 * [Kong](https://konghq.com/)
 * [Kong Prometheus Plugin](https://docs.konghq.com/hub/kong-inc/prometheus/)

--- a/modules/prometheus-exporter_kong/README.md
+++ b/modules/prometheus-exporter_kong/README.md
@@ -16,7 +16,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -33,7 +33,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -49,7 +49,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -60,7 +60,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/prometheus-exporter_kong/conf/readme.yaml
+++ b/modules/prometheus-exporter_kong/conf/readme.yaml
@@ -28,5 +28,5 @@ source_doc: |
           - '!kong_nginx_http_current_connections'
   ```
 
-  It uses whitelist [filtering](https://docs.signalfx.com/en/latest/integrations/agent/filtering.html)
+  It uses whitelist [filtering](https://github.com/signalfx/signalfx-agent/blob/main/docs/filtering.md)
   to keep only interesting metrics. Only the last two are required by this module.

--- a/modules/prometheus-exporter_oracledb/README.md
+++ b/modules/prometheus-exporter_oracledb/README.md
@@ -49,8 +49,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -81,14 +81,20 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-the scraping of a server following the [OpenMetrics convention](https://openmetrics.io/) based on and compatible with [the Prometheus
+This module deploys detectors using metrics reported by the
+scraping of a server following the [OpenMetrics convention](https://openmetrics.io/) based on and compatible with [the Prometheus
 exposition format](https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/exposition_formats.md#openmetrics-text-format).
-They are generally called "Prometheus Exporter" which can be fetched by both the [SignalFx Smart Agent](https://github.com/signalfx/signalfx-agent)
-thanks to its [prometheus exporter monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/prometheus-exporter.html) and the
+
+They are generally called `Prometheus Exporters` which can be fetched by both the [SignalFx Smart Agent](https://github.com/signalfx/signalfx-agent)
+thanks to its [prometheus exporter monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/prometheus-exporter.md) and the
 [OpenTelemetry Collector](https://github.com/signalfx/splunk-otel-collector) using its [prometheus
 receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/prometheusreceiver) or its derivates.
 
+These exporters could be embedded directly in the tool you want to monitor (e.g. nginx ingress) or must be installed next to it as
+a separate program configured to connect, create metrics and expose them as server.
+
+
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 The detectors of this module uses defaults metrics from the [oracledb exporter](https://github.com/iamseth/oracledb_exporter).
 Check its documentation to install and configure it appropriately with your Oracle database host.
@@ -186,4 +192,5 @@ Here is the list of required metrics for detectors in this module.
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
 * [Prometheus Exporter for oracledb](https://github.com/iamseth/oracledb_exporter)

--- a/modules/prometheus-exporter_oracledb/README.md
+++ b/modules/prometheus-exporter_oracledb/README.md
@@ -16,7 +16,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -33,7 +33,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -49,7 +49,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -60,7 +60,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables-gen.tf](variables-gen.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/prometheus-exporter_squid/README.md
+++ b/modules/prometheus-exporter_squid/README.md
@@ -49,8 +49,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -83,14 +83,20 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-the scraping of a server following the [OpenMetrics convention](https://openmetrics.io/) based on and compatible with [the Prometheus
+This module deploys detectors using metrics reported by the
+scraping of a server following the [OpenMetrics convention](https://openmetrics.io/) based on and compatible with [the Prometheus
 exposition format](https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/exposition_formats.md#openmetrics-text-format).
-They are generally called "Prometheus Exporter" which can be fetched by both the [SignalFx Smart Agent](https://github.com/signalfx/signalfx-agent)
-thanks to its [prometheus exporter monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/prometheus-exporter.html) and the
+
+They are generally called `Prometheus Exporters` which can be fetched by both the [SignalFx Smart Agent](https://github.com/signalfx/signalfx-agent)
+thanks to its [prometheus exporter monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/prometheus-exporter.md) and the
 [OpenTelemetry Collector](https://github.com/signalfx/splunk-otel-collector) using its [prometheus
 receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/prometheusreceiver) or its derivates.
 
+These exporters could be embedded directly in the tool you want to monitor (e.g. nginx ingress) or must be installed next to it as
+a separate program configured to connect, create metrics and expose them as server.
+
+
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 The detectors of this module uses metrics from the [squid exporter prometheus](https://github.com/boynux/squid-exporter).
 Check its documentation to install and configure it appropriately with your Squid server.
@@ -160,5 +166,6 @@ Here is the list of required metrics for detectors in this module.
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
 * [Squid Server](http://www.squid-cache.org/)
 * [Prometheus Exporter for Squid](https://github.com/boynux/squid-exporter)

--- a/modules/prometheus-exporter_squid/README.md
+++ b/modules/prometheus-exporter_squid/README.md
@@ -16,7 +16,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -33,7 +33,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -49,7 +49,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -60,7 +60,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables-gen.tf](variables-gen.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/prometheus-exporter_wallix-bastion/README.md
+++ b/modules/prometheus-exporter_wallix-bastion/README.md
@@ -49,8 +49,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -84,14 +84,20 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-the scraping of a server following the [OpenMetrics convention](https://openmetrics.io/) based on and compatible with [the Prometheus
+This module deploys detectors using metrics reported by the
+scraping of a server following the [OpenMetrics convention](https://openmetrics.io/) based on and compatible with [the Prometheus
 exposition format](https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/exposition_formats.md#openmetrics-text-format).
-They are generally called "Prometheus Exporter" which can be fetched by both the [SignalFx Smart Agent](https://github.com/signalfx/signalfx-agent)
-thanks to its [prometheus exporter monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/prometheus-exporter.html) and the
+
+They are generally called `Prometheus Exporters` which can be fetched by both the [SignalFx Smart Agent](https://github.com/signalfx/signalfx-agent)
+thanks to its [prometheus exporter monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/prometheus-exporter.md) and the
 [OpenTelemetry Collector](https://github.com/signalfx/splunk-otel-collector) using its [prometheus
 receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/prometheusreceiver) or its derivates.
 
+These exporters could be embedded directly in the tool you want to monitor (e.g. nginx ingress) or must be installed next to it as
+a separate program configured to connect, create metrics and expose them as server.
+
+
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 The detectors of this module uses metrics from the [wallix-bastion exporter prometheus](https://github.com/claranet/wallix_bastion_exporter).
 Check its documentation to install and configure it appropriately with your Wallix Bastion instance.
@@ -149,5 +155,6 @@ Here is the list of required metrics for detectors in this module.
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
 * [Wallix-Bastion](https://www.wallix.com/privileged-access-management)
 * [Prometheus Exporter for Wallix-Bastion](https://github.com/claranet/wallix_bastion_exporter)

--- a/modules/prometheus-exporter_wallix-bastion/README.md
+++ b/modules/prometheus-exporter_wallix-bastion/README.md
@@ -16,7 +16,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -33,7 +33,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -49,7 +49,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -60,7 +60,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables-gen.tf](variables-gen.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/smart-agent_apache/README.md
+++ b/modules/smart-agent_apache/README.md
@@ -48,8 +48,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -80,24 +80,38 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-[monitors](https://docs.signalfx.com/en/latest/integrations/agent/monitors/_monitor-config.html)
-available in the [SignalFx Smart
-Agent](https://github.com/signalfx/signalfx-agent). Check the [Related documentation](#related-documentation) section for more
-information including the official documentation of this monitor.
+This module deploys detectors using metrics reported by the
+[SignalFx Smart Agent Monitors](https://github.com/signalfx/signalfx-agent#monitors).
+
+Even if the [Smart Agent is deprecated](https://github.com/signalfx/signalfx-agent/blob/main/docs/smartagent-deprecation-notice.md)
+it remains an efficient, lightweight and simple monitoring agent which still works fine.
+See the [official documentation](https://docs.splunk.com/Observability/gdi/smart-agent/smart-agent-resources.html) for more information
+about this agent.
+You might find the related following documentations useful:
+- the global level [agent configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/config-schema.md)
+- the [monitor level configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitor-config.md)
+- the internal [agent configuration tips](https://github.com/claranet/terraform-signalfx-detectors/wiki/Guidance#agent-configuration).
+- the full list of [monitors available](https://github.com/signalfx/signalfx-agent/tree/main/docs/monitors) with their own specific documentation.
+
+In addition, all of these monitors are still available in the [Splunk Otel Collector](https://github.com/signalfx/splunk-otel-collector),
+the Splunk [distro of OpenTelemetry Collector](https://opentelemetry.io/docs/concepts/distributions/) which replaces SignalFx Smart Agent,
+thanks to the internal [Smart Agent Receiver](https://github.com/signalfx/splunk-otel-collector/tree/main/internal/receiver/smartagentreceiver).
+
+As a result:
+- any SignalFx Smart Agent monitor are compatible with the new agent OpenTelemetry Collector and related modules in this repository keep `smart-agent` as source name.
+- any OpenTelemetry receiver not based on an existing Smart Agent monitor is not available from old agent so related modules in this repository use `otel-collector` as source name.
 
 
-Check the [integration
-documentation](https://docs.signalfx.com/en/latest/integrations/integrations-reference/integrations.apache.html)
-in addition to the monitor one which it uses.
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
+
 
 
 ### Metrics
 
 
 To filter only required metrics for the detectors of this module, add the
-[datapointsToExclude](https://docs.signalfx.com/en/latest/integrations/agent/filtering.html) parameter to
-the corresponding monitor configuration:
+[datapointsToExclude](https://docs.splunk.com/observability/gdi/smart-agent/smart-agent-resources.html#filtering-data-using-the-smart-agent)
+parameter to the corresponding monitor configuration:
 
 ```yaml
     datapointsToExclude:
@@ -114,6 +128,8 @@ the corresponding monitor configuration:
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [Smart Agent monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/collectd-apache.html)
-* [Apache status module](http://httpd.apache.org/docs/2.4/mod/mod_status.html)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [Smart Agent monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-apache.md)
+* [Splunk Observability integration](https://docs.splunk.com/Observability/gdi/apache/apache.html)
 * [Collectd plugin](https://collectd.org/wiki/index.php/Plugin:Apache)
+* [Apache status module](http://httpd.apache.org/docs/2.4/mod/mod_status.html)

--- a/modules/smart-agent_apache/README.md
+++ b/modules/smart-agent_apache/README.md
@@ -15,7 +15,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -32,7 +32,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -48,7 +48,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -59,7 +59,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables-gen.tf](variables-gen.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/smart-agent_apache/conf/readme.yaml
+++ b/modules/smart-agent_apache/conf/readme.yaml
@@ -1,6 +1,6 @@
 documentations:
   - name: Smart Agent monitor
-    url: 'https://docs.signalfx.com/en/latest/integrations/agent/monitors/collectd-apache.html'
+    url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-apache.md'
   - name: Apache status module
     url: 'http://httpd.apache.org/docs/2.4/mod/mod_status.html'
   - name: Collectd plugin

--- a/modules/smart-agent_apache/conf/readme.yaml
+++ b/modules/smart-agent_apache/conf/readme.yaml
@@ -1,12 +1,9 @@
 documentations:
   - name: Smart Agent monitor
     url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-apache.md'
-  - name: Apache status module
-    url: 'http://httpd.apache.org/docs/2.4/mod/mod_status.html'
+  - name: Splunk Observability integration
+    url: 'https://docs.splunk.com/Observability/gdi/apache/apache.html'
   - name: Collectd plugin
     url: 'https://collectd.org/wiki/index.php/Plugin:Apache'
-
-source_doc: |
-  Check the [integration
-  documentation](https://docs.signalfx.com/en/latest/integrations/integrations-reference/integrations.apache.html)
-  in addition to the monitor one which it uses.
+  - name: Apache status module
+    url: 'http://httpd.apache.org/docs/2.4/mod/mod_status.html'

--- a/modules/smart-agent_cassandra-nodetool/README.md
+++ b/modules/smart-agent_cassandra-nodetool/README.md
@@ -18,7 +18,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -35,7 +35,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -51,7 +51,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -62,7 +62,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables-gen.tf](variables-gen.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/smart-agent_cassandra-nodetool/README.md
+++ b/modules/smart-agent_cassandra-nodetool/README.md
@@ -51,8 +51,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -83,13 +83,29 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-[monitors](https://docs.signalfx.com/en/latest/integrations/agent/monitors/_monitor-config.html)
-available in the [SignalFx Smart
-Agent](https://github.com/signalfx/signalfx-agent). Check the [Related documentation](#related-documentation) section for more
-information including the official documentation of this monitor.
+This module deploys detectors using metrics reported by the
+[SignalFx Smart Agent Monitors](https://github.com/signalfx/signalfx-agent#monitors).
+
+Even if the [Smart Agent is deprecated](https://github.com/signalfx/signalfx-agent/blob/main/docs/smartagent-deprecation-notice.md)
+it remains an efficient, lightweight and simple monitoring agent which still works fine.
+See the [official documentation](https://docs.splunk.com/Observability/gdi/smart-agent/smart-agent-resources.html) for more information
+about this agent.
+You might find the related following documentations useful:
+- the global level [agent configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/config-schema.md)
+- the [monitor level configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitor-config.md)
+- the internal [agent configuration tips](https://github.com/claranet/terraform-signalfx-detectors/wiki/Guidance#agent-configuration).
+- the full list of [monitors available](https://github.com/signalfx/signalfx-agent/tree/main/docs/monitors) with their own specific documentation.
+
+In addition, all of these monitors are still available in the [Splunk Otel Collector](https://github.com/signalfx/splunk-otel-collector),
+the Splunk [distro of OpenTelemetry Collector](https://opentelemetry.io/docs/concepts/distributions/) which replaces SignalFx Smart Agent,
+thanks to the internal [Smart Agent Receiver](https://github.com/signalfx/splunk-otel-collector/tree/main/internal/receiver/smartagentreceiver).
+
+As a result:
+- any SignalFx Smart Agent monitor are compatible with the new agent OpenTelemetry Collector and related modules in this repository keep `smart-agent` as source name.
+- any OpenTelemetry receiver not based on an existing Smart Agent monitor is not available from old agent so related modules in this repository use `otel-collector` as source name.
 
 
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 This module leverages the powerful `JMX` monitor to retrieve equivalent information
 from the output of [Cassandra
@@ -140,8 +156,8 @@ on your `cassandra` servers.
 
 
 To filter only required metrics for the detectors of this module, add the
-[datapointsToExclude](https://docs.signalfx.com/en/latest/integrations/agent/filtering.html) parameter to
-the corresponding monitor configuration:
+[datapointsToExclude](https://docs.splunk.com/observability/gdi/smart-agent/smart-agent-resources.html#filtering-data-using-the-smart-agent)
+parameter to the corresponding monitor configuration:
 
 ```yaml
     datapointsToExclude:
@@ -164,4 +180,5 @@ module.
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [Smart Agent monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/jmx.html)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [Smart Agent monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/jmx.md)

--- a/modules/smart-agent_cassandra-nodetool/conf/readme.yaml
+++ b/modules/smart-agent_cassandra-nodetool/conf/readme.yaml
@@ -3,7 +3,6 @@ documentations:
     url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/jmx.md'
 
 source_doc: |
-
   This module leverages the powerful `JMX` monitor to retrieve equivalent information
   from the output of [Cassandra
   Nodetool](https://cassandra.apache.org/doc/latest/tools/nodetool/nodetool.html) like

--- a/modules/smart-agent_cassandra-nodetool/conf/readme.yaml
+++ b/modules/smart-agent_cassandra-nodetool/conf/readme.yaml
@@ -1,6 +1,6 @@
 documentations:
   - name: Smart Agent monitor
-    url: 'https://docs.signalfx.com/en/latest/integrations/agent/monitors/jmx.html'
+    url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/jmx.md'
 
 source_doc: |
 

--- a/modules/smart-agent_cassandra/README.md
+++ b/modules/smart-agent_cassandra/README.md
@@ -19,7 +19,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -36,7 +36,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -52,7 +52,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -63,7 +63,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables-gen.tf](variables-gen.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/smart-agent_cassandra/README.md
+++ b/modules/smart-agent_cassandra/README.md
@@ -52,8 +52,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -92,23 +92,34 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-[monitors](https://docs.signalfx.com/en/latest/integrations/agent/monitors/_monitor-config.html)
-available in the [SignalFx Smart
-Agent](https://github.com/signalfx/signalfx-agent). Check the [Related documentation](#related-documentation) section for more
-information including the official documentation of this monitor.
+This module deploys detectors using metrics reported by the
+[SignalFx Smart Agent Monitors](https://github.com/signalfx/signalfx-agent#monitors).
+
+Even if the [Smart Agent is deprecated](https://github.com/signalfx/signalfx-agent/blob/main/docs/smartagent-deprecation-notice.md)
+it remains an efficient, lightweight and simple monitoring agent which still works fine.
+See the [official documentation](https://docs.splunk.com/Observability/gdi/smart-agent/smart-agent-resources.html) for more information
+about this agent.
+You might find the related following documentations useful:
+- the global level [agent configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/config-schema.md)
+- the [monitor level configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitor-config.md)
+- the internal [agent configuration tips](https://github.com/claranet/terraform-signalfx-detectors/wiki/Guidance#agent-configuration).
+- the full list of [monitors available](https://github.com/signalfx/signalfx-agent/tree/main/docs/monitors) with their own specific documentation.
+
+In addition, all of these monitors are still available in the [Splunk Otel Collector](https://github.com/signalfx/splunk-otel-collector),
+the Splunk [distro of OpenTelemetry Collector](https://opentelemetry.io/docs/concepts/distributions/) which replaces SignalFx Smart Agent,
+thanks to the internal [Smart Agent Receiver](https://github.com/signalfx/splunk-otel-collector/tree/main/internal/receiver/smartagentreceiver).
+
+As a result:
+- any SignalFx Smart Agent monitor are compatible with the new agent OpenTelemetry Collector and related modules in this repository keep `smart-agent` as source name.
+- any OpenTelemetry receiver not based on an existing Smart Agent monitor is not available from old agent so related modules in this repository use `otel-collector` as source name.
 
 
-Check the [integration
-documentation](https://docs.signalfx.com/en/latest/integrations/integrations-reference/integrations.cassandra.html)
-in addition to the monitor one which it uses.
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 ### Agent
 
-The agent requires to [Java
-plugin](https://docs.signalfx.com/en/latest/integrations/integrations-reference/integrations.java.html)
-for Collectd which is already installed in the [SignalFx Smart
-Agent](https://github.com/signalfx/signalfx-agent/).
+The agent requires the [Collectd Java plugin](https://collectd.org/wiki/index.php/Plugin:Java)
+which should already be installed with the [SignalFx Smart Agent](https://github.com/signalfx/signalfx-agent/).
 
 ### Monitors
 
@@ -140,8 +151,8 @@ on your `cassandra` servers.
 
 
 To filter only required metrics for the detectors of this module, add the
-[datapointsToExclude](https://docs.signalfx.com/en/latest/integrations/agent/filtering.html) parameter to
-the corresponding monitor configuration:
+[datapointsToExclude](https://docs.splunk.com/observability/gdi/smart-agent/smart-agent-resources.html#filtering-data-using-the-smart-agent)
+parameter to the corresponding monitor configuration:
 
 ```yaml
     datapointsToExclude:
@@ -176,5 +187,7 @@ You can use `genericjmx` module as complement to this one to monitor generic JMX
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [Smart Agent monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/collectd-cassandra.html)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [Smart Agent monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-cassandra.md)
+* [Splunk Observability integration](https://docs.splunk.com/Observability/gdi/cassandra/cassandra.html)
 * [Collectd plugin](https://collectd.org/wiki/index.php/Plugin:GenericJMX)

--- a/modules/smart-agent_cassandra/conf/readme.yaml
+++ b/modules/smart-agent_cassandra/conf/readme.yaml
@@ -1,6 +1,6 @@
 documentations:
   - name: Smart Agent monitor
-    url: 'https://docs.signalfx.com/en/latest/integrations/agent/monitors/collectd-cassandra.html'
+    url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-cassandra.md'
   - name: Collectd plugin
     url: 'https://collectd.org/wiki/index.php/Plugin:GenericJMX'
 

--- a/modules/smart-agent_cassandra/conf/readme.yaml
+++ b/modules/smart-agent_cassandra/conf/readme.yaml
@@ -1,20 +1,16 @@
 documentations:
   - name: Smart Agent monitor
     url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-cassandra.md'
+  - name: Splunk Observability integration
+    url: 'https://docs.splunk.com/Observability/gdi/cassandra/cassandra.html'
   - name: Collectd plugin
     url: 'https://collectd.org/wiki/index.php/Plugin:GenericJMX'
 
 source_doc: |
-  Check the [integration
-  documentation](https://docs.signalfx.com/en/latest/integrations/integrations-reference/integrations.cassandra.html)
-  in addition to the monitor one which it uses.
-
   ### Agent
 
-  The agent requires to [Java
-  plugin](https://docs.signalfx.com/en/latest/integrations/integrations-reference/integrations.java.html)
-  for Collectd which is already installed in the [SignalFx Smart
-  Agent](https://github.com/signalfx/signalfx-agent/).
+  The agent requires the [Collectd Java plugin](https://collectd.org/wiki/index.php/Plugin:Java)
+  which should already be installed with the [SignalFx Smart Agent](https://github.com/signalfx/signalfx-agent/).
 
   ### Monitors
 

--- a/modules/smart-agent_couchbase/README.md
+++ b/modules/smart-agent_couchbase/README.md
@@ -48,8 +48,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -81,12 +81,29 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-[monitors](https://docs.signalfx.com/en/latest/integrations/agent/monitors/_monitor-config.html)
-available in the [SignalFx Smart
-Agent](https://github.com/signalfx/signalfx-agent). Check the [Related documentation](#related-documentation) section for more
-information including the official documentation of this monitor.
+This module deploys detectors using metrics reported by the
+[SignalFx Smart Agent Monitors](https://github.com/signalfx/signalfx-agent#monitors).
 
+Even if the [Smart Agent is deprecated](https://github.com/signalfx/signalfx-agent/blob/main/docs/smartagent-deprecation-notice.md)
+it remains an efficient, lightweight and simple monitoring agent which still works fine.
+See the [official documentation](https://docs.splunk.com/Observability/gdi/smart-agent/smart-agent-resources.html) for more information
+about this agent.
+You might find the related following documentations useful:
+- the global level [agent configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/config-schema.md)
+- the [monitor level configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitor-config.md)
+- the internal [agent configuration tips](https://github.com/claranet/terraform-signalfx-detectors/wiki/Guidance#agent-configuration).
+- the full list of [monitors available](https://github.com/signalfx/signalfx-agent/tree/main/docs/monitors) with their own specific documentation.
+
+In addition, all of these monitors are still available in the [Splunk Otel Collector](https://github.com/signalfx/splunk-otel-collector),
+the Splunk [distro of OpenTelemetry Collector](https://opentelemetry.io/docs/concepts/distributions/) which replaces SignalFx Smart Agent,
+thanks to the internal [Smart Agent Receiver](https://github.com/signalfx/splunk-otel-collector/tree/main/internal/receiver/smartagentreceiver).
+
+As a result:
+- any SignalFx Smart Agent monitor are compatible with the new agent OpenTelemetry Collector and related modules in this repository keep `smart-agent` as source name.
+- any OpenTelemetry receiver not based on an existing Smart Agent monitor is not available from old agent so related modules in this repository use `otel-collector` as source name.
+
+
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 
 
@@ -94,8 +111,8 @@ information including the official documentation of this monitor.
 
 
 To filter only required metrics for the detectors of this module, add the
-[datapointsToExclude](https://docs.signalfx.com/en/latest/integrations/agent/filtering.html) parameter to
-the corresponding monitor configuration:
+[datapointsToExclude](https://docs.splunk.com/observability/gdi/smart-agent/smart-agent-resources.html#filtering-data-using-the-smart-agent)
+parameter to the corresponding monitor configuration:
 
 ```yaml
     datapointsToExclude:
@@ -114,4 +131,7 @@ the corresponding monitor configuration:
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [Smart Agent monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/collectd-couchbase.html)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [Smart Agent monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-couchbase.md)
+* [Splunk Observability integration](https://docs.splunk.com/Observability/gdi/couchbase/couchbase.html)
+* [Collectd Script](https://github.com/signalfx/collectd-couchbase)

--- a/modules/smart-agent_couchbase/README.md
+++ b/modules/smart-agent_couchbase/README.md
@@ -15,7 +15,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -32,7 +32,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -48,7 +48,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -59,7 +59,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables-gen.tf](variables-gen.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/smart-agent_couchbase/conf/readme.yaml
+++ b/modules/smart-agent_couchbase/conf/readme.yaml
@@ -1,5 +1,7 @@
 documentations:
   - name: Smart Agent monitor
     url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-couchbase.md'
-
-source_doc:
+  - name: Splunk Observability integration
+    url: 'https://docs.splunk.com/Observability/gdi/couchbase/couchbase.html'
+  - name: Collectd Script
+    url: 'https://github.com/signalfx/collectd-couchbase'

--- a/modules/smart-agent_couchbase/conf/readme.yaml
+++ b/modules/smart-agent_couchbase/conf/readme.yaml
@@ -1,5 +1,5 @@
 documentations:
   - name: Smart Agent monitor
-    url: 'https://docs.signalfx.com/en/latest/integrations/agent/monitors/collectd-couchbase.html'
+    url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-couchbase.md'
 
 source_doc:

--- a/modules/smart-agent_dns/README.md
+++ b/modules/smart-agent_dns/README.md
@@ -49,8 +49,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -82,15 +82,29 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-[monitors](https://docs.signalfx.com/en/latest/integrations/agent/monitors/_monitor-config.html)
-available in the [SignalFx Smart
-Agent](https://github.com/signalfx/signalfx-agent). Check the [Related documentation](#related-documentation) section for more
-information including the official documentation of this monitor.
+This module deploys detectors using metrics reported by the
+[SignalFx Smart Agent Monitors](https://github.com/signalfx/signalfx-agent#monitors).
+
+Even if the [Smart Agent is deprecated](https://github.com/signalfx/signalfx-agent/blob/main/docs/smartagent-deprecation-notice.md)
+it remains an efficient, lightweight and simple monitoring agent which still works fine.
+See the [official documentation](https://docs.splunk.com/Observability/gdi/smart-agent/smart-agent-resources.html) for more information
+about this agent.
+You might find the related following documentations useful:
+- the global level [agent configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/config-schema.md)
+- the [monitor level configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitor-config.md)
+- the internal [agent configuration tips](https://github.com/claranet/terraform-signalfx-detectors/wiki/Guidance#agent-configuration).
+- the full list of [monitors available](https://github.com/signalfx/signalfx-agent/tree/main/docs/monitors) with their own specific documentation.
+
+In addition, all of these monitors are still available in the [Splunk Otel Collector](https://github.com/signalfx/splunk-otel-collector),
+the Splunk [distro of OpenTelemetry Collector](https://opentelemetry.io/docs/concepts/distributions/) which replaces SignalFx Smart Agent,
+thanks to the internal [Smart Agent Receiver](https://github.com/signalfx/splunk-otel-collector/tree/main/internal/receiver/smartagentreceiver).
+
+As a result:
+- any SignalFx Smart Agent monitor are compatible with the new agent OpenTelemetry Collector and related modules in this repository keep `smart-agent` as source name.
+- any OpenTelemetry receiver not based on an existing Smart Agent monitor is not available from old agent so related modules in this repository use `otel-collector` as source name.
 
 
-There is no SignalFx official integration for `dns` but there is still a
-[monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/telegraf-dns.html) to use.
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 ### Monitors
 
@@ -101,8 +115,8 @@ This monitor is only available from agent version `>= 5.2.1`.
 
 
 To filter only required metrics for the detectors of this module, add the
-[datapointsToExclude](https://docs.signalfx.com/en/latest/integrations/agent/filtering.html) parameter to
-the corresponding monitor configuration:
+[datapointsToExclude](https://docs.splunk.com/observability/gdi/smart-agent/smart-agent-resources.html#filtering-data-using-the-smart-agent)
+parameter to the corresponding monitor configuration:
 
 ```yaml
     datapointsToExclude:
@@ -119,4 +133,7 @@ the corresponding monitor configuration:
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [Smart Agent monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/telegraf-dns.html)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [Smart Agent monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/telegraf-dns.md)
+* [Splunk Observability integration](https://docs.splunk.com/Observability/gdi/dns/telegraf-dns.html)
+* [Telegraf plugin](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/dns_query)

--- a/modules/smart-agent_dns/README.md
+++ b/modules/smart-agent_dns/README.md
@@ -16,7 +16,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -33,7 +33,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -49,7 +49,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -60,7 +60,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/smart-agent_dns/conf/readme.yaml
+++ b/modules/smart-agent_dns/conf/readme.yaml
@@ -1,11 +1,12 @@
 documentations:
   - name: Smart Agent monitor
     url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/telegraf-dns.md'
+  - name: Splunk Observability integration
+    url: 'https://docs.splunk.com/Observability/gdi/dns/telegraf-dns.html'
+  - name: Telegraf plugin
+    url: 'https://github.com/influxdata/telegraf/tree/master/plugins/inputs/dns_query'
 
 source_doc: |
-  There is no SignalFx official integration for `dns` but there is still a
-  [monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/telegraf-dns.md) to use.
-
   ### Monitors
 
   This monitor is only available from agent version `>= 5.2.1`.

--- a/modules/smart-agent_dns/conf/readme.yaml
+++ b/modules/smart-agent_dns/conf/readme.yaml
@@ -1,10 +1,10 @@
 documentations:
   - name: Smart Agent monitor
-    url: 'https://docs.signalfx.com/en/latest/integrations/agent/monitors/telegraf-dns.html'
+    url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/telegraf-dns.md'
 
 source_doc: |
   There is no SignalFx official integration for `dns` but there is still a
-  [monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/telegraf-dns.html) to use.
+  [monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/telegraf-dns.md) to use.
 
   ### Monitors
 

--- a/modules/smart-agent_docker/README.md
+++ b/modules/smart-agent_docker/README.md
@@ -49,8 +49,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -83,16 +83,29 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-[monitors](https://docs.signalfx.com/en/latest/integrations/agent/monitors/_monitor-config.html)
-available in the [SignalFx Smart
-Agent](https://github.com/signalfx/signalfx-agent). Check the [Related documentation](#related-documentation) section for more
-information including the official documentation of this monitor.
+This module deploys detectors using metrics reported by the
+[SignalFx Smart Agent Monitors](https://github.com/signalfx/signalfx-agent#monitors).
+
+Even if the [Smart Agent is deprecated](https://github.com/signalfx/signalfx-agent/blob/main/docs/smartagent-deprecation-notice.md)
+it remains an efficient, lightweight and simple monitoring agent which still works fine.
+See the [official documentation](https://docs.splunk.com/Observability/gdi/smart-agent/smart-agent-resources.html) for more information
+about this agent.
+You might find the related following documentations useful:
+- the global level [agent configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/config-schema.md)
+- the [monitor level configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitor-config.md)
+- the internal [agent configuration tips](https://github.com/claranet/terraform-signalfx-detectors/wiki/Guidance#agent-configuration).
+- the full list of [monitors available](https://github.com/signalfx/signalfx-agent/tree/main/docs/monitors) with their own specific documentation.
+
+In addition, all of these monitors are still available in the [Splunk Otel Collector](https://github.com/signalfx/splunk-otel-collector),
+the Splunk [distro of OpenTelemetry Collector](https://opentelemetry.io/docs/concepts/distributions/) which replaces SignalFx Smart Agent,
+thanks to the internal [Smart Agent Receiver](https://github.com/signalfx/splunk-otel-collector/tree/main/internal/receiver/smartagentreceiver).
+
+As a result:
+- any SignalFx Smart Agent monitor are compatible with the new agent OpenTelemetry Collector and related modules in this repository keep `smart-agent` as source name.
+- any OpenTelemetry receiver not based on an existing Smart Agent monitor is not available from old agent so related modules in this repository use `otel-collector` as source name.
 
 
-Follow the
-[docker-container-stats](https://docs.signalfx.com/en/latest/integrations/agent/monitors/docker-container-stats.html)
-monitor configuration to collect metrics.
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 It requires to enable the following `extraMetrics`:
 
@@ -104,8 +117,8 @@ It requires to enable the following `extraMetrics`:
 
 
 To filter only required metrics for the detectors of this module, add the
-[datapointsToExclude](https://docs.signalfx.com/en/latest/integrations/agent/filtering.html) parameter to
-the corresponding monitor configuration:
+[datapointsToExclude](https://docs.splunk.com/observability/gdi/smart-agent/smart-agent-resources.html#filtering-data-using-the-smart-agent)
+parameter to the corresponding monitor configuration:
 
 ```yaml
     datapointsToExclude:
@@ -132,4 +145,6 @@ lead to duplicated detectors and alerts.
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [Smart Agent monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/docker-container-stats.html)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [Smart Agent monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/docker-container-stats.md)
+* [Splunk Observability integration](https://docs.splunk.com/Observability/gdi/docker/docker.html)

--- a/modules/smart-agent_docker/README.md
+++ b/modules/smart-agent_docker/README.md
@@ -16,7 +16,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -33,7 +33,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -49,7 +49,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -60,7 +60,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/smart-agent_docker/conf/readme.yaml
+++ b/modules/smart-agent_docker/conf/readme.yaml
@@ -1,12 +1,10 @@
 documentations:
   - name: Smart Agent monitor
     url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/docker-container-stats.md'
+  - name: Splunk Observability integration
+    url: 'https://docs.splunk.com/Observability/gdi/docker/docker.html'
 
 source_doc: |
-  Follow the
-  [docker-container-stats](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/docker-container-stats.md)
-  monitor configuration to collect metrics.
-
   It requires to enable the following `extraMetrics`:
 
   * `cpu.percent`

--- a/modules/smart-agent_docker/conf/readme.yaml
+++ b/modules/smart-agent_docker/conf/readme.yaml
@@ -1,10 +1,10 @@
 documentations:
   - name: Smart Agent monitor
-    url: 'https://docs.signalfx.com/en/latest/integrations/agent/monitors/docker-container-stats.html'
+    url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/docker-container-stats.md'
 
 source_doc: |
   Follow the
-  [docker-container-stats](https://docs.signalfx.com/en/latest/integrations/agent/monitors/docker-container-stats.html)
+  [docker-container-stats](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/docker-container-stats.md)
   monitor configuration to collect metrics.
 
   It requires to enable the following `extraMetrics`:

--- a/modules/smart-agent_elasticsearch/README.md
+++ b/modules/smart-agent_elasticsearch/README.md
@@ -50,8 +50,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -99,16 +99,29 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-[monitors](https://docs.signalfx.com/en/latest/integrations/agent/monitors/_monitor-config.html)
-available in the [SignalFx Smart
-Agent](https://github.com/signalfx/signalfx-agent). Check the [Related documentation](#related-documentation) section for more
-information including the official documentation of this monitor.
+This module deploys detectors using metrics reported by the
+[SignalFx Smart Agent Monitors](https://github.com/signalfx/signalfx-agent#monitors).
+
+Even if the [Smart Agent is deprecated](https://github.com/signalfx/signalfx-agent/blob/main/docs/smartagent-deprecation-notice.md)
+it remains an efficient, lightweight and simple monitoring agent which still works fine.
+See the [official documentation](https://docs.splunk.com/Observability/gdi/smart-agent/smart-agent-resources.html) for more information
+about this agent.
+You might find the related following documentations useful:
+- the global level [agent configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/config-schema.md)
+- the [monitor level configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitor-config.md)
+- the internal [agent configuration tips](https://github.com/claranet/terraform-signalfx-detectors/wiki/Guidance#agent-configuration).
+- the full list of [monitors available](https://github.com/signalfx/signalfx-agent/tree/main/docs/monitors) with their own specific documentation.
+
+In addition, all of these monitors are still available in the [Splunk Otel Collector](https://github.com/signalfx/splunk-otel-collector),
+the Splunk [distro of OpenTelemetry Collector](https://opentelemetry.io/docs/concepts/distributions/) which replaces SignalFx Smart Agent,
+thanks to the internal [Smart Agent Receiver](https://github.com/signalfx/splunk-otel-collector/tree/main/internal/receiver/smartagentreceiver).
+
+As a result:
+- any SignalFx Smart Agent monitor are compatible with the new agent OpenTelemetry Collector and related modules in this repository keep `smart-agent` as source name.
+- any OpenTelemetry receiver not based on an existing Smart Agent monitor is not available from old agent so related modules in this repository use `otel-collector` as source name.
 
 
-Check the [integration
-documentation](https://docs.signalfx.com/en/latest/integrations/integrations-reference/integrations.elasticsearch.html)
-in addition to the monitor one which it uses.
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 ### Monitors
 
@@ -140,7 +153,7 @@ You have to enable the following `extraMetrics` in your monitor configuration:
 * `elasticsearch.indices.search.fetch-total`
 
 You also have to configure following parameters from the
-[elasticsearch](https://docs.signalfx.com/en/latest/integrations/agent/monitors/elasticsearch.html)
+[elasticsearch](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/elasticsearch.md)
 monitor configuration:
 
 * `enableEnhancedClusterHealthStats` to `true`
@@ -196,8 +209,8 @@ node or if the master and data are the same node.
 
 
 To filter only required metrics for the detectors of this module, add the
-[datapointsToExclude](https://docs.signalfx.com/en/latest/integrations/agent/filtering.html) parameter to
-the corresponding monitor configuration:
+[datapointsToExclude](https://docs.splunk.com/observability/gdi/smart-agent/smart-agent-resources.html#filtering-data-using-the-smart-agent)
+parameter to the corresponding monitor configuration:
 
 ```yaml
     datapointsToExclude:
@@ -240,6 +253,6 @@ the corresponding monitor configuration:
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [Smart Agent monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/elasticsearch.html)
-* [RabbitMQ management plugin](https://www.rabbitmq.com/management.html)
-* [Collection script](https://github.com/signalfx/collectd-rabbitmq)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [Smart Agent monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/elasticsearch.md)
+* [Splunk Observability integration](https://docs.splunk.com/Observability/gdi/elasticsearch/elasticsearch.html)

--- a/modules/smart-agent_elasticsearch/README.md
+++ b/modules/smart-agent_elasticsearch/README.md
@@ -17,7 +17,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -34,7 +34,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -50,7 +50,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -61,7 +61,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/smart-agent_elasticsearch/conf/readme.yaml
+++ b/modules/smart-agent_elasticsearch/conf/readme.yaml
@@ -1,16 +1,10 @@
 documentations:
   - name: Smart Agent monitor
     url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/elasticsearch.md'
-  - name: RabbitMQ management plugin
-    url: 'https://www.rabbitmq.com/management.html'
-  - name: Collection script
-    url: 'https://github.com/signalfx/collectd-rabbitmq'
+  - name: Splunk Observability integration
+    url: 'https://docs.splunk.com/Observability/gdi/elasticsearch/elasticsearch.html'
 
 source_doc: |
-  Check the [integration
-  documentation](https://docs.signalfx.com/en/latest/integrations/integrations-reference/integrations.elasticsearch.html)
-  in addition to the monitor one which it uses.
-
   ### Monitors
 
   You have to enable the following `extraMetrics` in your monitor configuration:

--- a/modules/smart-agent_elasticsearch/conf/readme.yaml
+++ b/modules/smart-agent_elasticsearch/conf/readme.yaml
@@ -1,6 +1,6 @@
 documentations:
   - name: Smart Agent monitor
-    url: 'https://docs.signalfx.com/en/latest/integrations/agent/monitors/elasticsearch.html'
+    url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/elasticsearch.md'
   - name: RabbitMQ management plugin
     url: 'https://www.rabbitmq.com/management.html'
   - name: Collection script
@@ -41,7 +41,7 @@ source_doc: |
   * `elasticsearch.indices.search.fetch-total`
 
   You also have to configure following parameters from the
-  [elasticsearch](https://docs.signalfx.com/en/latest/integrations/agent/monitors/elasticsearch.html)
+  [elasticsearch](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/elasticsearch.md)
   monitor configuration:
 
   * `enableEnhancedClusterHealthStats` to `true`

--- a/modules/smart-agent_genericjmx/README.md
+++ b/modules/smart-agent_genericjmx/README.md
@@ -19,7 +19,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -36,7 +36,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -52,7 +52,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -63,7 +63,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/smart-agent_genericjmx/README.md
+++ b/modules/smart-agent_genericjmx/README.md
@@ -52,8 +52,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -84,22 +84,34 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-[monitors](https://docs.signalfx.com/en/latest/integrations/agent/monitors/_monitor-config.html)
-available in the [SignalFx Smart
-Agent](https://github.com/signalfx/signalfx-agent). Check the [Related documentation](#related-documentation) section for more
-information including the official documentation of this monitor.
+This module deploys detectors using metrics reported by the
+[SignalFx Smart Agent Monitors](https://github.com/signalfx/signalfx-agent#monitors).
+
+Even if the [Smart Agent is deprecated](https://github.com/signalfx/signalfx-agent/blob/main/docs/smartagent-deprecation-notice.md)
+it remains an efficient, lightweight and simple monitoring agent which still works fine.
+See the [official documentation](https://docs.splunk.com/Observability/gdi/smart-agent/smart-agent-resources.html) for more information
+about this agent.
+You might find the related following documentations useful:
+- the global level [agent configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/config-schema.md)
+- the [monitor level configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitor-config.md)
+- the internal [agent configuration tips](https://github.com/claranet/terraform-signalfx-detectors/wiki/Guidance#agent-configuration).
+- the full list of [monitors available](https://github.com/signalfx/signalfx-agent/tree/main/docs/monitors) with their own specific documentation.
+
+In addition, all of these monitors are still available in the [Splunk Otel Collector](https://github.com/signalfx/splunk-otel-collector),
+the Splunk [distro of OpenTelemetry Collector](https://opentelemetry.io/docs/concepts/distributions/) which replaces SignalFx Smart Agent,
+thanks to the internal [Smart Agent Receiver](https://github.com/signalfx/splunk-otel-collector/tree/main/internal/receiver/smartagentreceiver).
+
+As a result:
+- any SignalFx Smart Agent monitor are compatible with the new agent OpenTelemetry Collector and related modules in this repository keep `smart-agent` as source name.
+- any OpenTelemetry receiver not based on an existing Smart Agent monitor is not available from old agent so related modules in this repository use `otel-collector` as source name.
 
 
-There is no SignalFx official integration for `jmx` but there is still a
-[monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/collectd-genericjmx.html) to use.
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 ### Agent
 
-The agent requires to [Java
-plugin](https://docs.signalfx.com/en/latest/integrations/integrations-reference/integrations.java.html)
-for Collectd which is already installed in the [SignalFx Smart
-Agent](https://github.com/signalfx/signalfx-agent/).
+The agent requires the [Collectd Java plugin](https://collectd.org/wiki/index.php/Plugin:Java)
+which should already be installed with the [SignalFx Smart Agent](https://github.com/signalfx/signalfx-agent/).
 
 ### Monitors
 
@@ -128,8 +140,8 @@ application. Depending on your application you should add following parameters a
 
 
 To filter only required metrics for the detectors of this module, add the
-[datapointsToExclude](https://docs.signalfx.com/en/latest/integrations/agent/filtering.html) parameter to
-the corresponding monitor configuration:
+[datapointsToExclude](https://docs.splunk.com/observability/gdi/smart-agent/smart-agent-resources.html#filtering-data-using-the-smart-agent)
+parameter to the corresponding monitor configuration:
 
 ```yaml
     datapointsToExclude:
@@ -150,5 +162,7 @@ configuration for metrology or troubleshooting purposes.
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [Smart Agent monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/collectd-genericjmx.html)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [Smart Agent monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-genericjmx.md)
+* [Splunk Observability integration](https://docs.splunk.com/Observability/gdi/genericjmx/genericjmx.html)
 * [Collectd plugin](https://collectd.org/wiki/index.php/Plugin:GenericJMX)

--- a/modules/smart-agent_genericjmx/conf/readme.yaml
+++ b/modules/smart-agent_genericjmx/conf/readme.yaml
@@ -1,12 +1,12 @@
 documentations:
   - name: Smart Agent monitor
-    url: 'https://docs.signalfx.com/en/latest/integrations/agent/monitors/collectd-genericjmx.html'
+    url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-genericjmx.md'
   - name: Collectd plugin
     url: 'https://collectd.org/wiki/index.php/Plugin:GenericJMX'
 
 source_doc: |
   There is no SignalFx official integration for `jmx` but there is still a
-  [monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/collectd-genericjmx.html) to use.
+  [monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-genericjmx.md) to use.
 
   ### Agent
 

--- a/modules/smart-agent_genericjmx/conf/readme.yaml
+++ b/modules/smart-agent_genericjmx/conf/readme.yaml
@@ -1,19 +1,16 @@
 documentations:
   - name: Smart Agent monitor
     url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-genericjmx.md'
+  - name: Splunk Observability integration
+    url: 'https://docs.splunk.com/Observability/gdi/genericjmx/genericjmx.html'
   - name: Collectd plugin
     url: 'https://collectd.org/wiki/index.php/Plugin:GenericJMX'
 
 source_doc: |
-  There is no SignalFx official integration for `jmx` but there is still a
-  [monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-genericjmx.md) to use.
-
   ### Agent
 
-  The agent requires to [Java
-  plugin](https://docs.signalfx.com/en/latest/integrations/integrations-reference/integrations.java.html)
-  for Collectd which is already installed in the [SignalFx Smart
-  Agent](https://github.com/signalfx/signalfx-agent/).
+  The agent requires the [Collectd Java plugin](https://collectd.org/wiki/index.php/Plugin:Java)
+  which should already be installed with the [SignalFx Smart Agent](https://github.com/signalfx/signalfx-agent/).
 
   ### Monitors
 

--- a/modules/smart-agent_haproxy/README.md
+++ b/modules/smart-agent_haproxy/README.md
@@ -49,8 +49,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -85,16 +85,29 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-[monitors](https://docs.signalfx.com/en/latest/integrations/agent/monitors/_monitor-config.html)
-available in the [SignalFx Smart
-Agent](https://github.com/signalfx/signalfx-agent). Check the [Related documentation](#related-documentation) section for more
-information including the official documentation of this monitor.
+This module deploys detectors using metrics reported by the
+[SignalFx Smart Agent Monitors](https://github.com/signalfx/signalfx-agent#monitors).
+
+Even if the [Smart Agent is deprecated](https://github.com/signalfx/signalfx-agent/blob/main/docs/smartagent-deprecation-notice.md)
+it remains an efficient, lightweight and simple monitoring agent which still works fine.
+See the [official documentation](https://docs.splunk.com/Observability/gdi/smart-agent/smart-agent-resources.html) for more information
+about this agent.
+You might find the related following documentations useful:
+- the global level [agent configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/config-schema.md)
+- the [monitor level configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitor-config.md)
+- the internal [agent configuration tips](https://github.com/claranet/terraform-signalfx-detectors/wiki/Guidance#agent-configuration).
+- the full list of [monitors available](https://github.com/signalfx/signalfx-agent/tree/main/docs/monitors) with their own specific documentation.
+
+In addition, all of these monitors are still available in the [Splunk Otel Collector](https://github.com/signalfx/splunk-otel-collector),
+the Splunk [distro of OpenTelemetry Collector](https://opentelemetry.io/docs/concepts/distributions/) which replaces SignalFx Smart Agent,
+thanks to the internal [Smart Agent Receiver](https://github.com/signalfx/splunk-otel-collector/tree/main/internal/receiver/smartagentreceiver).
+
+As a result:
+- any SignalFx Smart Agent monitor are compatible with the new agent OpenTelemetry Collector and related modules in this repository keep `smart-agent` as source name.
+- any OpenTelemetry receiver not based on an existing Smart Agent monitor is not available from old agent so related modules in this repository use `otel-collector` as source name.
 
 
-Check the [integration
-documentation](https://docs.signalfx.com/en/latest/integrations/integrations-reference/integrations.haproxy.html)
-in addition to the monitor one which it uses.
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 ### Monitors
 
@@ -112,8 +125,8 @@ The first one is available only from agent version `v5.3.2`.
 
 
 To filter only required metrics for the detectors of this module, add the
-[datapointsToExclude](https://docs.signalfx.com/en/latest/integrations/agent/filtering.html) parameter to
-the corresponding monitor configuration:
+[datapointsToExclude](https://docs.splunk.com/observability/gdi/smart-agent/smart-agent-resources.html#filtering-data-using-the-smart-agent)
+parameter to the corresponding monitor configuration:
 
 ```yaml
     datapointsToExclude:
@@ -134,7 +147,7 @@ the corresponding monitor configuration:
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [Smart Agent monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/collectd-haproxy.html)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [Smart Agent monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/haproxy.md)
+* [Splunk Observability integration](https://docs.splunk.com/Observability/gdi/haproxy/haproxy.html)
 * [HAproxy stats page](https://www.haproxy.com/blog/exploring-the-haproxy-stats-page/)
-* [Collectd plugin](https://collectd.org/wiki/index.php/Haproxy)
-* [Collection script](https://github.com/signalfx/collectd-haproxy)

--- a/modules/smart-agent_haproxy/README.md
+++ b/modules/smart-agent_haproxy/README.md
@@ -16,7 +16,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -33,7 +33,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -49,7 +49,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -60,7 +60,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/smart-agent_haproxy/conf/readme.yaml
+++ b/modules/smart-agent_haproxy/conf/readme.yaml
@@ -1,6 +1,6 @@
 documentations:
   - name: Smart Agent monitor
-    url: 'https://docs.signalfx.com/en/latest/integrations/agent/monitors/collectd-haproxy.html'
+    url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-haproxy.md'
   - name: HAproxy stats page
     url: 'https://www.haproxy.com/blog/exploring-the-haproxy-stats-page/'
   - name: Collectd plugin

--- a/modules/smart-agent_haproxy/conf/readme.yaml
+++ b/modules/smart-agent_haproxy/conf/readme.yaml
@@ -1,18 +1,12 @@
 documentations:
   - name: Smart Agent monitor
-    url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-haproxy.md'
+    url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/haproxy.md'
+  - name: Splunk Observability integration
+    url: 'https://docs.splunk.com/Observability/gdi/haproxy/haproxy.html'
   - name: HAproxy stats page
     url: 'https://www.haproxy.com/blog/exploring-the-haproxy-stats-page/'
-  - name: Collectd plugin
-    url: 'https://collectd.org/wiki/index.php/Haproxy'
-  - name: Collection script
-    url: 'https://github.com/signalfx/collectd-haproxy'
 
 source_doc: |
-  Check the [integration
-  documentation](https://docs.signalfx.com/en/latest/integrations/integrations-reference/integrations.haproxy.html)
-  in addition to the monitor one which it uses.
-
   ### Monitors
 
   You have to enable the following `extraMetrics` in your monitor configuration:

--- a/modules/smart-agent_health-checker/README.md
+++ b/modules/smart-agent_health-checker/README.md
@@ -16,7 +16,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -33,7 +33,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -49,7 +49,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -60,7 +60,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables-gen.tf](variables-gen.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/smart-agent_health-checker/README.md
+++ b/modules/smart-agent_health-checker/README.md
@@ -49,8 +49,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -81,16 +81,31 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-[monitors](https://docs.signalfx.com/en/latest/integrations/agent/monitors/_monitor-config.html)
-available in the [SignalFx Smart
-Agent](https://github.com/signalfx/signalfx-agent). Check the [Related documentation](#related-documentation) section for more
-information including the official documentation of this monitor.
+This module deploys detectors using metrics reported by the
+[SignalFx Smart Agent Monitors](https://github.com/signalfx/signalfx-agent#monitors).
 
+Even if the [Smart Agent is deprecated](https://github.com/signalfx/signalfx-agent/blob/main/docs/smartagent-deprecation-notice.md)
+it remains an efficient, lightweight and simple monitoring agent which still works fine.
+See the [official documentation](https://docs.splunk.com/Observability/gdi/smart-agent/smart-agent-resources.html) for more information
+about this agent.
+You might find the related following documentations useful:
+- the global level [agent configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/config-schema.md)
+- the [monitor level configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitor-config.md)
+- the internal [agent configuration tips](https://github.com/claranet/terraform-signalfx-detectors/wiki/Guidance#agent-configuration).
+- the full list of [monitors available](https://github.com/signalfx/signalfx-agent/tree/main/docs/monitors) with their own specific documentation.
+
+In addition, all of these monitors are still available in the [Splunk Otel Collector](https://github.com/signalfx/splunk-otel-collector),
+the Splunk [distro of OpenTelemetry Collector](https://opentelemetry.io/docs/concepts/distributions/) which replaces SignalFx Smart Agent,
+thanks to the internal [Smart Agent Receiver](https://github.com/signalfx/splunk-otel-collector/tree/main/internal/receiver/smartagentreceiver).
+
+As a result:
+- any SignalFx Smart Agent monitor are compatible with the new agent OpenTelemetry Collector and related modules in this repository keep `smart-agent` as source name.
+- any OpenTelemetry receiver not based on an existing Smart Agent monitor is not available from old agent so related modules in this repository use `otel-collector` as source name.
+
+
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 ### Monitor
-
-The detector of this module is based on metrics reported by the [collectd/health-checker](https://docs.signalfx.com/en/latest/integrations/agent/monitors/collectd-health-checker.html) monitor.
 
 It can monitor:
   * network port (use `health_checker_value`)
@@ -116,8 +131,8 @@ I advise you to read the [collectd source code of health_checker.py](https://git
 
 
 To filter only required metrics for the detectors of this module, add the
-[datapointsToExclude](https://docs.signalfx.com/en/latest/integrations/agent/filtering.html) parameter to
-the corresponding monitor configuration:
+[datapointsToExclude](https://docs.splunk.com/observability/gdi/smart-agent/smart-agent-resources.html#filtering-data-using-the-smart-agent)
+parameter to the corresponding monitor configuration:
 
 ```yaml
     datapointsToExclude:
@@ -134,5 +149,7 @@ the corresponding monitor configuration:
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [Smart Agent monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/collectd-health-checker.html)
-* [Collectd source code health_checker.py](https://github.com/signalfx/collectd-health_checker/blob/master/health_checker.py)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [Smart Agent monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-health-checker.md)
+* [Splunk Observability integration](https://docs.splunk.com/Observability/gdi/health-checker/health-checker.html)
+* [Collectd plugin script](https://github.com/signalfx/collectd-health_checker)

--- a/modules/smart-agent_health-checker/conf/readme.yaml
+++ b/modules/smart-agent_health-checker/conf/readme.yaml
@@ -1,13 +1,13 @@
 documentations:
   - name: Smart Agent monitor
-    url: https://docs.signalfx.com/en/latest/integrations/agent/monitors/collectd-health-checker.html
+    url: https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-health-checker.md
   - name: Collectd source code health_checker.py
     url: https://github.com/signalfx/collectd-health_checker/blob/master/health_checker.py
 
 source_doc: |
   ### Monitor
 
-  The detector of this module is based on metrics reported by the [collectd/health-checker](https://docs.signalfx.com/en/latest/integrations/agent/monitors/collectd-health-checker.html) monitor.
+  The detector of this module is based on metrics reported by the [collectd/health-checker](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-health-checker.md) monitor.
 
   It can monitor:
     * network port (use `health_checker_value`)

--- a/modules/smart-agent_health-checker/conf/readme.yaml
+++ b/modules/smart-agent_health-checker/conf/readme.yaml
@@ -1,13 +1,13 @@
 documentations:
   - name: Smart Agent monitor
     url: https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-health-checker.md
-  - name: Collectd source code health_checker.py
-    url: https://github.com/signalfx/collectd-health_checker/blob/master/health_checker.py
+  - name: Splunk Observability integration
+    url: 'https://docs.splunk.com/Observability/gdi/health-checker/health-checker.html'
+  - name: Collectd plugin script
+    url: https://github.com/signalfx/collectd-health_checker
 
 source_doc: |
   ### Monitor
-
-  The detector of this module is based on metrics reported by the [collectd/health-checker](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-health-checker.md) monitor.
 
   It can monitor:
     * network port (use `health_checker_value`)

--- a/modules/smart-agent_http/README.md
+++ b/modules/smart-agent_http/README.md
@@ -17,7 +17,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -34,7 +34,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -50,7 +50,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -61,7 +61,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables-gen.tf](variables-gen.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/smart-agent_http/README.md
+++ b/modules/smart-agent_http/README.md
@@ -50,8 +50,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -87,15 +87,29 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-[monitors](https://docs.signalfx.com/en/latest/integrations/agent/monitors/_monitor-config.html)
-available in the [SignalFx Smart
-Agent](https://github.com/signalfx/signalfx-agent). Check the [Related documentation](#related-documentation) section for more
-information including the official documentation of this monitor.
+This module deploys detectors using metrics reported by the
+[SignalFx Smart Agent Monitors](https://github.com/signalfx/signalfx-agent#monitors).
+
+Even if the [Smart Agent is deprecated](https://github.com/signalfx/signalfx-agent/blob/main/docs/smartagent-deprecation-notice.md)
+it remains an efficient, lightweight and simple monitoring agent which still works fine.
+See the [official documentation](https://docs.splunk.com/Observability/gdi/smart-agent/smart-agent-resources.html) for more information
+about this agent.
+You might find the related following documentations useful:
+- the global level [agent configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/config-schema.md)
+- the [monitor level configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitor-config.md)
+- the internal [agent configuration tips](https://github.com/claranet/terraform-signalfx-detectors/wiki/Guidance#agent-configuration).
+- the full list of [monitors available](https://github.com/signalfx/signalfx-agent/tree/main/docs/monitors) with their own specific documentation.
+
+In addition, all of these monitors are still available in the [Splunk Otel Collector](https://github.com/signalfx/splunk-otel-collector),
+the Splunk [distro of OpenTelemetry Collector](https://opentelemetry.io/docs/concepts/distributions/) which replaces SignalFx Smart Agent,
+thanks to the internal [Smart Agent Receiver](https://github.com/signalfx/splunk-otel-collector/tree/main/internal/receiver/smartagentreceiver).
+
+As a result:
+- any SignalFx Smart Agent monitor are compatible with the new agent OpenTelemetry Collector and related modules in this repository keep `smart-agent` as source name.
+- any OpenTelemetry receiver not based on an existing Smart Agent monitor is not available from old agent so related modules in this repository use `otel-collector` as source name.
 
 
-There is no SignalFx official integration for `http` but there is still a
-[monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/http.html) to use.
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 ### Monitors
 
@@ -109,8 +123,8 @@ Check the examples in the official monitor documentation and the Notes section b
 
 
 To filter only required metrics for the detectors of this module, add the
-[datapointsToExclude](https://docs.signalfx.com/en/latest/integrations/agent/filtering.html) parameter to
-the corresponding monitor configuration:
+[datapointsToExclude](https://docs.splunk.com/observability/gdi/smart-agent/smart-agent-resources.html#filtering-data-using-the-smart-agent)
+parameter to the corresponding monitor configuration:
 
 ```yaml
     datapointsToExclude:
@@ -164,7 +178,7 @@ to `min`).
 
 * If you have multiple webhecks which require different sensitivity level so you can add
 common dimension using `addExtraDimensions` to set of similar monitors on agent. Then,
-you can import as many times this module with different value for `filter_custom_*` variables
+you can import as many times this module with different value for `filtering_custom` variable
 to match these different dimension(s) value(s).
 
 * The certificate metrics will be collected only if `useHTTPS: true` (or if using the
@@ -178,4 +192,5 @@ as generic purpose but `disabled` variables allow to change this.
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [Smart Agent monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/http.html)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [Smart Agent monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/http.md)

--- a/modules/smart-agent_http/conf/readme.yaml
+++ b/modules/smart-agent_http/conf/readme.yaml
@@ -1,10 +1,10 @@
 documentations:
   - name: Smart Agent monitor
-    url: 'https://docs.signalfx.com/en/latest/integrations/agent/monitors/http.html'
+    url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/http.md'
 
 source_doc: |
   There is no SignalFx official integration for `http` but there is still a
-  [monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/http.html) to use.
+  [monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/http.md) to use.
 
   ### Monitors
 

--- a/modules/smart-agent_http/conf/readme.yaml
+++ b/modules/smart-agent_http/conf/readme.yaml
@@ -50,7 +50,7 @@ notes: |
 
   * If you have multiple webhecks which require different sensitivity level so you can add
   common dimension using `addExtraDimensions` to set of similar monitors on agent. Then,
-  you can import as many times this module with different value for `filter_custom_*` variables
+  you can import as many times this module with different value for `filtering_custom` variable
   to match these different dimension(s) value(s).
 
   * The certificate metrics will be collected only if `useHTTPS: true` (or if using the

--- a/modules/smart-agent_http/conf/readme.yaml
+++ b/modules/smart-agent_http/conf/readme.yaml
@@ -3,9 +3,6 @@ documentations:
     url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/http.md'
 
 source_doc: |
-  There is no SignalFx official integration for `http` but there is still a
-  [monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/http.md) to use.
-
   ### Monitors
 
   This monitor is only available from agent version `>= 5.2.0` but it has evolved since and we

--- a/modules/smart-agent_kubernetes-apiserver/README.md
+++ b/modules/smart-agent_kubernetes-apiserver/README.md
@@ -49,8 +49,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -80,24 +80,38 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-[monitors](https://docs.signalfx.com/en/latest/integrations/agent/monitors/_monitor-config.html)
-available in the [SignalFx Smart
-Agent](https://github.com/signalfx/signalfx-agent). Check the [Related documentation](#related-documentation) section for more
-information including the official documentation of this monitor.
+This module deploys detectors using metrics reported by the
+[SignalFx Smart Agent Monitors](https://github.com/signalfx/signalfx-agent#monitors).
+
+Even if the [Smart Agent is deprecated](https://github.com/signalfx/signalfx-agent/blob/main/docs/smartagent-deprecation-notice.md)
+it remains an efficient, lightweight and simple monitoring agent which still works fine.
+See the [official documentation](https://docs.splunk.com/Observability/gdi/smart-agent/smart-agent-resources.html) for more information
+about this agent.
+You might find the related following documentations useful:
+- the global level [agent configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/config-schema.md)
+- the [monitor level configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitor-config.md)
+- the internal [agent configuration tips](https://github.com/claranet/terraform-signalfx-detectors/wiki/Guidance#agent-configuration).
+- the full list of [monitors available](https://github.com/signalfx/signalfx-agent/tree/main/docs/monitors) with their own specific documentation.
+
+In addition, all of these monitors are still available in the [Splunk Otel Collector](https://github.com/signalfx/splunk-otel-collector),
+the Splunk [distro of OpenTelemetry Collector](https://opentelemetry.io/docs/concepts/distributions/) which replaces SignalFx Smart Agent,
+thanks to the internal [Smart Agent Receiver](https://github.com/signalfx/splunk-otel-collector/tree/main/internal/receiver/smartagentreceiver).
+
+As a result:
+- any SignalFx Smart Agent monitor are compatible with the new agent OpenTelemetry Collector and related modules in this repository keep `smart-agent` as source name.
+- any OpenTelemetry receiver not based on an existing Smart Agent monitor is not available from old agent so related modules in this repository use `otel-collector` as source name.
 
 
-Follow the
-[kubernetes-apiserver](https://docs.signalfx.com/en/latest/integrations/agent/monitors/kubernetes-apiserver.html)
-monitor configuration to collect metrics.
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
+
 
 
 ### Metrics
 
 
 To filter only required metrics for the detectors of this module, add the
-[datapointsToExclude](https://docs.signalfx.com/en/latest/integrations/agent/filtering.html) parameter to
-the corresponding monitor configuration:
+[datapointsToExclude](https://docs.splunk.com/observability/gdi/smart-agent/smart-agent-resources.html#filtering-data-using-the-smart-agent)
+parameter to the corresponding monitor configuration:
 
 ```yaml
     datapointsToExclude:
@@ -123,4 +137,6 @@ provider availability.
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [Smart Agent monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/kubernetes-apiserver.html)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [Smart Agent monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/kubernetes-apiserver.md)
+* [Splunk Observability integration](https://docs.splunk.com/Observability/gdi/kubernetes-apiserver/kubernetes-apiserver.html)

--- a/modules/smart-agent_kubernetes-apiserver/README.md
+++ b/modules/smart-agent_kubernetes-apiserver/README.md
@@ -16,7 +16,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -33,7 +33,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -49,7 +49,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -60,7 +60,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/smart-agent_kubernetes-apiserver/conf/readme.yaml
+++ b/modules/smart-agent_kubernetes-apiserver/conf/readme.yaml
@@ -1,10 +1,10 @@
 documentations:
   - name: Smart Agent monitor
-    url: 'https://docs.signalfx.com/en/latest/integrations/agent/monitors/kubernetes-apiserver.html'
+    url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/kubernetes-apiserver.md'
 
 source_doc: |
   Follow the
-  [kubernetes-apiserver](https://docs.signalfx.com/en/latest/integrations/agent/monitors/kubernetes-apiserver.html)
+  [kubernetes-apiserver](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/kubernetes-apiserver.md)
   monitor configuration to collect metrics.
 
 notes: |

--- a/modules/smart-agent_kubernetes-apiserver/conf/readme.yaml
+++ b/modules/smart-agent_kubernetes-apiserver/conf/readme.yaml
@@ -1,11 +1,8 @@
 documentations:
   - name: Smart Agent monitor
     url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/kubernetes-apiserver.md'
-
-source_doc: |
-  Follow the
-  [kubernetes-apiserver](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/kubernetes-apiserver.md)
-  monitor configuration to collect metrics.
+  - name: Splunk Observability integration
+    url: 'https://docs.splunk.com/Observability/gdi/kubernetes-apiserver/kubernetes-apiserver.html'
 
 notes: |
   For now this module only contains an heartbeat detector to check the health of the api server.

--- a/modules/smart-agent_kubernetes-common/README.md
+++ b/modules/smart-agent_kubernetes-common/README.md
@@ -22,7 +22,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -39,7 +39,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -55,7 +55,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -66,7 +66,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables-gen.tf](variables-gen.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/smart-agent_kubernetes-common/README.md
+++ b/modules/smart-agent_kubernetes-common/README.md
@@ -55,8 +55,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -101,17 +101,34 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-[monitors](https://docs.signalfx.com/en/latest/integrations/agent/monitors/_monitor-config.html)
-available in the [SignalFx Smart
-Agent](https://github.com/signalfx/signalfx-agent). Check the [Related documentation](#related-documentation) section for more
-information including the official documentation of this monitor.
+This module deploys detectors using metrics reported by the
+[SignalFx Smart Agent Monitors](https://github.com/signalfx/signalfx-agent#monitors).
 
+Even if the [Smart Agent is deprecated](https://github.com/signalfx/signalfx-agent/blob/main/docs/smartagent-deprecation-notice.md)
+it remains an efficient, lightweight and simple monitoring agent which still works fine.
+See the [official documentation](https://docs.splunk.com/Observability/gdi/smart-agent/smart-agent-resources.html) for more information
+about this agent.
+You might find the related following documentations useful:
+- the global level [agent configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/config-schema.md)
+- the [monitor level configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitor-config.md)
+- the internal [agent configuration tips](https://github.com/claranet/terraform-signalfx-detectors/wiki/Guidance#agent-configuration).
+- the full list of [monitors available](https://github.com/signalfx/signalfx-agent/tree/main/docs/monitors) with their own specific documentation.
+
+In addition, all of these monitors are still available in the [Splunk Otel Collector](https://github.com/signalfx/splunk-otel-collector),
+the Splunk [distro of OpenTelemetry Collector](https://opentelemetry.io/docs/concepts/distributions/) which replaces SignalFx Smart Agent,
+thanks to the internal [Smart Agent Receiver](https://github.com/signalfx/splunk-otel-collector/tree/main/internal/receiver/smartagentreceiver).
+
+As a result:
+- any SignalFx Smart Agent monitor are compatible with the new agent OpenTelemetry Collector and related modules in this repository keep `smart-agent` as source name.
+- any OpenTelemetry receiver not based on an existing Smart Agent monitor is not available from old agent so related modules in this repository use `otel-collector` as source name.
+
+
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 ### Agent
 
 Here is the official [main
-documentation](https://docs.signalfx.com/en/latest/integrations/integrations-reference/integrations.kubernetes.html) for
+documentation](https://github.com/signalfx/integrations/blob/master/kubernetes/SMART_AGENT_MONITOR.md) for
 kubernetes including the `signalfx-agent` installation which must be installed as
 [daemonset](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/) on your cluster.
 
@@ -119,12 +136,9 @@ kubernetes including the `signalfx-agent` installation which must be installed a
 
 The detectors in this module are based on metrics reported by the following monitors:
 
-* [kubelet-metrics](https://docs.signalfx.com/en/latest/integrations/agent/monitors/kubelet-metrics.html) for Kubernetes `>= 1.18`
-* [kubelet-stats](https://docs.signalfx.com/en/latest/integrations/agent/monitors/kubelet-stats.html) for Kubernetes `< 1.18
-* [kubernetes-cluster](https://docs.signalfx.com/en/latest/integrations/agent/monitors/kubernetes-cluster.html)
-
-[Others](https://docs.signalfx.com/en/latest/integrations/kubernetes/k8s-monitors-observers.html#monitors-observers)
-exist to increase visibility or may be in future to enrich this modules or create new ones.
+* [kubelet-metrics](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/kubelet-metrics.md) for Kubernetes `>= 1.18`
+* [kubelet-stats](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/kubelet-stats.md) for Kubernetes `< 1.18
+* [kubernetes-cluster](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/kubernetes-cluster.md)
 
 The `kubernetes-cluster` requires to enable the following `extraMetrics`:
 
@@ -243,8 +257,8 @@ __Note__: `clusterExtraMetrics` option is only available from the `1.7.1` versio
 
 
 To filter only required metrics for the detectors of this module, add the
-[datapointsToExclude](https://docs.signalfx.com/en/latest/integrations/agent/filtering.html) parameter to
-the corresponding monitor configuration:
+[datapointsToExclude](https://docs.splunk.com/observability/gdi/smart-agent/smart-agent-resources.html#filtering-data-using-the-smart-agent)
+parameter to the corresponding monitor configuration:
 
 ```yaml
     datapointsToExclude:
@@ -301,6 +315,8 @@ modules covering more data sources like `kubernetes-volumes` or use cases like `
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [Smart Agent monitor kubernetes-cluster](https://docs.signalfx.com/en/latest/integrations/agent/monitors/kubernetes-cluster.html)
-* [Smart Agent monitor kubelet-stats](https://docs.signalfx.com/en/latest/integrations/agent/monitors/kubelet-stats.html)
-* [Smart Agent monitor kubelet-metrics](https://docs.signalfx.com/en/latest/integrations/agent/monitors/kubelet-metrics.html)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [Smart Agent monitor kubernetes-cluster](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/kubernetes-cluster.md)
+* [Smart Agent monitor kubelet-stats](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/kubelet-stats.md)
+* [Smart Agent monitor kubelet-metrics](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/kubelet-metrics.md)
+* [Splunk Observability integration](https://docs.splunk.com/Observability/gdi/kubernetes-cluster/kubernetes-cluster.html)

--- a/modules/smart-agent_kubernetes-common/conf/readme.yaml
+++ b/modules/smart-agent_kubernetes-common/conf/readme.yaml
@@ -2,11 +2,11 @@ documentations:
 
 
   - name: Smart Agent monitor kubernetes-cluster
-    url: 'https://docs.signalfx.com/en/latest/integrations/agent/monitors/kubernetes-cluster.html'
+    url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/kubernetes-cluster.md'
   - name: Smart Agent monitor kubelet-stats
-    url: 'https://docs.signalfx.com/en/latest/integrations/agent/monitors/kubelet-stats.html'
+    url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/kubelet-stats.md'
   - name: Smart Agent monitor kubelet-metrics
-    url: 'https://docs.signalfx.com/en/latest/integrations/agent/monitors/kubelet-metrics.html'
+    url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/kubelet-metrics.md'
 
 source_doc: |
   ### Agent
@@ -20,9 +20,9 @@ source_doc: |
 
   The detectors in this module are based on metrics reported by the following monitors:
 
-  * [kubelet-metrics](https://docs.signalfx.com/en/latest/integrations/agent/monitors/kubelet-metrics.html) for Kubernetes `>= 1.18`
-  * [kubelet-stats](https://docs.signalfx.com/en/latest/integrations/agent/monitors/kubelet-stats.html) for Kubernetes `< 1.18
-  * [kubernetes-cluster](https://docs.signalfx.com/en/latest/integrations/agent/monitors/kubernetes-cluster.html)
+  * [kubelet-metrics](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/kubelet-metrics.md) for Kubernetes `>= 1.18`
+  * [kubelet-stats](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/kubelet-stats.md) for Kubernetes `< 1.18
+  * [kubernetes-cluster](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/kubernetes-cluster.md)
 
   [Others](https://docs.signalfx.com/en/latest/integrations/kubernetes/k8s-monitors-observers.html#monitors-observers)
   exist to increase visibility or may be in future to enrich this modules or create new ones.

--- a/modules/smart-agent_kubernetes-common/conf/readme.yaml
+++ b/modules/smart-agent_kubernetes-common/conf/readme.yaml
@@ -1,18 +1,18 @@
 documentations:
-
-
   - name: Smart Agent monitor kubernetes-cluster
     url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/kubernetes-cluster.md'
   - name: Smart Agent monitor kubelet-stats
     url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/kubelet-stats.md'
   - name: Smart Agent monitor kubelet-metrics
     url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/kubelet-metrics.md'
+  - name: Splunk Observability integration
+    url: 'https://docs.splunk.com/Observability/gdi/kubernetes-cluster/kubernetes-cluster.html'
 
 source_doc: |
   ### Agent
 
   Here is the official [main
-  documentation](https://docs.signalfx.com/en/latest/integrations/integrations-reference/integrations.kubernetes.html) for
+  documentation](https://github.com/signalfx/integrations/blob/master/kubernetes/SMART_AGENT_MONITOR.md) for
   kubernetes including the `signalfx-agent` installation which must be installed as
   [daemonset](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/) on your cluster.
 
@@ -23,9 +23,6 @@ source_doc: |
   * [kubelet-metrics](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/kubelet-metrics.md) for Kubernetes `>= 1.18`
   * [kubelet-stats](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/kubelet-stats.md) for Kubernetes `< 1.18
   * [kubernetes-cluster](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/kubernetes-cluster.md)
-
-  [Others](https://docs.signalfx.com/en/latest/integrations/kubernetes/k8s-monitors-observers.html#monitors-observers)
-  exist to increase visibility or may be in future to enrich this modules or create new ones.
 
   The `kubernetes-cluster` requires to enable the following `extraMetrics`:
 

--- a/modules/smart-agent_kubernetes-velero/README.md
+++ b/modules/smart-agent_kubernetes-velero/README.md
@@ -19,7 +19,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -36,7 +36,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -52,7 +52,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -63,7 +63,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/smart-agent_kubernetes-velero/README.md
+++ b/modules/smart-agent_kubernetes-velero/README.md
@@ -7,7 +7,6 @@
 - [How to use this module?](#how-to-use-this-module)
 - [What are the available detectors in this module?](#what-are-the-available-detectors-in-this-module)
 - [How to collect required metrics?](#how-to-collect-required-metrics)
-  - [Agent](#agent)
   - [Monitors](#monitors)
   - [Velero](#velero)
   - [Examples](#examples)
@@ -53,8 +52,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -88,32 +87,38 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-[monitors](https://docs.signalfx.com/en/latest/integrations/agent/monitors/_monitor-config.html)
-available in the [SignalFx Smart
-Agent](https://github.com/signalfx/signalfx-agent). Check the [Related documentation](#related-documentation) section for more
-information including the official documentation of this monitor.
+This module deploys detectors using metrics reported by the
+[SignalFx Smart Agent Monitors](https://github.com/signalfx/signalfx-agent#monitors).
+
+Even if the [Smart Agent is deprecated](https://github.com/signalfx/signalfx-agent/blob/main/docs/smartagent-deprecation-notice.md)
+it remains an efficient, lightweight and simple monitoring agent which still works fine.
+See the [official documentation](https://docs.splunk.com/Observability/gdi/smart-agent/smart-agent-resources.html) for more information
+about this agent.
+You might find the related following documentations useful:
+- the global level [agent configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/config-schema.md)
+- the [monitor level configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitor-config.md)
+- the internal [agent configuration tips](https://github.com/claranet/terraform-signalfx-detectors/wiki/Guidance#agent-configuration).
+- the full list of [monitors available](https://github.com/signalfx/signalfx-agent/tree/main/docs/monitors) with their own specific documentation.
+
+In addition, all of these monitors are still available in the [Splunk Otel Collector](https://github.com/signalfx/splunk-otel-collector),
+the Splunk [distro of OpenTelemetry Collector](https://opentelemetry.io/docs/concepts/distributions/) which replaces SignalFx Smart Agent,
+thanks to the internal [Smart Agent Receiver](https://github.com/signalfx/splunk-otel-collector/tree/main/internal/receiver/smartagentreceiver).
+
+As a result:
+- any SignalFx Smart Agent monitor are compatible with the new agent OpenTelemetry Collector and related modules in this repository keep `smart-agent` as source name.
+- any OpenTelemetry receiver not based on an existing Smart Agent monitor is not available from old agent so related modules in this repository use `otel-collector` as source name.
 
 
-### Agent
-
-Here is the official [main
-documentation](https://docs.signalfx.com/en/latest/integrations/integrations-reference/integrations.kubernetes.html) for
-kubernetes including the `signalfx-agent` installation which must be installed as
-[daemonset](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/) on your cluster.
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 ### Monitors
 
-The detectors in this module are based on metrics reported by the following monitors:
-
-* [prometheus/velero](https://docs.signalfx.com/en/latest/integrations/agent/monitors/prometheus-velero.html)
-
 This monitor is only available for agent `>= 5.5.5` but it is basically a wrapper around [prometheus exporter
-monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/prometheus-exporter.html) to filter important
+monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/prometheus-exporter.md) to filter important
 metrics while prometheus metrics are considered as custom metrics which could have an impact on SignalFx billing.
 
 You must configure it for every velero deployments so this is almost sure you will need to use [service
-discovery](https://docs.signalfx.com/en/latest/integrations/agent/auto-discovery.html) to do it dynamically.
+discovery](https://github.com/signalfx/signalfx-agent/blob/main/docs/auto-discovery.md) to do it dynamically.
 
 Detectors in this module will at least require these metrics:
 
@@ -149,8 +154,8 @@ monitors:
 
 
 To filter only required metrics for the detectors of this module, add the
-[datapointsToExclude](https://docs.signalfx.com/en/latest/integrations/agent/filtering.html) parameter to
-the corresponding monitor configuration:
+[datapointsToExclude](https://docs.splunk.com/observability/gdi/smart-agent/smart-agent-resources.html#filtering-data-using-the-smart-agent)
+parameter to the corresponding monitor configuration:
 
 ```yaml
     datapointsToExclude:
@@ -183,7 +188,7 @@ monitors:
         - '!velero_restore_success_total'
 ```
 
-It uses whitelist [filtering](https://docs.signalfx.com/en/latest/integrations/agent/filtering.html)
+It uses whitelist [filtering](https://github.com/signalfx/signalfx-agent/blob/main/docs/filtering.md)
 to keep only interesting metrics. The last one is not required by this module.
 
 You can replace `prometheus/velero` by `prometheus-exporter` to make this module works
@@ -194,4 +199,6 @@ with agent version prior `5.5.5`.
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [Smart Agent monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/prometheus-velero.html)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [Smart Agent monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/prometheus-velero.md)
+* [Splunk Observability integration](https://docs.splunk.com/Observability/gdi/velero/prometheus-velero.html)

--- a/modules/smart-agent_kubernetes-velero/conf/readme.yaml
+++ b/modules/smart-agent_kubernetes-velero/conf/readme.yaml
@@ -1,6 +1,6 @@
 documentations:
   - name: Smart Agent monitor
-    url: 'https://docs.signalfx.com/en/latest/integrations/agent/monitors/prometheus-velero.html'
+    url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/prometheus-velero.md'
 
 source_doc: |
   ### Agent
@@ -14,10 +14,10 @@ source_doc: |
 
   The detectors in this module are based on metrics reported by the following monitors:
 
-  * [prometheus/velero](https://docs.signalfx.com/en/latest/integrations/agent/monitors/prometheus-velero.html)
+  * [prometheus/velero](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/prometheus-velero.md)
 
   This monitor is only available for agent `>= 5.5.5` but it is basically a wrapper around [prometheus exporter
-  monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/prometheus-exporter.html) to filter important
+  monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/prometheus-exporter.md) to filter important
   metrics while prometheus metrics are considered as custom metrics which could have an impact on SignalFx billing.
 
   You must configure it for every velero deployments so this is almost sure you will need to use [service

--- a/modules/smart-agent_kubernetes-velero/conf/readme.yaml
+++ b/modules/smart-agent_kubernetes-velero/conf/readme.yaml
@@ -1,27 +1,18 @@
 documentations:
   - name: Smart Agent monitor
     url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/prometheus-velero.md'
+  - name: Splunk Observability integration
+    url: 'https://docs.splunk.com/Observability/gdi/velero/prometheus-velero.html'
 
 source_doc: |
-  ### Agent
-
-  Here is the official [main
-  documentation](https://docs.signalfx.com/en/latest/integrations/integrations-reference/integrations.kubernetes.html) for
-  kubernetes including the `signalfx-agent` installation which must be installed as
-  [daemonset](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/) on your cluster.
-
   ### Monitors
-
-  The detectors in this module are based on metrics reported by the following monitors:
-
-  * [prometheus/velero](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/prometheus-velero.md)
 
   This monitor is only available for agent `>= 5.5.5` but it is basically a wrapper around [prometheus exporter
   monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/prometheus-exporter.md) to filter important
   metrics while prometheus metrics are considered as custom metrics which could have an impact on SignalFx billing.
 
   You must configure it for every velero deployments so this is almost sure you will need to use [service
-  discovery](https://docs.signalfx.com/en/latest/integrations/agent/auto-discovery.html) to do it dynamically.
+  discovery](https://github.com/signalfx/signalfx-agent/blob/main/docs/auto-discovery.md) to do it dynamically.
 
   Detectors in this module will at least require these metrics:
 
@@ -70,7 +61,7 @@ notes: |
           - '!velero_restore_success_total'
   ```
 
-  It uses whitelist [filtering](https://docs.signalfx.com/en/latest/integrations/agent/filtering.html)
+  It uses whitelist [filtering](https://github.com/signalfx/signalfx-agent/blob/main/docs/filtering.md)
   to keep only interesting metrics. The last one is not required by this module.
 
   You can replace `prometheus/velero` by `prometheus-exporter` to make this module works

--- a/modules/smart-agent_kubernetes-volumes/README.md
+++ b/modules/smart-agent_kubernetes-volumes/README.md
@@ -18,7 +18,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -35,7 +35,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -51,7 +51,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -62,7 +62,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/smart-agent_kubernetes-volumes/README.md
+++ b/modules/smart-agent_kubernetes-volumes/README.md
@@ -7,7 +7,6 @@
 - [How to use this module?](#how-to-use-this-module)
 - [What are the available detectors in this module?](#what-are-the-available-detectors-in-this-module)
 - [How to collect required metrics?](#how-to-collect-required-metrics)
-  - [Agent](#agent)
   - [Monitors](#monitors)
   - [Examples](#examples)
   - [Metrics](#metrics)
@@ -52,8 +51,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -84,33 +83,35 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-[monitors](https://docs.signalfx.com/en/latest/integrations/agent/monitors/_monitor-config.html)
-available in the [SignalFx Smart
-Agent](https://github.com/signalfx/signalfx-agent). Check the [Related documentation](#related-documentation) section for more
-information including the official documentation of this monitor.
+This module deploys detectors using metrics reported by the
+[SignalFx Smart Agent Monitors](https://github.com/signalfx/signalfx-agent#monitors).
+
+Even if the [Smart Agent is deprecated](https://github.com/signalfx/signalfx-agent/blob/main/docs/smartagent-deprecation-notice.md)
+it remains an efficient, lightweight and simple monitoring agent which still works fine.
+See the [official documentation](https://docs.splunk.com/Observability/gdi/smart-agent/smart-agent-resources.html) for more information
+about this agent.
+You might find the related following documentations useful:
+- the global level [agent configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/config-schema.md)
+- the [monitor level configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitor-config.md)
+- the internal [agent configuration tips](https://github.com/claranet/terraform-signalfx-detectors/wiki/Guidance#agent-configuration).
+- the full list of [monitors available](https://github.com/signalfx/signalfx-agent/tree/main/docs/monitors) with their own specific documentation.
+
+In addition, all of these monitors are still available in the [Splunk Otel Collector](https://github.com/signalfx/splunk-otel-collector),
+the Splunk [distro of OpenTelemetry Collector](https://opentelemetry.io/docs/concepts/distributions/) which replaces SignalFx Smart Agent,
+thanks to the internal [Smart Agent Receiver](https://github.com/signalfx/splunk-otel-collector/tree/main/internal/receiver/smartagentreceiver).
+
+As a result:
+- any SignalFx Smart Agent monitor are compatible with the new agent OpenTelemetry Collector and related modules in this repository keep `smart-agent` as source name.
+- any OpenTelemetry receiver not based on an existing Smart Agent monitor is not available from old agent so related modules in this repository use `otel-collector` as source name.
 
 
-### Agent
-
-Here is the official [main
-documentation](https://docs.signalfx.com/en/latest/integrations/integrations-reference/integrations.kubernetes.html) for
-kubernetes including the `signalfx-agent` installation which must be installed as
-[daemonset](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/) on your cluster.
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 ### Monitors
 
-The detectors in this module are based on metrics reported by the following monitors:
+This monitor does support non persistent volume types filtered out in this module before `signalfx-agent` `v5.3.2` version.
 
-* [kubernetes-volumes](https://docs.signalfx.com/en/latest/integrations/agent/monitors/kubernetes-volumes.html)
-
-The `kubernetes-volumes` monitor does support non persistent volume types filtered out in this module before
-`signalfx-agent` `v5.3.2` version.
-
-[Others](https://docs.signalfx.com/en/latest/integrations/kubernetes/k8s-monitors-observers.html#monitors-observers)
-exist to increase visibility or may be in future to enrich this modules or create new ones.
-
-The `kubernetes-volumes` requires to enable the following `extraMetrics`:
+It requires to enable the following `extraMetrics`:
 
 * `kubernetes.volume_inodes`
 * `kubernetes.volume_inodes_free`
@@ -150,8 +151,8 @@ could ease the agent installation and configuration. Only need to enable `gather
 
 
 To filter only required metrics for the detectors of this module, add the
-[datapointsToExclude](https://docs.signalfx.com/en/latest/integrations/agent/filtering.html) parameter to
-the corresponding monitor configuration:
+[datapointsToExclude](https://docs.splunk.com/observability/gdi/smart-agent/smart-agent-resources.html#filtering-data-using-the-smart-agent)
+parameter to the corresponding monitor configuration:
 
 ```yaml
     datapointsToExclude:
@@ -170,11 +171,12 @@ the corresponding monitor configuration:
 it must also have the `get`, `list` and `watch` on `persistentvolumes` and `persistentvolumeclaim` resources.
 
 * If you use the [Helm chart](https://github.com/signalfx/signalfx-agent/tree/master/deployments/k8s/helm/signalfx-agent)
-to deploy the agent, so you need chart version `>= 1.5.0` and enable `gatherVolumesMetrics: true` in `values.yml`.
+to deploy the agent, so you need chart version `>= 1.6.0` and enable `gatherVolumesMetrics: true` in `values.yml`.
 
 
 ## Related documentation
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [Smart Agent monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/kubernetes-volumes.html)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [Smart Agent monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/kubernetes-volumes.md)

--- a/modules/smart-agent_kubernetes-volumes/conf/readme.yaml
+++ b/modules/smart-agent_kubernetes-volumes/conf/readme.yaml
@@ -1,6 +1,6 @@
 documentations:
   - name: Smart Agent monitor
-    url: 'https://docs.signalfx.com/en/latest/integrations/agent/monitors/kubernetes-volumes.html'
+    url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/kubernetes-volumes.md'
 
 source_doc: |
   ### Agent
@@ -14,7 +14,7 @@ source_doc: |
 
   The detectors in this module are based on metrics reported by the following monitors:
 
-  * [kubernetes-volumes](https://docs.signalfx.com/en/latest/integrations/agent/monitors/kubernetes-volumes.html)
+  * [kubernetes-volumes](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/kubernetes-volumes.md)
 
   The `kubernetes-volumes` monitor does support non persistent volume types filtered out in this module before
   `signalfx-agent` `v5.3.2` version.

--- a/modules/smart-agent_kubernetes-volumes/conf/readme.yaml
+++ b/modules/smart-agent_kubernetes-volumes/conf/readme.yaml
@@ -3,26 +3,11 @@ documentations:
     url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/kubernetes-volumes.md'
 
 source_doc: |
-  ### Agent
-
-  Here is the official [main
-  documentation](https://docs.signalfx.com/en/latest/integrations/integrations-reference/integrations.kubernetes.html) for
-  kubernetes including the `signalfx-agent` installation which must be installed as
-  [daemonset](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/) on your cluster.
-
   ### Monitors
 
-  The detectors in this module are based on metrics reported by the following monitors:
+  This monitor does support non persistent volume types filtered out in this module before `signalfx-agent` `v5.3.2` version.
 
-  * [kubernetes-volumes](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/kubernetes-volumes.md)
-
-  The `kubernetes-volumes` monitor does support non persistent volume types filtered out in this module before
-  `signalfx-agent` `v5.3.2` version.
-
-  [Others](https://docs.signalfx.com/en/latest/integrations/kubernetes/k8s-monitors-observers.html#monitors-observers)
-  exist to increase visibility or may be in future to enrich this modules or create new ones.
-
-  The `kubernetes-volumes` requires to enable the following `extraMetrics`:
+  It requires to enable the following `extraMetrics`:
 
   * `kubernetes.volume_inodes`
   * `kubernetes.volume_inodes_free`
@@ -63,4 +48,4 @@ notes: |
   it must also have the `get`, `list` and `watch` on `persistentvolumes` and `persistentvolumeclaim` resources.
 
   * If you use the [Helm chart](https://github.com/signalfx/signalfx-agent/tree/master/deployments/k8s/helm/signalfx-agent)
-  to deploy the agent, so you need chart version `>= 1.5.0` and enable `gatherVolumesMetrics: true` in `values.yml`.
+  to deploy the agent, so you need chart version `>= 1.6.0` and enable `gatherVolumesMetrics: true` in `values.yml`.

--- a/modules/smart-agent_kubernetes-workloads-count/README.md
+++ b/modules/smart-agent_kubernetes-workloads-count/README.md
@@ -17,7 +17,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -36,7 +36,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -52,7 +52,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -63,7 +63,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables-gen.tf](variables-gen.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/smart-agent_kubernetes-workloads-count/README.md
+++ b/modules/smart-agent_kubernetes-workloads-count/README.md
@@ -52,8 +52,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -83,21 +83,38 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-[monitors](https://docs.signalfx.com/en/latest/integrations/agent/monitors/_monitor-config.html)
-available in the [SignalFx Smart
-Agent](https://github.com/signalfx/signalfx-agent). Check the [Related documentation](#related-documentation) section for more
-information including the official documentation of this monitor.
+This module deploys detectors using metrics reported by the
+[SignalFx Smart Agent Monitors](https://github.com/signalfx/signalfx-agent#monitors).
+
+Even if the [Smart Agent is deprecated](https://github.com/signalfx/signalfx-agent/blob/main/docs/smartagent-deprecation-notice.md)
+it remains an efficient, lightweight and simple monitoring agent which still works fine.
+See the [official documentation](https://docs.splunk.com/Observability/gdi/smart-agent/smart-agent-resources.html) for more information
+about this agent.
+You might find the related following documentations useful:
+- the global level [agent configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/config-schema.md)
+- the [monitor level configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitor-config.md)
+- the internal [agent configuration tips](https://github.com/claranet/terraform-signalfx-detectors/wiki/Guidance#agent-configuration).
+- the full list of [monitors available](https://github.com/signalfx/signalfx-agent/tree/main/docs/monitors) with their own specific documentation.
+
+In addition, all of these monitors are still available in the [Splunk Otel Collector](https://github.com/signalfx/splunk-otel-collector),
+the Splunk [distro of OpenTelemetry Collector](https://opentelemetry.io/docs/concepts/distributions/) which replaces SignalFx Smart Agent,
+thanks to the internal [Smart Agent Receiver](https://github.com/signalfx/splunk-otel-collector/tree/main/internal/receiver/smartagentreceiver).
+
+As a result:
+- any SignalFx Smart Agent monitor are compatible with the new agent OpenTelemetry Collector and related modules in this repository keep `smart-agent` as source name.
+- any OpenTelemetry receiver not based on an existing Smart Agent monitor is not available from old agent so related modules in this repository use `otel-collector` as source name.
 
 
-[Kubernetes Common](https://github.com/claranet/terraform-signalfx-detectors/tree/master/modules/smart-agent_kubernetes-common)
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
+
+
 
 ### Metrics
 
 
 To filter only required metrics for the detectors of this module, add the
-[datapointsToExclude](https://docs.signalfx.com/en/latest/integrations/agent/filtering.html) parameter to
-the corresponding monitor configuration:
+[datapointsToExclude](https://docs.splunk.com/observability/gdi/smart-agent/smart-agent-resources.html#filtering-data-using-the-smart-agent)
+parameter to the corresponding monitor configuration:
 
 ```yaml
     datapointsToExclude:
@@ -127,9 +144,12 @@ The following namespaces are excluded:
   * kube-system
   * kubernetes-replicator
 
+
 ## Related documentation
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [Smart Agent monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/kubernetes-cluster.md)
 * [Kubernetes Workloads](https://kubernetes.io/docs/concepts/workloads/)
-* [Smart Agent monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/kubernetes-cluster.html)
+* [Splunk Observability integration](https://docs.splunk.com/Observability/gdi/kubernetes-cluster/kubernetes-cluster.html)

--- a/modules/smart-agent_kubernetes-workloads-count/conf/readme.yaml
+++ b/modules/smart-agent_kubernetes-workloads-count/conf/readme.yaml
@@ -2,7 +2,7 @@ documentations:
   - name: Kubernetes Workloads
     url: 'https://kubernetes.io/docs/concepts/workloads/'
   - name: Smart Agent monitor
-    url: 'https://docs.signalfx.com/en/latest/integrations/agent/monitors/kubernetes-cluster.html'
+    url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/kubernetes-cluster.md'
 source_doc: >-
   [Kubernetes Common](https://github.com/claranet/terraform-signalfx-detectors/tree/master/modules/smart-agent_kubernetes-common)
 notes: |

--- a/modules/smart-agent_kubernetes-workloads-count/conf/readme.yaml
+++ b/modules/smart-agent_kubernetes-workloads-count/conf/readme.yaml
@@ -1,10 +1,11 @@
 documentations:
-  - name: Kubernetes Workloads
-    url: 'https://kubernetes.io/docs/concepts/workloads/'
   - name: Smart Agent monitor
     url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/kubernetes-cluster.md'
-source_doc: >-
-  [Kubernetes Common](https://github.com/claranet/terraform-signalfx-detectors/tree/master/modules/smart-agent_kubernetes-common)
+  - name: Kubernetes Workloads
+    url: 'https://kubernetes.io/docs/concepts/workloads/'
+  - name: Splunk Observability integration
+    url: 'https://docs.splunk.com/Observability/gdi/kubernetes-cluster/kubernetes-cluster.html'
+
 notes: |
   ### Kubernetes Workloads Count
   This detector allows to set a custom limit on the total count of workloads configured on a Kubernetes cluster. This represents the sum of deployments, replicasets, statefulsets and daemonsets desired.

--- a/modules/smart-agent_mdadm/README.md
+++ b/modules/smart-agent_mdadm/README.md
@@ -20,7 +20,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -37,7 +37,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -53,7 +53,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -64,7 +64,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables-gen.tf](variables-gen.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/smart-agent_mdadm/README.md
+++ b/modules/smart-agent_mdadm/README.md
@@ -53,8 +53,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -85,16 +85,29 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-[monitors](https://docs.signalfx.com/en/latest/integrations/agent/monitors/_monitor-config.html)
-available in the [SignalFx Smart
-Agent](https://github.com/signalfx/signalfx-agent). Check the [Related documentation](#related-documentation) section for more
-information including the official documentation of this monitor.
+This module deploys detectors using metrics reported by the
+[SignalFx Smart Agent Monitors](https://github.com/signalfx/signalfx-agent#monitors).
+
+Even if the [Smart Agent is deprecated](https://github.com/signalfx/signalfx-agent/blob/main/docs/smartagent-deprecation-notice.md)
+it remains an efficient, lightweight and simple monitoring agent which still works fine.
+See the [official documentation](https://docs.splunk.com/Observability/gdi/smart-agent/smart-agent-resources.html) for more information
+about this agent.
+You might find the related following documentations useful:
+- the global level [agent configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/config-schema.md)
+- the [monitor level configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitor-config.md)
+- the internal [agent configuration tips](https://github.com/claranet/terraform-signalfx-detectors/wiki/Guidance#agent-configuration).
+- the full list of [monitors available](https://github.com/signalfx/signalfx-agent/tree/main/docs/monitors) with their own specific documentation.
+
+In addition, all of these monitors are still available in the [Splunk Otel Collector](https://github.com/signalfx/splunk-otel-collector),
+the Splunk [distro of OpenTelemetry Collector](https://opentelemetry.io/docs/concepts/distributions/) which replaces SignalFx Smart Agent,
+thanks to the internal [Smart Agent Receiver](https://github.com/signalfx/splunk-otel-collector/tree/main/internal/receiver/smartagentreceiver).
+
+As a result:
+- any SignalFx Smart Agent monitor are compatible with the new agent OpenTelemetry Collector and related modules in this repository keep `smart-agent` as source name.
+- any OpenTelemetry receiver not based on an existing Smart Agent monitor is not available from old agent so related modules in this repository use `otel-collector` as source name.
 
 
-There is no SignalFx official integration nor a monitor for `mdadm` but we use the
-[collectd/custom monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/collectd-custom.html)
-with bundled `md` collectd plugin.
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 ### Monitors
 
@@ -121,8 +134,8 @@ monitors:
 
 
 To filter only required metrics for the detectors of this module, add the
-[datapointsToExclude](https://docs.signalfx.com/en/latest/integrations/agent/filtering.html) parameter to
-the corresponding monitor configuration:
+[datapointsToExclude](https://docs.splunk.com/observability/gdi/smart-agent/smart-agent-resources.html#filtering-data-using-the-smart-agent)
+parameter to the corresponding monitor configuration:
 
 ```yaml
     datapointsToExclude:
@@ -150,5 +163,6 @@ The detector triggers:
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [Smart Agent monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/collectd-php-fpm.html)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [Smart Agent monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-custom.md)
 * [Collectd plugin](https://collectd.org/wiki/index.php/Plugin:MD)

--- a/modules/smart-agent_mdadm/conf/readme.yaml
+++ b/modules/smart-agent_mdadm/conf/readme.yaml
@@ -1,12 +1,12 @@
 documentations:
   - name: Smart Agent monitor
-    url: 'https://docs.signalfx.com/en/latest/integrations/agent/monitors/collectd-php-fpm.html'
+    url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-php-fpm.md'
   - name: Collectd plugin
     url: 'https://collectd.org/wiki/index.php/Plugin:MD'
 
 source_doc: |
   There is no SignalFx official integration nor a monitor for `mdadm` but we use the
-  [collectd/custom monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/collectd-custom.html)
+  [collectd/custom monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-custom.md)
   with bundled `md` collectd plugin.
 
   ### Monitors

--- a/modules/smart-agent_mdadm/conf/readme.yaml
+++ b/modules/smart-agent_mdadm/conf/readme.yaml
@@ -1,14 +1,10 @@
 documentations:
   - name: Smart Agent monitor
-    url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-php-fpm.md'
+    url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-custom.md'
   - name: Collectd plugin
     url: 'https://collectd.org/wiki/index.php/Plugin:MD'
 
 source_doc: |
-  There is no SignalFx official integration nor a monitor for `mdadm` but we use the
-  [collectd/custom monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-custom.md)
-  with bundled `md` collectd plugin.
-
   ### Monitors
 
   The Collectd plugin requires access on MD devices owned by user `root` and group `disk`.

--- a/modules/smart-agent_memcached/README.md
+++ b/modules/smart-agent_memcached/README.md
@@ -50,8 +50,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -83,16 +83,29 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-[monitors](https://docs.signalfx.com/en/latest/integrations/agent/monitors/_monitor-config.html)
-available in the [SignalFx Smart
-Agent](https://github.com/signalfx/signalfx-agent). Check the [Related documentation](#related-documentation) section for more
-information including the official documentation of this monitor.
+This module deploys detectors using metrics reported by the
+[SignalFx Smart Agent Monitors](https://github.com/signalfx/signalfx-agent#monitors).
+
+Even if the [Smart Agent is deprecated](https://github.com/signalfx/signalfx-agent/blob/main/docs/smartagent-deprecation-notice.md)
+it remains an efficient, lightweight and simple monitoring agent which still works fine.
+See the [official documentation](https://docs.splunk.com/Observability/gdi/smart-agent/smart-agent-resources.html) for more information
+about this agent.
+You might find the related following documentations useful:
+- the global level [agent configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/config-schema.md)
+- the [monitor level configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitor-config.md)
+- the internal [agent configuration tips](https://github.com/claranet/terraform-signalfx-detectors/wiki/Guidance#agent-configuration).
+- the full list of [monitors available](https://github.com/signalfx/signalfx-agent/tree/main/docs/monitors) with their own specific documentation.
+
+In addition, all of these monitors are still available in the [Splunk Otel Collector](https://github.com/signalfx/splunk-otel-collector),
+the Splunk [distro of OpenTelemetry Collector](https://opentelemetry.io/docs/concepts/distributions/) which replaces SignalFx Smart Agent,
+thanks to the internal [Smart Agent Receiver](https://github.com/signalfx/splunk-otel-collector/tree/main/internal/receiver/smartagentreceiver).
+
+As a result:
+- any SignalFx Smart Agent monitor are compatible with the new agent OpenTelemetry Collector and related modules in this repository keep `smart-agent` as source name.
+- any OpenTelemetry receiver not based on an existing Smart Agent monitor is not available from old agent so related modules in this repository use `otel-collector` as source name.
 
 
-Check the [integration
-documentation](https://docs.signalfx.com/en/latest/integrations/integrations-reference/integrations.memcached.html)
-in addition to the monitor one which it uses.
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 ### Monitors
 
@@ -117,8 +130,8 @@ The `collectd/memcached` monitor requires to enable the following `extraMetrics`
 
 
 To filter only required metrics for the detectors of this module, add the
-[datapointsToExclude](https://docs.signalfx.com/en/latest/integrations/agent/filtering.html) parameter to
-the corresponding monitor configuration:
+[datapointsToExclude](https://docs.splunk.com/observability/gdi/smart-agent/smart-agent-resources.html#filtering-data-using-the-smart-agent)
+parameter to the corresponding monitor configuration:
 
 ```yaml
     datapointsToExclude:
@@ -137,5 +150,7 @@ the corresponding monitor configuration:
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [Smart Agent monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/collectd-memcached.html)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [Smart Agent monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-memcached.md)
+* [Splunk Observability integration](https://docs.splunk.com/Observability/gdi/memcached/memcached.html)
 * [Collectd plugin](https://collectd.org/wiki/index.php/Plugin:memcached)

--- a/modules/smart-agent_memcached/README.md
+++ b/modules/smart-agent_memcached/README.md
@@ -17,7 +17,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -34,7 +34,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -50,7 +50,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -61,7 +61,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/smart-agent_memcached/conf/readme.yaml
+++ b/modules/smart-agent_memcached/conf/readme.yaml
@@ -1,14 +1,12 @@
 documentations:
   - name: Smart Agent monitor
     url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-memcached.md'
+  - name: Splunk Observability integration
+    url: 'https://docs.splunk.com/Observability/gdi/memcached/memcached.html'
   - name: Collectd plugin
     url: 'https://collectd.org/wiki/index.php/Plugin:memcached'
 
 source_doc: |
-  Check the [integration
-  documentation](https://docs.signalfx.com/en/latest/integrations/integrations-reference/integrations.memcached.html)
-  in addition to the monitor one which it uses.
-
   ### Monitors
 
   The `collectd/memcached` monitor requires to enable the following `extraMetrics`:

--- a/modules/smart-agent_memcached/conf/readme.yaml
+++ b/modules/smart-agent_memcached/conf/readme.yaml
@@ -1,6 +1,6 @@
 documentations:
   - name: Smart Agent monitor
-    url: 'https://docs.signalfx.com/en/latest/integrations/agent/monitors/collectd-memcached.html'
+    url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-memcached.md'
   - name: Collectd plugin
     url: 'https://collectd.org/wiki/index.php/Plugin:memcached'
 

--- a/modules/smart-agent_mongodb/README.md
+++ b/modules/smart-agent_mongodb/README.md
@@ -51,8 +51,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -88,16 +88,29 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-[monitors](https://docs.signalfx.com/en/latest/integrations/agent/monitors/_monitor-config.html)
-available in the [SignalFx Smart
-Agent](https://github.com/signalfx/signalfx-agent). Check the [Related documentation](#related-documentation) section for more
-information including the official documentation of this monitor.
+This module deploys detectors using metrics reported by the
+[SignalFx Smart Agent Monitors](https://github.com/signalfx/signalfx-agent#monitors).
+
+Even if the [Smart Agent is deprecated](https://github.com/signalfx/signalfx-agent/blob/main/docs/smartagent-deprecation-notice.md)
+it remains an efficient, lightweight and simple monitoring agent which still works fine.
+See the [official documentation](https://docs.splunk.com/Observability/gdi/smart-agent/smart-agent-resources.html) for more information
+about this agent.
+You might find the related following documentations useful:
+- the global level [agent configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/config-schema.md)
+- the [monitor level configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitor-config.md)
+- the internal [agent configuration tips](https://github.com/claranet/terraform-signalfx-detectors/wiki/Guidance#agent-configuration).
+- the full list of [monitors available](https://github.com/signalfx/signalfx-agent/tree/main/docs/monitors) with their own specific documentation.
+
+In addition, all of these monitors are still available in the [Splunk Otel Collector](https://github.com/signalfx/splunk-otel-collector),
+the Splunk [distro of OpenTelemetry Collector](https://opentelemetry.io/docs/concepts/distributions/) which replaces SignalFx Smart Agent,
+thanks to the internal [Smart Agent Receiver](https://github.com/signalfx/splunk-otel-collector/tree/main/internal/receiver/smartagentreceiver).
+
+As a result:
+- any SignalFx Smart Agent monitor are compatible with the new agent OpenTelemetry Collector and related modules in this repository keep `smart-agent` as source name.
+- any OpenTelemetry receiver not based on an existing Smart Agent monitor is not available from old agent so related modules in this repository use `otel-collector` as source name.
 
 
-Check the [integration
-documentation](https://docs.signalfx.com/en/latest/integrations/integrations-reference/integrations.mongodb.html)
-in addition to the monitor one which it uses.
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 ### Monitors
 
@@ -147,8 +160,8 @@ This is the only way to make the replicaset related detectors to work.
 
 
 To filter only required metrics for the detectors of this module, add the
-[datapointsToExclude](https://docs.signalfx.com/en/latest/integrations/agent/filtering.html) parameter to
-the corresponding monitor configuration:
+[datapointsToExclude](https://docs.splunk.com/observability/gdi/smart-agent/smart-agent-resources.html#filtering-data-using-the-smart-agent)
+parameter to the corresponding monitor configuration:
 
 ```yaml
     datapointsToExclude:
@@ -185,5 +198,8 @@ your environment.
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [Smart Agent monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/collectd-mongodb.html)
-* [Collection script](https://github.com/signalfx/collectd-mongodb)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [Smart Agent monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-mongodb.md)
+* [Splunk Observability integration](https://docs.splunk.com/Observability/gdi/mongodb/mongodb.html)
+* [Collectd plugin](https://collectd.org/wiki/index.php/Plugin:MongoDB)
+* [Collectd script](https://github.com/signalfx/collectd-mongodb)

--- a/modules/smart-agent_mongodb/README.md
+++ b/modules/smart-agent_mongodb/README.md
@@ -18,7 +18,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -35,7 +35,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -51,7 +51,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -62,7 +62,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/smart-agent_mongodb/conf/readme.yaml
+++ b/modules/smart-agent_mongodb/conf/readme.yaml
@@ -1,14 +1,14 @@
 documentations:
   - name: Smart Agent monitor
     url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-mongodb.md'
-  - name: Collection script
+  - name: Splunk Observability integration
+    url: 'https://docs.splunk.com/Observability/gdi/mongodb/mongodb.html'
+  - name: Collectd plugin
+    url: 'https://collectd.org/wiki/index.php/Plugin:MongoDB'
+  - name: Collectd script
     url: 'https://github.com/signalfx/collectd-mongodb'
 
 source_doc: |
-  Check the [integration
-  documentation](https://docs.signalfx.com/en/latest/integrations/integrations-reference/integrations.mongodb.html)
-  in addition to the monitor one which it uses.
-
   ### Monitors
 
   The `collectd/mongodb` monitor requires to enable the following `extraMetrics`:

--- a/modules/smart-agent_mongodb/conf/readme.yaml
+++ b/modules/smart-agent_mongodb/conf/readme.yaml
@@ -1,6 +1,6 @@
 documentations:
   - name: Smart Agent monitor
-    url: 'https://docs.signalfx.com/en/latest/integrations/agent/monitors/collectd-mongodb.html'
+    url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-mongodb.md'
   - name: Collection script
     url: 'https://github.com/signalfx/collectd-mongodb'
 

--- a/modules/smart-agent_mysql/README.md
+++ b/modules/smart-agent_mysql/README.md
@@ -19,7 +19,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -36,7 +36,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -52,7 +52,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -63,7 +63,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/smart-agent_mysql/README.md
+++ b/modules/smart-agent_mysql/README.md
@@ -52,8 +52,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -92,23 +92,36 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-[monitors](https://docs.signalfx.com/en/latest/integrations/agent/monitors/_monitor-config.html)
-available in the [SignalFx Smart
-Agent](https://github.com/signalfx/signalfx-agent). Check the [Related documentation](#related-documentation) section for more
-information including the official documentation of this monitor.
+This module deploys detectors using metrics reported by the
+[SignalFx Smart Agent Monitors](https://github.com/signalfx/signalfx-agent#monitors).
+
+Even if the [Smart Agent is deprecated](https://github.com/signalfx/signalfx-agent/blob/main/docs/smartagent-deprecation-notice.md)
+it remains an efficient, lightweight and simple monitoring agent which still works fine.
+See the [official documentation](https://docs.splunk.com/Observability/gdi/smart-agent/smart-agent-resources.html) for more information
+about this agent.
+You might find the related following documentations useful:
+- the global level [agent configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/config-schema.md)
+- the [monitor level configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitor-config.md)
+- the internal [agent configuration tips](https://github.com/claranet/terraform-signalfx-detectors/wiki/Guidance#agent-configuration).
+- the full list of [monitors available](https://github.com/signalfx/signalfx-agent/tree/main/docs/monitors) with their own specific documentation.
+
+In addition, all of these monitors are still available in the [Splunk Otel Collector](https://github.com/signalfx/splunk-otel-collector),
+the Splunk [distro of OpenTelemetry Collector](https://opentelemetry.io/docs/concepts/distributions/) which replaces SignalFx Smart Agent,
+thanks to the internal [Smart Agent Receiver](https://github.com/signalfx/splunk-otel-collector/tree/main/internal/receiver/smartagentreceiver).
+
+As a result:
+- any SignalFx Smart Agent monitor are compatible with the new agent OpenTelemetry Collector and related modules in this repository keep `smart-agent` as source name.
+- any OpenTelemetry receiver not based on an existing Smart Agent monitor is not available from old agent so related modules in this repository use `otel-collector` as source name.
 
 
-Check the [integration
-documentation](https://docs.signalfx.com/en/latest/integrations/integrations-reference/integrations.mysql.html)
-in addition to the monitor one which it uses.
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 ### Monitors
 
 The detectors in this module are based on metrics reported by the following monitors:
 
-* [collectd/mysql](https://docs.signalfx.com/en/latest/integrations/agent/monitors/collectd-mysql.html)
-* [sql](https://docs.signalfx.com/en/latest/integrations/agent/monitors/sql.html)
+* [collectd/mysql](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-mysql.md)
+* [sql](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/sql.md)
 
 The `collectd/mysql` requires to enable the following `extraMetrics`:
 
@@ -127,7 +140,7 @@ Others metrics are collected from the `sql` monitor thanks to custom queries. Se
 You have to configure your MySQL database to provide a user to collect metrics.
 You can use [this terraform module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/database/mysql)
 or follow instruction in [integration
-documentation](https://docs.signalfx.com/en/latest/integrations/integrations-reference/integrations.mysql.html#creating-a-mysql-user-for-collectd).
+documentation](https://docs.splunk.com/Observability/gdi/mysql/mysql.html#creating-a-mysql-user-for-this-monitor).
 
 ### Suggested configuration
 
@@ -223,8 +236,8 @@ __Note__: If you deploy this configuration via ansible, you will need to escape 
 
 
 To filter only required metrics for the detectors of this module, add the
-[datapointsToExclude](https://docs.signalfx.com/en/latest/integrations/agent/filtering.html) parameter to
-the corresponding monitor configuration:
+[datapointsToExclude](https://docs.splunk.com/observability/gdi/smart-agent/smart-agent-resources.html#filtering-data-using-the-smart-agent)
+parameter to the corresponding monitor configuration:
 
 ```yaml
     datapointsToExclude:
@@ -257,5 +270,8 @@ The `mysql_threads_anomaly` detector monitors query rate change of all `mysql_co
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [Smart Agent monitor mysql](https://docs.signalfx.com/en/latest/integrations/agent/monitors/collectd-mysql.html)
-* [Smart Agent monitor sql](https://docs.signalfx.com/en/latest/integrations/agent/monitors/sql.html)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [Smart Agent monitor mysql](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-mysql.md)
+* [Smart Agent monitor sql](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/sql.md)
+* [Splunk Observability integration mysql](https://docs.splunk.com/Observability/gdi/mysql/mysql.html)
+* [Splunk Observability integration sql](https://docs.splunk.com/Observability/gdi/sql/sql.html)

--- a/modules/smart-agent_mysql/conf/readme.yaml
+++ b/modules/smart-agent_mysql/conf/readme.yaml
@@ -3,12 +3,12 @@ documentations:
     url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-mysql.md'
   - name: Smart Agent monitor sql
     url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/sql.md'
+  - name: Splunk Observability integration mysql
+    url: 'https://docs.splunk.com/Observability/gdi/mysql/mysql.html'
+  - name: Splunk Observability integration sql
+    url: 'https://docs.splunk.com/Observability/gdi/sql/sql.html'
 
 source_doc: |
-  Check the [integration
-  documentation](https://docs.signalfx.com/en/latest/integrations/integrations-reference/integrations.mysql.html)
-  in addition to the monitor one which it uses.
-
   ### Monitors
 
   The detectors in this module are based on metrics reported by the following monitors:
@@ -33,7 +33,7 @@ source_doc: |
   You have to configure your MySQL database to provide a user to collect metrics.
   You can use [this terraform module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/database/mysql)
   or follow instruction in [integration
-  documentation](https://docs.signalfx.com/en/latest/integrations/integrations-reference/integrations.mysql.html#creating-a-mysql-user-for-collectd).
+  documentation](https://docs.splunk.com/Observability/gdi/mysql/mysql.html#creating-a-mysql-user-for-this-monitor).
 
   ### Suggested configuration
 

--- a/modules/smart-agent_mysql/conf/readme.yaml
+++ b/modules/smart-agent_mysql/conf/readme.yaml
@@ -1,8 +1,8 @@
 documentations:
   - name: Smart Agent monitor mysql
-    url: 'https://docs.signalfx.com/en/latest/integrations/agent/monitors/collectd-mysql.html'
+    url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-mysql.md'
   - name: Smart Agent monitor sql
-    url: 'https://docs.signalfx.com/en/latest/integrations/agent/monitors/sql.html'
+    url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/sql.md'
 
 source_doc: |
   Check the [integration
@@ -13,8 +13,8 @@ source_doc: |
 
   The detectors in this module are based on metrics reported by the following monitors:
 
-  * [collectd/mysql](https://docs.signalfx.com/en/latest/integrations/agent/monitors/collectd-mysql.html)
-  * [sql](https://docs.signalfx.com/en/latest/integrations/agent/monitors/sql.html)
+  * [collectd/mysql](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-mysql.md)
+  * [sql](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/sql.md)
 
   The `collectd/mysql` requires to enable the following `extraMetrics`:
 

--- a/modules/smart-agent_nagios-status-check/README.md
+++ b/modules/smart-agent_nagios-status-check/README.md
@@ -18,7 +18,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -35,7 +35,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -51,7 +51,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -62,7 +62,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables-gen.tf](variables-gen.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/smart-agent_nagios-status-check/README.md
+++ b/modules/smart-agent_nagios-status-check/README.md
@@ -51,8 +51,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -82,13 +82,29 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-[monitors](https://docs.signalfx.com/en/latest/integrations/agent/monitors/_monitor-config.html)
-available in the [SignalFx Smart
-Agent](https://github.com/signalfx/signalfx-agent). Check the [Related documentation](#related-documentation) section for more
-information including the official documentation of this monitor.
+This module deploys detectors using metrics reported by the
+[SignalFx Smart Agent Monitors](https://github.com/signalfx/signalfx-agent#monitors).
+
+Even if the [Smart Agent is deprecated](https://github.com/signalfx/signalfx-agent/blob/main/docs/smartagent-deprecation-notice.md)
+it remains an efficient, lightweight and simple monitoring agent which still works fine.
+See the [official documentation](https://docs.splunk.com/Observability/gdi/smart-agent/smart-agent-resources.html) for more information
+about this agent.
+You might find the related following documentations useful:
+- the global level [agent configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/config-schema.md)
+- the [monitor level configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitor-config.md)
+- the internal [agent configuration tips](https://github.com/claranet/terraform-signalfx-detectors/wiki/Guidance#agent-configuration).
+- the full list of [monitors available](https://github.com/signalfx/signalfx-agent/tree/main/docs/monitors) with their own specific documentation.
+
+In addition, all of these monitors are still available in the [Splunk Otel Collector](https://github.com/signalfx/splunk-otel-collector),
+the Splunk [distro of OpenTelemetry Collector](https://opentelemetry.io/docs/concepts/distributions/) which replaces SignalFx Smart Agent,
+thanks to the internal [Smart Agent Receiver](https://github.com/signalfx/splunk-otel-collector/tree/main/internal/receiver/smartagentreceiver).
+
+As a result:
+- any SignalFx Smart Agent monitor are compatible with the new agent OpenTelemetry Collector and related modules in this repository keep `smart-agent` as source name.
+- any OpenTelemetry receiver not based on an existing Smart Agent monitor is not available from old agent so related modules in this repository use `otel-collector` as source name.
 
 
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 ### Monitors
 
@@ -125,8 +141,8 @@ the metric and its value will be available.
 
 
 To filter only required metrics for the detectors of this module, add the
-[datapointsToExclude](https://docs.signalfx.com/en/latest/integrations/agent/filtering.html) parameter to
-the corresponding monitor configuration:
+[datapointsToExclude](https://docs.splunk.com/observability/gdi/smart-agent/smart-agent-resources.html#filtering-data-using-the-smart-agent)
+parameter to the corresponding monitor configuration:
 
 ```yaml
     datapointsToExclude:
@@ -151,5 +167,6 @@ The metric is named `nagios.state`.
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [Smart Agent monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/nagios.html)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [Smart Agent monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/nagios.md)
 * [Nagios checks guidelines](https://nagios-plugins.org/doc/guidelines.html#AEN78)

--- a/modules/smart-agent_nagios-status-check/conf/readme.yaml
+++ b/modules/smart-agent_nagios-status-check/conf/readme.yaml
@@ -1,6 +1,6 @@
 documentations:
   - name: Smart Agent monitor
-    url: 'https://docs.signalfx.com/en/latest/integrations/agent/monitors/nagios.html'
+    url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/nagios.md'
   - name: Nagios checks guidelines
     url: 'https://nagios-plugins.org/doc/guidelines.html#AEN78'
 

--- a/modules/smart-agent_nagios-status-check/conf/readme.yaml
+++ b/modules/smart-agent_nagios-status-check/conf/readme.yaml
@@ -5,7 +5,6 @@ documentations:
     url: 'https://nagios-plugins.org/doc/guidelines.html#AEN78'
 
 source_doc: |
-
   ### Monitors
 
   This monitor is only available for agent `>= 5.7.1`. For prior versions, it is possible to use the

--- a/modules/smart-agent_nginx-ingress/README.md
+++ b/modules/smart-agent_nginx-ingress/README.md
@@ -7,7 +7,6 @@
 - [How to use this module?](#how-to-use-this-module)
 - [What are the available detectors in this module?](#what-are-the-available-detectors-in-this-module)
 - [How to collect required metrics?](#how-to-collect-required-metrics)
-  - [Agent](#agent)
   - [Monitors](#monitors)
   - [Nginx Ingress Controller](#nginx-ingress-controller)
   - [Examples](#examples)
@@ -53,8 +52,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -86,32 +85,42 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-[monitors](https://docs.signalfx.com/en/latest/integrations/agent/monitors/_monitor-config.html)
-available in the [SignalFx Smart
-Agent](https://github.com/signalfx/signalfx-agent). Check the [Related documentation](#related-documentation) section for more
-information including the official documentation of this monitor.
+This module deploys detectors using metrics reported by the
+[SignalFx Smart Agent Monitors](https://github.com/signalfx/signalfx-agent#monitors).
+
+Even if the [Smart Agent is deprecated](https://github.com/signalfx/signalfx-agent/blob/main/docs/smartagent-deprecation-notice.md)
+it remains an efficient, lightweight and simple monitoring agent which still works fine.
+See the [official documentation](https://docs.splunk.com/Observability/gdi/smart-agent/smart-agent-resources.html) for more information
+about this agent.
+You might find the related following documentations useful:
+- the global level [agent configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/config-schema.md)
+- the [monitor level configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitor-config.md)
+- the internal [agent configuration tips](https://github.com/claranet/terraform-signalfx-detectors/wiki/Guidance#agent-configuration).
+- the full list of [monitors available](https://github.com/signalfx/signalfx-agent/tree/main/docs/monitors) with their own specific documentation.
+
+In addition, all of these monitors are still available in the [Splunk Otel Collector](https://github.com/signalfx/splunk-otel-collector),
+the Splunk [distro of OpenTelemetry Collector](https://opentelemetry.io/docs/concepts/distributions/) which replaces SignalFx Smart Agent,
+thanks to the internal [Smart Agent Receiver](https://github.com/signalfx/splunk-otel-collector/tree/main/internal/receiver/smartagentreceiver).
+
+As a result:
+- any SignalFx Smart Agent monitor are compatible with the new agent OpenTelemetry Collector and related modules in this repository keep `smart-agent` as source name.
+- any OpenTelemetry receiver not based on an existing Smart Agent monitor is not available from old agent so related modules in this repository use `otel-collector` as source name.
 
 
-### Agent
-
-Here is the official [main
-documentation](https://docs.signalfx.com/en/latest/integrations/integrations-reference/integrations.kubernetes.html) for
-kubernetes including the `signalfx-agent` installation which must be installed as
-[daemonset](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/) on your cluster.
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 ### Monitors
 
 The detectors in this module are based on metrics reported by the following monitors:
 
-* [prometheus/nginx-ingress](https://docs.signalfx.com/en/latest/integrations/agent/monitors/prometheus-nginx-ingress.html)
+* [prometheus/nginx-ingress](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/prometheus-nginx-ingress.md)
 
 This monitor is only available for agent `>= 5.5.5` but it is basically a wrapper around [prometheus exporter
-monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/prometheus-exporter.html) to filter important
+monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/prometheus-exporter.md) to filter important
 metrics while prometheus metrics are considered as custom metrics which could have an impact on SignalFx billing.
 
 You must configure it for every ingress deployments so this is almost sure you will need to use [service
-discovery](https://docs.signalfx.com/en/latest/integrations/agent/auto-discovery.html) to do it dynamically.
+discovery](https://github.com/signalfx/signalfx-agent/blob/main/docs/auto-discovery.md) to do it dynamically.
 
 Detectors in this module will at least require these metrics:
 
@@ -124,7 +133,7 @@ There are collected by default by `nginx-ingress` monitor but you have to enable
 
 Prometheus metrics from [Nginx Ingress Controller](https://github.com/kubernetes/ingress-nginx) are only available for
 version `>= 0.16`. For older versions you have to use
-[prometheus/nginx-vts](https://docs.signalfx.com/en/latest/integrations/agent/monitors/prometheus-nginx-vts.html) to collect
+[prometheus/nginx-vts](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/prometheus-nginx-vts.md) to collect
 metrics which will not be compatible with this module.
 
 Enable the following flags in the Nginx Ingress Controller chart:
@@ -148,8 +157,8 @@ monitors:
 
 
 To filter only required metrics for the detectors of this module, add the
-[datapointsToExclude](https://docs.signalfx.com/en/latest/integrations/agent/filtering.html) parameter to
-the corresponding monitor configuration:
+[datapointsToExclude](https://docs.splunk.com/observability/gdi/smart-agent/smart-agent-resources.html#filtering-data-using-the-smart-agent)
+parameter to the corresponding monitor configuration:
 
 ```yaml
     datapointsToExclude:
@@ -178,7 +187,7 @@ monitors:
         - '!nginx_ingress_controller_nginx_process_resident_memory_bytes'
 ```
 
-It uses whitelist [filtering](https://docs.signalfx.com/en/latest/integrations/agent/filtering.html)
+It uses whitelist [filtering](https://github.com/signalfx/signalfx-agent/blob/main/docs/filtering.md)
 to keep only interesting metrics. Only the first two are required by this module.
 
 You can replace `prometheus/nginx-ingress` by `prometheus-exporter` to make this module works
@@ -189,4 +198,6 @@ with agent version prior `5.5.5`.
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [Smart Agent monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/prometheus-nginx-ingress.html)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [Smart Agent monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/prometheus-nginx-ingress.md)
+* [Splunk Observability integration](https://docs.splunk.com/Observability/gdi/prometheus-nginx-ingress/prometheus-nginx-ingress.html)

--- a/modules/smart-agent_nginx-ingress/README.md
+++ b/modules/smart-agent_nginx-ingress/README.md
@@ -19,7 +19,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -36,7 +36,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -52,7 +52,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -63,7 +63,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf) and [variables-gen.tf](variables-gen.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/smart-agent_nginx-ingress/conf/readme.yaml
+++ b/modules/smart-agent_nginx-ingress/conf/readme.yaml
@@ -1,15 +1,10 @@
 documentations:
   - name: Smart Agent monitor
     url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/prometheus-nginx-ingress.md'
+  - name: Splunk Observability integration
+    url: 'https://docs.splunk.com/Observability/gdi/prometheus-nginx-ingress/prometheus-nginx-ingress.html'
 
 source_doc: |
-  ### Agent
-
-  Here is the official [main
-  documentation](https://docs.signalfx.com/en/latest/integrations/integrations-reference/integrations.kubernetes.html) for
-  kubernetes including the `signalfx-agent` installation which must be installed as
-  [daemonset](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/) on your cluster.
-
   ### Monitors
 
   The detectors in this module are based on metrics reported by the following monitors:
@@ -21,7 +16,7 @@ source_doc: |
   metrics while prometheus metrics are considered as custom metrics which could have an impact on SignalFx billing.
 
   You must configure it for every ingress deployments so this is almost sure you will need to use [service
-  discovery](https://docs.signalfx.com/en/latest/integrations/agent/auto-discovery.html) to do it dynamically.
+  discovery](https://github.com/signalfx/signalfx-agent/blob/main/docs/auto-discovery.md) to do it dynamically.
 
   Detectors in this module will at least require these metrics:
 
@@ -70,7 +65,7 @@ notes: |
           - '!nginx_ingress_controller_nginx_process_resident_memory_bytes'
   ```
 
-  It uses whitelist [filtering](https://docs.signalfx.com/en/latest/integrations/agent/filtering.html)
+  It uses whitelist [filtering](https://github.com/signalfx/signalfx-agent/blob/main/docs/filtering.md)
   to keep only interesting metrics. Only the first two are required by this module.
 
   You can replace `prometheus/nginx-ingress` by `prometheus-exporter` to make this module works

--- a/modules/smart-agent_nginx-ingress/conf/readme.yaml
+++ b/modules/smart-agent_nginx-ingress/conf/readme.yaml
@@ -1,6 +1,6 @@
 documentations:
   - name: Smart Agent monitor
-    url: 'https://docs.signalfx.com/en/latest/integrations/agent/monitors/prometheus-nginx-ingress.html'
+    url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/prometheus-nginx-ingress.md'
 
 source_doc: |
   ### Agent
@@ -14,10 +14,10 @@ source_doc: |
 
   The detectors in this module are based on metrics reported by the following monitors:
 
-  * [prometheus/nginx-ingress](https://docs.signalfx.com/en/latest/integrations/agent/monitors/prometheus-nginx-ingress.html)
+  * [prometheus/nginx-ingress](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/prometheus-nginx-ingress.md)
 
   This monitor is only available for agent `>= 5.5.5` but it is basically a wrapper around [prometheus exporter
-  monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/prometheus-exporter.html) to filter important
+  monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/prometheus-exporter.md) to filter important
   metrics while prometheus metrics are considered as custom metrics which could have an impact on SignalFx billing.
 
   You must configure it for every ingress deployments so this is almost sure you will need to use [service
@@ -34,7 +34,7 @@ source_doc: |
 
   Prometheus metrics from [Nginx Ingress Controller](https://github.com/kubernetes/ingress-nginx) are only available for
   version `>= 0.16`. For older versions you have to use
-  [prometheus/nginx-vts](https://docs.signalfx.com/en/latest/integrations/agent/monitors/prometheus-nginx-vts.html) to collect
+  [prometheus/nginx-vts](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/prometheus-nginx-vts.md) to collect
   metrics which will not be compatible with this module.
 
   Enable the following flags in the Nginx Ingress Controller chart:

--- a/modules/smart-agent_nginx/README.md
+++ b/modules/smart-agent_nginx/README.md
@@ -48,8 +48,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -80,12 +80,29 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-[monitors](https://docs.signalfx.com/en/latest/integrations/agent/monitors/_monitor-config.html)
-available in the [SignalFx Smart
-Agent](https://github.com/signalfx/signalfx-agent). Check the [Related documentation](#related-documentation) section for more
-information including the official documentation of this monitor.
+This module deploys detectors using metrics reported by the
+[SignalFx Smart Agent Monitors](https://github.com/signalfx/signalfx-agent#monitors).
 
+Even if the [Smart Agent is deprecated](https://github.com/signalfx/signalfx-agent/blob/main/docs/smartagent-deprecation-notice.md)
+it remains an efficient, lightweight and simple monitoring agent which still works fine.
+See the [official documentation](https://docs.splunk.com/Observability/gdi/smart-agent/smart-agent-resources.html) for more information
+about this agent.
+You might find the related following documentations useful:
+- the global level [agent configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/config-schema.md)
+- the [monitor level configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitor-config.md)
+- the internal [agent configuration tips](https://github.com/claranet/terraform-signalfx-detectors/wiki/Guidance#agent-configuration).
+- the full list of [monitors available](https://github.com/signalfx/signalfx-agent/tree/main/docs/monitors) with their own specific documentation.
+
+In addition, all of these monitors are still available in the [Splunk Otel Collector](https://github.com/signalfx/splunk-otel-collector),
+the Splunk [distro of OpenTelemetry Collector](https://opentelemetry.io/docs/concepts/distributions/) which replaces SignalFx Smart Agent,
+thanks to the internal [Smart Agent Receiver](https://github.com/signalfx/splunk-otel-collector/tree/main/internal/receiver/smartagentreceiver).
+
+As a result:
+- any SignalFx Smart Agent monitor are compatible with the new agent OpenTelemetry Collector and related modules in this repository keep `smart-agent` as source name.
+- any OpenTelemetry receiver not based on an existing Smart Agent monitor is not available from old agent so related modules in this repository use `otel-collector` as source name.
+
+
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 
 
@@ -93,8 +110,8 @@ information including the official documentation of this monitor.
 
 
 To filter only required metrics for the detectors of this module, add the
-[datapointsToExclude](https://docs.signalfx.com/en/latest/integrations/agent/filtering.html) parameter to
-the corresponding monitor configuration:
+[datapointsToExclude](https://docs.splunk.com/observability/gdi/smart-agent/smart-agent-resources.html#filtering-data-using-the-smart-agent)
+parameter to the corresponding monitor configuration:
 
 ```yaml
     datapointsToExclude:
@@ -111,5 +128,7 @@ the corresponding monitor configuration:
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [SignalFx agent monitor](https://docs.signalfx.com/en/latest/integrations/integrations-reference/integrations.nginx.html)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [SignalFx agent monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-nginx.md)
+* [Splunk Observability integration](https://docs.splunk.com/Observability/gdi/nginx/nginx.html)
 * [Nginx status module](http://nginx.org/en/docs/http/ngx_http_status_module.html)

--- a/modules/smart-agent_nginx/README.md
+++ b/modules/smart-agent_nginx/README.md
@@ -15,7 +15,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -32,7 +32,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -48,7 +48,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -59,7 +59,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/smart-agent_nginx/conf/readme.yaml
+++ b/modules/smart-agent_nginx/conf/readme.yaml
@@ -1,9 +1,7 @@
-detectors:
-  - Nginx dropped connections
-  - Nginx heartbeat
-
 documentations:
   - name: SignalFx agent monitor
-    url: 'https://docs.signalfx.com/en/latest/integrations/integrations-reference/integrations.nginx.html'
+    url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-nginx.md'
+  - name: Splunk Observability integration
+    url: 'https://docs.splunk.com/Observability/gdi/nginx/nginx.html'
   - name: Nginx status module
     url: 'http://nginx.org/en/docs/http/ngx_http_status_module.html'

--- a/modules/smart-agent_ntp/README.md
+++ b/modules/smart-agent_ntp/README.md
@@ -50,8 +50,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -82,15 +82,29 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-[monitors](https://docs.signalfx.com/en/latest/integrations/agent/monitors/_monitor-config.html)
-available in the [SignalFx Smart
-Agent](https://github.com/signalfx/signalfx-agent). Check the [Related documentation](#related-documentation) section for more
-information including the official documentation of this monitor.
+This module deploys detectors using metrics reported by the
+[SignalFx Smart Agent Monitors](https://github.com/signalfx/signalfx-agent#monitors).
+
+Even if the [Smart Agent is deprecated](https://github.com/signalfx/signalfx-agent/blob/main/docs/smartagent-deprecation-notice.md)
+it remains an efficient, lightweight and simple monitoring agent which still works fine.
+See the [official documentation](https://docs.splunk.com/Observability/gdi/smart-agent/smart-agent-resources.html) for more information
+about this agent.
+You might find the related following documentations useful:
+- the global level [agent configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/config-schema.md)
+- the [monitor level configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitor-config.md)
+- the internal [agent configuration tips](https://github.com/claranet/terraform-signalfx-detectors/wiki/Guidance#agent-configuration).
+- the full list of [monitors available](https://github.com/signalfx/signalfx-agent/tree/main/docs/monitors) with their own specific documentation.
+
+In addition, all of these monitors are still available in the [Splunk Otel Collector](https://github.com/signalfx/splunk-otel-collector),
+the Splunk [distro of OpenTelemetry Collector](https://opentelemetry.io/docs/concepts/distributions/) which replaces SignalFx Smart Agent,
+thanks to the internal [Smart Agent Receiver](https://github.com/signalfx/splunk-otel-collector/tree/main/internal/receiver/smartagentreceiver).
+
+As a result:
+- any SignalFx Smart Agent monitor are compatible with the new agent OpenTelemetry Collector and related modules in this repository keep `smart-agent` as source name.
+- any OpenTelemetry receiver not based on an existing Smart Agent monitor is not available from old agent so related modules in this repository use `otel-collector` as source name.
 
 
-There is no SignalFx official integration for `ntp` but there is still a
-[monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/ntp.html) to use.
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 ### Monitors
 
@@ -103,8 +117,8 @@ Also, in contrast with all other monitors it enforce an `intervalSeconds` to `30
 
 
 To filter only required metrics for the detectors of this module, add the
-[datapointsToExclude](https://docs.signalfx.com/en/latest/integrations/agent/filtering.html) parameter to
-the corresponding monitor configuration:
+[datapointsToExclude](https://docs.splunk.com/observability/gdi/smart-agent/smart-agent-resources.html#filtering-data-using-the-smart-agent)
+parameter to the corresponding monitor configuration:
 
 ```yaml
     datapointsToExclude:
@@ -133,4 +147,6 @@ In the future we could improve this monitor to:
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [Smart Agent monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/ntp.html)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [Smart Agent monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/ntp.md)
+* [Splunk Observability integration](https://docs.splunk.com/Observability/gdi/ntp/ntp.html)

--- a/modules/smart-agent_ntp/README.md
+++ b/modules/smart-agent_ntp/README.md
@@ -17,7 +17,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -34,7 +34,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -50,7 +50,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -61,7 +61,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/smart-agent_ntp/conf/readme.yaml
+++ b/modules/smart-agent_ntp/conf/readme.yaml
@@ -1,11 +1,10 @@
 documentations:
   - name: Smart Agent monitor
     url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/ntp.md'
+  - name: Splunk Observability integration
+    url: 'https://docs.splunk.com/Observability/gdi/ntp/ntp.html'
 
 source_doc: |
-  There is no SignalFx official integration for `ntp` but there is still a
-  [monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/ntp.md) to use.
-
   ### Monitors
 
   This monitor is only available from agent version `>= 5.1.5`.

--- a/modules/smart-agent_ntp/conf/readme.yaml
+++ b/modules/smart-agent_ntp/conf/readme.yaml
@@ -1,10 +1,10 @@
 documentations:
   - name: Smart Agent monitor
-    url: 'https://docs.signalfx.com/en/latest/integrations/agent/monitors/ntp.html'
+    url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/ntp.md'
 
 source_doc: |
   There is no SignalFx official integration for `ntp` but there is still a
-  [monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/ntp.html) to use.
+  [monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/ntp.md) to use.
 
   ### Monitors
 

--- a/modules/smart-agent_php-fpm/README.md
+++ b/modules/smart-agent_php-fpm/README.md
@@ -16,7 +16,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -33,7 +33,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -49,7 +49,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -60,7 +60,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/smart-agent_php-fpm/README.md
+++ b/modules/smart-agent_php-fpm/README.md
@@ -49,8 +49,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -81,20 +81,34 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-[monitors](https://docs.signalfx.com/en/latest/integrations/agent/monitors/_monitor-config.html)
-available in the [SignalFx Smart
-Agent](https://github.com/signalfx/signalfx-agent). Check the [Related documentation](#related-documentation) section for more
-information including the official documentation of this monitor.
+This module deploys detectors using metrics reported by the
+[SignalFx Smart Agent Monitors](https://github.com/signalfx/signalfx-agent#monitors).
+
+Even if the [Smart Agent is deprecated](https://github.com/signalfx/signalfx-agent/blob/main/docs/smartagent-deprecation-notice.md)
+it remains an efficient, lightweight and simple monitoring agent which still works fine.
+See the [official documentation](https://docs.splunk.com/Observability/gdi/smart-agent/smart-agent-resources.html) for more information
+about this agent.
+You might find the related following documentations useful:
+- the global level [agent configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/config-schema.md)
+- the [monitor level configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitor-config.md)
+- the internal [agent configuration tips](https://github.com/claranet/terraform-signalfx-detectors/wiki/Guidance#agent-configuration).
+- the full list of [monitors available](https://github.com/signalfx/signalfx-agent/tree/main/docs/monitors) with their own specific documentation.
+
+In addition, all of these monitors are still available in the [Splunk Otel Collector](https://github.com/signalfx/splunk-otel-collector),
+the Splunk [distro of OpenTelemetry Collector](https://opentelemetry.io/docs/concepts/distributions/) which replaces SignalFx Smart Agent,
+thanks to the internal [Smart Agent Receiver](https://github.com/signalfx/splunk-otel-collector/tree/main/internal/receiver/smartagentreceiver).
+
+As a result:
+- any SignalFx Smart Agent monitor are compatible with the new agent OpenTelemetry Collector and related modules in this repository keep `smart-agent` as source name.
+- any OpenTelemetry receiver not based on an existing Smart Agent monitor is not available from old agent so related modules in this repository use `otel-collector` as source name.
 
 
-There is no SignalFx official integration for `php-fpm` but there is still a
-[monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/collectd-php-fpm.html) to use.
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 ### Monitors
 
 This monitor is only available for agent `>= 5.2.0` but for previous versions you can use the generic
-[collectd/custom](https://docs.signalfx.com/en/latest/integrations/agent/monitors/collectd-custom.html)
+[collectd/custom](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-custom.md)
 monitor with [this
 configuration](https://github.com/signalfx/signalfx-agent/blob/master/pkg/monitors/collectd/php/php.tmpl).
 
@@ -103,8 +117,8 @@ configuration](https://github.com/signalfx/signalfx-agent/blob/master/pkg/monito
 
 
 To filter only required metrics for the detectors of this module, add the
-[datapointsToExclude](https://docs.signalfx.com/en/latest/integrations/agent/filtering.html) parameter to
-the corresponding monitor configuration:
+[datapointsToExclude](https://docs.splunk.com/observability/gdi/smart-agent/smart-agent-resources.html#filtering-data-using-the-smart-agent)
+parameter to the corresponding monitor configuration:
 
 ```yaml
     datapointsToExclude:
@@ -122,5 +136,7 @@ the corresponding monitor configuration:
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [Smart Agent monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/collectd-php-fpm.html)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [Smart Agent monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-php-fpm.md)
+* [Splunk Observability integration](https://docs.splunk.com/Observability/gdi/collectd/collectd-php-fpm.html)
 * [Collectd plugin](https://collectd.org/wiki/index.php/Plugin:cURL-JSON)

--- a/modules/smart-agent_php-fpm/conf/readme.yaml
+++ b/modules/smart-agent_php-fpm/conf/readme.yaml
@@ -1,16 +1,16 @@
 documentations:
   - name: Smart Agent monitor
-    url: 'https://docs.signalfx.com/en/latest/integrations/agent/monitors/collectd-php-fpm.html'
+    url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-php-fpm.md'
   - name: Collectd plugin
     url: 'https://collectd.org/wiki/index.php/Plugin:cURL-JSON'
 
 source_doc: |
   There is no SignalFx official integration for `php-fpm` but there is still a
-  [monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/collectd-php-fpm.html) to use.
+  [monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-php-fpm.md) to use.
 
   ### Monitors
 
   This monitor is only available for agent `>= 5.2.0` but for previous versions you can use the generic
-  [collectd/custom](https://docs.signalfx.com/en/latest/integrations/agent/monitors/collectd-custom.html)
+  [collectd/custom](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-custom.md)
   monitor with [this
   configuration](https://github.com/signalfx/signalfx-agent/blob/master/pkg/monitors/collectd/php/php.tmpl).

--- a/modules/smart-agent_php-fpm/conf/readme.yaml
+++ b/modules/smart-agent_php-fpm/conf/readme.yaml
@@ -1,13 +1,12 @@
 documentations:
   - name: Smart Agent monitor
     url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-php-fpm.md'
+  - name: Splunk Observability integration
+    url: 'https://docs.splunk.com/Observability/gdi/collectd/collectd-php-fpm.html'
   - name: Collectd plugin
     url: 'https://collectd.org/wiki/index.php/Plugin:cURL-JSON'
 
 source_doc: |
-  There is no SignalFx official integration for `php-fpm` but there is still a
-  [monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-php-fpm.md) to use.
-
   ### Monitors
 
   This monitor is only available for agent `>= 5.2.0` but for previous versions you can use the generic

--- a/modules/smart-agent_postgresql/README.md
+++ b/modules/smart-agent_postgresql/README.md
@@ -19,7 +19,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -36,7 +36,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -52,7 +52,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -63,7 +63,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/smart-agent_postgresql/README.md
+++ b/modules/smart-agent_postgresql/README.md
@@ -52,8 +52,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -90,22 +90,31 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-[monitors](https://docs.signalfx.com/en/latest/integrations/agent/monitors/_monitor-config.html)
-available in the [SignalFx Smart
-Agent](https://github.com/signalfx/signalfx-agent). Check the [Related documentation](#related-documentation) section for more
-information including the official documentation of this monitor.
+This module deploys detectors using metrics reported by the
+[SignalFx Smart Agent Monitors](https://github.com/signalfx/signalfx-agent#monitors).
+
+Even if the [Smart Agent is deprecated](https://github.com/signalfx/signalfx-agent/blob/main/docs/smartagent-deprecation-notice.md)
+it remains an efficient, lightweight and simple monitoring agent which still works fine.
+See the [official documentation](https://docs.splunk.com/Observability/gdi/smart-agent/smart-agent-resources.html) for more information
+about this agent.
+You might find the related following documentations useful:
+- the global level [agent configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/config-schema.md)
+- the [monitor level configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitor-config.md)
+- the internal [agent configuration tips](https://github.com/claranet/terraform-signalfx-detectors/wiki/Guidance#agent-configuration).
+- the full list of [monitors available](https://github.com/signalfx/signalfx-agent/tree/main/docs/monitors) with their own specific documentation.
+
+In addition, all of these monitors are still available in the [Splunk Otel Collector](https://github.com/signalfx/splunk-otel-collector),
+the Splunk [distro of OpenTelemetry Collector](https://opentelemetry.io/docs/concepts/distributions/) which replaces SignalFx Smart Agent,
+thanks to the internal [Smart Agent Receiver](https://github.com/signalfx/splunk-otel-collector/tree/main/internal/receiver/smartagentreceiver).
+
+As a result:
+- any SignalFx Smart Agent monitor are compatible with the new agent OpenTelemetry Collector and related modules in this repository keep `smart-agent` as source name.
+- any OpenTelemetry receiver not based on an existing Smart Agent monitor is not available from old agent so related modules in this repository use `otel-collector` as source name.
 
 
-Check the [integration
-documentation](https://docs.signalfx.com/en/latest/integrations/integrations-reference/integrations.postgresql.html)
-in addition to the monitor one which it uses.
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 ### Monitors
-
-The detectors in this module are based on metrics reported by the following monitors:
-
-* [postgresql](https://docs.signalfx.com/en/latest/integrations/agent/monitors/postgresql.html)
 
 The `postgresql` requires to enable the following `extraMetrics`:
 
@@ -127,7 +136,7 @@ You have to configure your PostgreSQL database to provide a user to collect metr
 
 And you also have to [enable statement tracking](https://www.postgresql.org/docs/9.3/pgstatstatements.html#AEN160631).
 More information available on
-[postgresl](https://docs.signalfx.com/en/latest/integrations/agent/monitors/postgresql.html#metrics-about-queries)
+[postgresl](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/postgresql.md#metrics-about-queries)
 monitor documentation.
 
 ### Examples
@@ -184,8 +193,8 @@ You have to `disableHostDimensions: true` and add your PostgreSQL server as `hos
 
 
 To filter only required metrics for the detectors of this module, add the
-[datapointsToExclude](https://docs.signalfx.com/en/latest/integrations/agent/filtering.html) parameter to
-the corresponding monitor configuration:
+[datapointsToExclude](https://docs.splunk.com/observability/gdi/smart-agent/smart-agent-resources.html#filtering-data-using-the-smart-agent)
+parameter to the corresponding monitor configuration:
 
 ```yaml
     datapointsToExclude:
@@ -223,5 +232,8 @@ extension must be enabled for each database by running `CREATE EXTENSION IF NOT 
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [Smart Agent monitor postgresql](https://docs.signalfx.com/en/latest/integrations/agent/monitors/postgresql.html)
-* [Smart Agent monitor sql](https://docs.signalfx.com/en/latest/integrations/agent/monitors/sql.html)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [Smart Agent monitor postgresql](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/postgresql.md)
+* [Smart Agent monitor sql](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/sql.md)
+* [Splunk Observability integration postgresql](https://docs.splunk.com/Observability/gdi/postgresql/postgresql.html)
+* [Splunk Observability integration sql](https://docs.splunk.com/Observability/gdi/sql/sql.html)

--- a/modules/smart-agent_postgresql/conf/readme.yaml
+++ b/modules/smart-agent_postgresql/conf/readme.yaml
@@ -3,17 +3,13 @@ documentations:
     url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/postgresql.md'
   - name: Smart Agent monitor sql
     url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/sql.md'
+  - name: Splunk Observability integration postgresql
+    url: 'https://docs.splunk.com/Observability/gdi/postgresql/postgresql.html'
+  - name: Splunk Observability integration sql
+    url: 'https://docs.splunk.com/Observability/gdi/sql/sql.html'
 
 source_doc: |
-  Check the [integration
-  documentation](https://docs.signalfx.com/en/latest/integrations/integrations-reference/integrations.postgresql.html)
-  in addition to the monitor one which it uses.
-
   ### Monitors
-
-  The detectors in this module are based on metrics reported by the following monitors:
-
-  * [postgresql](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/postgresql.md)
 
   The `postgresql` requires to enable the following `extraMetrics`:
 

--- a/modules/smart-agent_postgresql/conf/readme.yaml
+++ b/modules/smart-agent_postgresql/conf/readme.yaml
@@ -1,8 +1,8 @@
 documentations:
   - name: Smart Agent monitor postgresql
-    url: 'https://docs.signalfx.com/en/latest/integrations/agent/monitors/postgresql.html'
+    url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/postgresql.md'
   - name: Smart Agent monitor sql
-    url: 'https://docs.signalfx.com/en/latest/integrations/agent/monitors/sql.html'
+    url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/sql.md'
 
 source_doc: |
   Check the [integration
@@ -13,7 +13,7 @@ source_doc: |
 
   The detectors in this module are based on metrics reported by the following monitors:
 
-  * [postgresql](https://docs.signalfx.com/en/latest/integrations/agent/monitors/postgresql.html)
+  * [postgresql](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/postgresql.md)
 
   The `postgresql` requires to enable the following `extraMetrics`:
 
@@ -35,7 +35,7 @@ source_doc: |
 
   And you also have to [enable statement tracking](https://www.postgresql.org/docs/9.3/pgstatstatements.html#AEN160631).
   More information available on
-  [postgresl](https://docs.signalfx.com/en/latest/integrations/agent/monitors/postgresql.html#metrics-about-queries)
+  [postgresl](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/postgresql.md#metrics-about-queries)
   monitor documentation.
 
   ### Examples

--- a/modules/smart-agent_processes/README.md
+++ b/modules/smart-agent_processes/README.md
@@ -49,8 +49,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -80,23 +80,38 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-[monitors](https://docs.signalfx.com/en/latest/integrations/agent/monitors/_monitor-config.html)
-available in the [SignalFx Smart
-Agent](https://github.com/signalfx/signalfx-agent). Check the [Related documentation](#related-documentation) section for more
-information including the official documentation of this monitor.
+This module deploys detectors using metrics reported by the
+[SignalFx Smart Agent Monitors](https://github.com/signalfx/signalfx-agent#monitors).
+
+Even if the [Smart Agent is deprecated](https://github.com/signalfx/signalfx-agent/blob/main/docs/smartagent-deprecation-notice.md)
+it remains an efficient, lightweight and simple monitoring agent which still works fine.
+See the [official documentation](https://docs.splunk.com/Observability/gdi/smart-agent/smart-agent-resources.html) for more information
+about this agent.
+You might find the related following documentations useful:
+- the global level [agent configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/config-schema.md)
+- the [monitor level configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitor-config.md)
+- the internal [agent configuration tips](https://github.com/claranet/terraform-signalfx-detectors/wiki/Guidance#agent-configuration).
+- the full list of [monitors available](https://github.com/signalfx/signalfx-agent/tree/main/docs/monitors) with their own specific documentation.
+
+In addition, all of these monitors are still available in the [Splunk Otel Collector](https://github.com/signalfx/splunk-otel-collector),
+the Splunk [distro of OpenTelemetry Collector](https://opentelemetry.io/docs/concepts/distributions/) which replaces SignalFx Smart Agent,
+thanks to the internal [Smart Agent Receiver](https://github.com/signalfx/splunk-otel-collector/tree/main/internal/receiver/smartagentreceiver).
+
+As a result:
+- any SignalFx Smart Agent monitor are compatible with the new agent OpenTelemetry Collector and related modules in this repository keep `smart-agent` as source name.
+- any OpenTelemetry receiver not based on an existing Smart Agent monitor is not available from old agent so related modules in this repository use `otel-collector` as source name.
 
 
-There is no SignalFx official integration for `processes` but there is still a
-[monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/collectd-processes.html) to use.
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
+
 
 
 ### Metrics
 
 
 To filter only required metrics for the detectors of this module, add the
-[datapointsToExclude](https://docs.signalfx.com/en/latest/integrations/agent/filtering.html) parameter to
-the corresponding monitor configuration:
+[datapointsToExclude](https://docs.splunk.com/observability/gdi/smart-agent/smart-agent-resources.html#filtering-data-using-the-smart-agent)
+parameter to the corresponding monitor configuration:
 
 ```yaml
     datapointsToExclude:
@@ -120,4 +135,7 @@ running (i.e. I need 5 "foo" processes for my api to run correctly, so I will up
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [Smart Agent monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/collectd-processes.html)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [Smart Agent monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-processes.md)
+* [Splunk Observability integration](https://docs.splunk.com/Observability/gdi/processes/processes.html)
+* [Collectd Plugin](https://collectd.org/wiki/index.php/Plugin:Processes)

--- a/modules/smart-agent_processes/README.md
+++ b/modules/smart-agent_processes/README.md
@@ -16,7 +16,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -33,7 +33,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -49,7 +49,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -60,7 +60,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables-gen.tf](variables-gen.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/smart-agent_processes/conf/readme.yaml
+++ b/modules/smart-agent_processes/conf/readme.yaml
@@ -1,10 +1,10 @@
 documentations:
   - name: Smart Agent monitor
-    url: 'https://docs.signalfx.com/en/latest/integrations/agent/monitors/collectd-processes.html'
+    url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-processes.md'
 
 source_doc: |
   There is no SignalFx official integration for `processes` but there is still a
-  [monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/collectd-processes.html) to use.
+  [monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-processes.md) to use.
 
 notes: |
   By default, only `critical` rule is enabled. This allows the detector to check if the service has, at least,

--- a/modules/smart-agent_processes/conf/readme.yaml
+++ b/modules/smart-agent_processes/conf/readme.yaml
@@ -1,10 +1,10 @@
 documentations:
   - name: Smart Agent monitor
     url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-processes.md'
-
-source_doc: |
-  There is no SignalFx official integration for `processes` but there is still a
-  [monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-processes.md) to use.
+  - name: Splunk Observability integration
+    url: 'https://docs.splunk.com/Observability/gdi/processes/processes.html'
+  - name: Collectd Plugin
+    url: 'https://collectd.org/wiki/index.php/Plugin:Processes'
 
 notes: |
   By default, only `critical` rule is enabled. This allows the detector to check if the service has, at least,

--- a/modules/smart-agent_rabbitmq-node/README.md
+++ b/modules/smart-agent_rabbitmq-node/README.md
@@ -18,7 +18,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -35,7 +35,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -51,7 +51,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -62,7 +62,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/smart-agent_rabbitmq-node/README.md
+++ b/modules/smart-agent_rabbitmq-node/README.md
@@ -51,8 +51,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -86,16 +86,29 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-[monitors](https://docs.signalfx.com/en/latest/integrations/agent/monitors/_monitor-config.html)
-available in the [SignalFx Smart
-Agent](https://github.com/signalfx/signalfx-agent). Check the [Related documentation](#related-documentation) section for more
-information including the official documentation of this monitor.
+This module deploys detectors using metrics reported by the
+[SignalFx Smart Agent Monitors](https://github.com/signalfx/signalfx-agent#monitors).
+
+Even if the [Smart Agent is deprecated](https://github.com/signalfx/signalfx-agent/blob/main/docs/smartagent-deprecation-notice.md)
+it remains an efficient, lightweight and simple monitoring agent which still works fine.
+See the [official documentation](https://docs.splunk.com/Observability/gdi/smart-agent/smart-agent-resources.html) for more information
+about this agent.
+You might find the related following documentations useful:
+- the global level [agent configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/config-schema.md)
+- the [monitor level configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitor-config.md)
+- the internal [agent configuration tips](https://github.com/claranet/terraform-signalfx-detectors/wiki/Guidance#agent-configuration).
+- the full list of [monitors available](https://github.com/signalfx/signalfx-agent/tree/main/docs/monitors) with their own specific documentation.
+
+In addition, all of these monitors are still available in the [Splunk Otel Collector](https://github.com/signalfx/splunk-otel-collector),
+the Splunk [distro of OpenTelemetry Collector](https://opentelemetry.io/docs/concepts/distributions/) which replaces SignalFx Smart Agent,
+thanks to the internal [Smart Agent Receiver](https://github.com/signalfx/splunk-otel-collector/tree/main/internal/receiver/smartagentreceiver).
+
+As a result:
+- any SignalFx Smart Agent monitor are compatible with the new agent OpenTelemetry Collector and related modules in this repository keep `smart-agent` as source name.
+- any OpenTelemetry receiver not based on an existing Smart Agent monitor is not available from old agent so related modules in this repository use `otel-collector` as source name.
 
 
-Check the [integration
-documentation](https://docs.signalfx.com/en/latest/integrations/integrations-reference/integrations.rabbitmq.html)
-in addition to the monitor one which it uses.
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 ### Monitors
 
@@ -107,7 +120,7 @@ You have to enable the following `extraMetrics` in your monitor configuration:
 * `gauge.node.sockets_total`
 
 You also have to enable `collectNodes` and `collectQueues` parameters from the
-[collectd/rabbitmq](https://docs.signalfx.com/en/latest/integrations/agent/monitors/collectd-rabbitmq.html)
+[collectd/rabbitmq](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-rabbitmq.md)
 monitor configuration.
 
 ### Examples
@@ -130,8 +143,8 @@ monitors:
 
 
 To filter only required metrics for the detectors of this module, add the
-[datapointsToExclude](https://docs.signalfx.com/en/latest/integrations/agent/filtering.html) parameter to
-the corresponding monitor configuration:
+[datapointsToExclude](https://docs.splunk.com/observability/gdi/smart-agent/smart-agent-resources.html#filtering-data-using-the-smart-agent)
+parameter to the corresponding monitor configuration:
 
 ```yaml
     datapointsToExclude:
@@ -158,6 +171,8 @@ In order to have a really complete monitoring, you should consider using the `[r
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [Smart Agent monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/collectd-rabbitmq.html)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [Smart Agent monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-rabbitmq.md)
+* [Splunk Observability integration](https://docs.splunk.com/Observability/gdi/rabbitmq/rabbitmq.html)
+* [Collectd script](https://github.com/signalfx/collectd-rabbitmq)
 * [RabbitMQ management plugin](https://www.rabbitmq.com/management.html)
-* [Collection script](https://github.com/signalfx/collectd-rabbitmq)

--- a/modules/smart-agent_rabbitmq-node/conf/readme.yaml
+++ b/modules/smart-agent_rabbitmq-node/conf/readme.yaml
@@ -1,16 +1,14 @@
 documentations:
   - name: Smart Agent monitor
     url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-rabbitmq.md'
+  - name: Splunk Observability integration
+    url: 'https://docs.splunk.com/Observability/gdi/rabbitmq/rabbitmq.html'
+  - name: Collectd script
+    url: 'https://github.com/signalfx/collectd-rabbitmq'
   - name: RabbitMQ management plugin
     url: 'https://www.rabbitmq.com/management.html'
-  - name: Collection script
-    url: 'https://github.com/signalfx/collectd-rabbitmq'
 
 source_doc: |
-  Check the [integration
-  documentation](https://docs.signalfx.com/en/latest/integrations/integrations-reference/integrations.rabbitmq.html)
-  in addition to the monitor one which it uses.
-
   ### Monitors
 
   You have to enable the following `extraMetrics` in your monitor configuration:

--- a/modules/smart-agent_rabbitmq-node/conf/readme.yaml
+++ b/modules/smart-agent_rabbitmq-node/conf/readme.yaml
@@ -1,6 +1,6 @@
 documentations:
   - name: Smart Agent monitor
-    url: 'https://docs.signalfx.com/en/latest/integrations/agent/monitors/collectd-rabbitmq.html'
+    url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-rabbitmq.md'
   - name: RabbitMQ management plugin
     url: 'https://www.rabbitmq.com/management.html'
   - name: Collection script
@@ -21,7 +21,7 @@ source_doc: |
   * `gauge.node.sockets_total`
 
   You also have to enable `collectNodes` and `collectQueues` parameters from the
-  [collectd/rabbitmq](https://docs.signalfx.com/en/latest/integrations/agent/monitors/collectd-rabbitmq.html)
+  [collectd/rabbitmq](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-rabbitmq.md)
   monitor configuration.
 
   ### Examples

--- a/modules/smart-agent_rabbitmq-queue/README.md
+++ b/modules/smart-agent_rabbitmq-queue/README.md
@@ -18,7 +18,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -35,7 +35,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -51,7 +51,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -62,7 +62,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables-gen.tf](variables-gen.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/smart-agent_rabbitmq-queue/README.md
+++ b/modules/smart-agent_rabbitmq-queue/README.md
@@ -51,8 +51,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -85,16 +85,29 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-[monitors](https://docs.signalfx.com/en/latest/integrations/agent/monitors/_monitor-config.html)
-available in the [SignalFx Smart
-Agent](https://github.com/signalfx/signalfx-agent). Check the [Related documentation](#related-documentation) section for more
-information including the official documentation of this monitor.
+This module deploys detectors using metrics reported by the
+[SignalFx Smart Agent Monitors](https://github.com/signalfx/signalfx-agent#monitors).
+
+Even if the [Smart Agent is deprecated](https://github.com/signalfx/signalfx-agent/blob/main/docs/smartagent-deprecation-notice.md)
+it remains an efficient, lightweight and simple monitoring agent which still works fine.
+See the [official documentation](https://docs.splunk.com/Observability/gdi/smart-agent/smart-agent-resources.html) for more information
+about this agent.
+You might find the related following documentations useful:
+- the global level [agent configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/config-schema.md)
+- the [monitor level configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitor-config.md)
+- the internal [agent configuration tips](https://github.com/claranet/terraform-signalfx-detectors/wiki/Guidance#agent-configuration).
+- the full list of [monitors available](https://github.com/signalfx/signalfx-agent/tree/main/docs/monitors) with their own specific documentation.
+
+In addition, all of these monitors are still available in the [Splunk Otel Collector](https://github.com/signalfx/splunk-otel-collector),
+the Splunk [distro of OpenTelemetry Collector](https://opentelemetry.io/docs/concepts/distributions/) which replaces SignalFx Smart Agent,
+thanks to the internal [Smart Agent Receiver](https://github.com/signalfx/splunk-otel-collector/tree/main/internal/receiver/smartagentreceiver).
+
+As a result:
+- any SignalFx Smart Agent monitor are compatible with the new agent OpenTelemetry Collector and related modules in this repository keep `smart-agent` as source name.
+- any OpenTelemetry receiver not based on an existing Smart Agent monitor is not available from old agent so related modules in this repository use `otel-collector` as source name.
 
 
-Check the [integration
-documentation](https://docs.signalfx.com/en/latest/integrations/integrations-reference/integrations.rabbitmq.html)
-in addition to the monitor one which it uses.
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 ### Monitors
 
@@ -105,7 +118,7 @@ You have to enable the following `extraMetrics` in your monitor configuration:
 * `gauge.queue.consumer_utilisation`
 
 You also have to enable `collectNodes` and `collectQueues` parameters from the
-[collectd/rabbitmq](https://docs.signalfx.com/en/latest/integrations/agent/monitors/collectd-rabbitmq.html)
+[collectd/rabbitmq](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-rabbitmq.md)
 monitor configuration.
 
 ### Examples
@@ -127,8 +140,8 @@ monitors:
 
 
 To filter only required metrics for the detectors of this module, add the
-[datapointsToExclude](https://docs.signalfx.com/en/latest/integrations/agent/filtering.html) parameter to
-the corresponding monitor configuration:
+[datapointsToExclude](https://docs.splunk.com/observability/gdi/smart-agent/smart-agent-resources.html#filtering-data-using-the-smart-agent)
+parameter to the corresponding monitor configuration:
 
 ```yaml
     datapointsToExclude:
@@ -156,6 +169,8 @@ thresholds (on a particular queue for example).
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [Smart Agent monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/collectd-rabbitmq.html)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [Smart Agent monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-rabbitmq.md)
+* [Splunk Observability integration](https://docs.splunk.com/Observability/gdi/rabbitmq/rabbitmq.html)
+* [Collectd script](https://github.com/signalfx/collectd-rabbitmq)
 * [RabbitMQ management plugin](https://www.rabbitmq.com/management.html)
-* [Collection script](https://github.com/signalfx/collectd-rabbitmq)

--- a/modules/smart-agent_rabbitmq-queue/conf/readme.yaml
+++ b/modules/smart-agent_rabbitmq-queue/conf/readme.yaml
@@ -1,16 +1,14 @@
 documentations:
   - name: Smart Agent monitor
     url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-rabbitmq.md'
+  - name: Splunk Observability integration
+    url: 'https://docs.splunk.com/Observability/gdi/rabbitmq/rabbitmq.html'
+  - name: Collectd script
+    url: 'https://github.com/signalfx/collectd-rabbitmq'
   - name: RabbitMQ management plugin
     url: 'https://www.rabbitmq.com/management.html'
-  - name: Collection script
-    url: 'https://github.com/signalfx/collectd-rabbitmq'
 
 source_doc: |
-  Check the [integration
-  documentation](https://docs.signalfx.com/en/latest/integrations/integrations-reference/integrations.rabbitmq.html)
-  in addition to the monitor one which it uses.
-
   ### Monitors
 
   You have to enable the following `extraMetrics` in your monitor configuration:

--- a/modules/smart-agent_rabbitmq-queue/conf/readme.yaml
+++ b/modules/smart-agent_rabbitmq-queue/conf/readme.yaml
@@ -1,6 +1,6 @@
 documentations:
   - name: Smart Agent monitor
-    url: 'https://docs.signalfx.com/en/latest/integrations/agent/monitors/collectd-rabbitmq.html'
+    url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-rabbitmq.md'
   - name: RabbitMQ management plugin
     url: 'https://www.rabbitmq.com/management.html'
   - name: Collection script
@@ -20,7 +20,7 @@ source_doc: |
   * `gauge.queue.consumer_utilisation`
 
   You also have to enable `collectNodes` and `collectQueues` parameters from the
-  [collectd/rabbitmq](https://docs.signalfx.com/en/latest/integrations/agent/monitors/collectd-rabbitmq.html)
+  [collectd/rabbitmq](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-rabbitmq.md)
   monitor configuration.
 
   ### Examples

--- a/modules/smart-agent_redis/README.md
+++ b/modules/smart-agent_redis/README.md
@@ -50,8 +50,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -91,16 +91,29 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-[monitors](https://docs.signalfx.com/en/latest/integrations/agent/monitors/_monitor-config.html)
-available in the [SignalFx Smart
-Agent](https://github.com/signalfx/signalfx-agent). Check the [Related documentation](#related-documentation) section for more
-information including the official documentation of this monitor.
+This module deploys detectors using metrics reported by the
+[SignalFx Smart Agent Monitors](https://github.com/signalfx/signalfx-agent#monitors).
+
+Even if the [Smart Agent is deprecated](https://github.com/signalfx/signalfx-agent/blob/main/docs/smartagent-deprecation-notice.md)
+it remains an efficient, lightweight and simple monitoring agent which still works fine.
+See the [official documentation](https://docs.splunk.com/Observability/gdi/smart-agent/smart-agent-resources.html) for more information
+about this agent.
+You might find the related following documentations useful:
+- the global level [agent configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/config-schema.md)
+- the [monitor level configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitor-config.md)
+- the internal [agent configuration tips](https://github.com/claranet/terraform-signalfx-detectors/wiki/Guidance#agent-configuration).
+- the full list of [monitors available](https://github.com/signalfx/signalfx-agent/tree/main/docs/monitors) with their own specific documentation.
+
+In addition, all of these monitors are still available in the [Splunk Otel Collector](https://github.com/signalfx/splunk-otel-collector),
+the Splunk [distro of OpenTelemetry Collector](https://opentelemetry.io/docs/concepts/distributions/) which replaces SignalFx Smart Agent,
+thanks to the internal [Smart Agent Receiver](https://github.com/signalfx/splunk-otel-collector/tree/main/internal/receiver/smartagentreceiver).
+
+As a result:
+- any SignalFx Smart Agent monitor are compatible with the new agent OpenTelemetry Collector and related modules in this repository keep `smart-agent` as source name.
+- any OpenTelemetry receiver not based on an existing Smart Agent monitor is not available from old agent so related modules in this repository use `otel-collector` as source name.
 
 
-Check the [integration
-documentation](https://docs.signalfx.com/en/latest/integrations/integrations-reference/integrations.redis.html)
-in addition to the monitor one which it uses.
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 ### Monitors
 
@@ -117,8 +130,8 @@ Some of them are available since agent version `v5.4.2` like the two first.
 
 
 To filter only required metrics for the detectors of this module, add the
-[datapointsToExclude](https://docs.signalfx.com/en/latest/integrations/agent/filtering.html) parameter to
-the corresponding monitor configuration:
+[datapointsToExclude](https://docs.splunk.com/observability/gdi/smart-agent/smart-agent-resources.html#filtering-data-using-the-smart-agent)
+parameter to the corresponding monitor configuration:
 
 ```yaml
     datapointsToExclude:
@@ -150,5 +163,7 @@ This detector is disabled by default because it makes sens only when redis is us
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [Smart Agent monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/collectd-redis.html)
-* [Collection script](https://github.com/signalfx/redis-collectd-plugin)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [Smart Agent monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-redis.md)
+* [Splunk Observability integration](https://docs.splunk.com/Observability/gdi/redis/redis.html)
+* [Collectd script](https://github.com/signalfx/redis-collectd-plugin)

--- a/modules/smart-agent_redis/README.md
+++ b/modules/smart-agent_redis/README.md
@@ -17,7 +17,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -34,7 +34,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -50,7 +50,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -61,7 +61,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/smart-agent_redis/conf/readme.yaml
+++ b/modules/smart-agent_redis/conf/readme.yaml
@@ -1,6 +1,6 @@
 documentations:
   - name: Smart Agent monitor
-    url: 'https://docs.signalfx.com/en/latest/integrations/agent/monitors/collectd-redis.html'
+    url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-redis.md'
   - name: Collection script
     url: 'https://github.com/signalfx/redis-collectd-plugin'
 

--- a/modules/smart-agent_redis/conf/readme.yaml
+++ b/modules/smart-agent_redis/conf/readme.yaml
@@ -1,14 +1,12 @@
 documentations:
   - name: Smart Agent monitor
     url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-redis.md'
-  - name: Collection script
+  - name: Splunk Observability integration
+    url: 'https://docs.splunk.com/Observability/gdi/redis/redis.html'
+  - name: Collectd script
     url: 'https://github.com/signalfx/redis-collectd-plugin'
 
 source_doc: |
-  Check the [integration
-  documentation](https://docs.signalfx.com/en/latest/integrations/integrations-reference/integrations.redis.html)
-  in addition to the monitor one which it uses.
-
   ### Monitors
 
   The `collectd/redis` monitor requires to enable the following `extraMetrics`:

--- a/modules/smart-agent_solr/README.md
+++ b/modules/smart-agent_solr/README.md
@@ -7,7 +7,6 @@
 - [How to use this module?](#how-to-use-this-module)
 - [What are the available detectors in this module?](#what-are-the-available-detectors-in-this-module)
 - [How to collect required metrics?](#how-to-collect-required-metrics)
-  - [Monitors](#monitors)
   - [Metrics](#metrics)
 - [Related documentation](#related-documentation)
 
@@ -49,8 +48,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -82,32 +81,38 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-[monitors](https://docs.signalfx.com/en/latest/integrations/agent/monitors/_monitor-config.html)
-available in the [SignalFx Smart
-Agent](https://github.com/signalfx/signalfx-agent). Check the [Related documentation](#related-documentation) section for more
-information including the official documentation of this monitor.
+This module deploys detectors using metrics reported by the
+[SignalFx Smart Agent Monitors](https://github.com/signalfx/signalfx-agent#monitors).
+
+Even if the [Smart Agent is deprecated](https://github.com/signalfx/signalfx-agent/blob/main/docs/smartagent-deprecation-notice.md)
+it remains an efficient, lightweight and simple monitoring agent which still works fine.
+See the [official documentation](https://docs.splunk.com/Observability/gdi/smart-agent/smart-agent-resources.html) for more information
+about this agent.
+You might find the related following documentations useful:
+- the global level [agent configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/config-schema.md)
+- the [monitor level configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitor-config.md)
+- the internal [agent configuration tips](https://github.com/claranet/terraform-signalfx-detectors/wiki/Guidance#agent-configuration).
+- the full list of [monitors available](https://github.com/signalfx/signalfx-agent/tree/main/docs/monitors) with their own specific documentation.
+
+In addition, all of these monitors are still available in the [Splunk Otel Collector](https://github.com/signalfx/splunk-otel-collector),
+the Splunk [distro of OpenTelemetry Collector](https://opentelemetry.io/docs/concepts/distributions/) which replaces SignalFx Smart Agent,
+thanks to the internal [Smart Agent Receiver](https://github.com/signalfx/splunk-otel-collector/tree/main/internal/receiver/smartagentreceiver).
+
+As a result:
+- any SignalFx Smart Agent monitor are compatible with the new agent OpenTelemetry Collector and related modules in this repository keep `smart-agent` as source name.
+- any OpenTelemetry receiver not based on an existing Smart Agent monitor is not available from old agent so related modules in this repository use `otel-collector` as source name.
 
 
-Check the [integration
-documentation](https://docs.signalfx.com/en/latest/integrations/integrations-reference/integrations.apache.solr.html)
-in addition to the monitor one which it uses.
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
-### Monitors
-
-The `collectd/zookeeper` monitor requires to enable the following `extraMetrics`:
-
-* `counter.solr.zookeeper_errors`
-
-It can collect metrics from Solr only when a Solr instance is running in SolrCloud mode.
 
 
 ### Metrics
 
 
 To filter only required metrics for the detectors of this module, add the
-[datapointsToExclude](https://docs.signalfx.com/en/latest/integrations/agent/filtering.html) parameter to
-the corresponding monitor configuration:
+[datapointsToExclude](https://docs.splunk.com/observability/gdi/smart-agent/smart-agent-resources.html#filtering-data-using-the-smart-agent)
+parameter to the corresponding monitor configuration:
 
 ```yaml
     datapointsToExclude:
@@ -125,5 +130,7 @@ the corresponding monitor configuration:
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [Smart Agent monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/collectd-solr.html)
-* [Collection script](https://github.com/signalfx/collectd-solr)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [Smart Agent monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-solr.md)
+* [Splunk Observability integration](https://docs.splunk.com/Observability/gdi/solr/solr.html)
+* [Collectd script](https://github.com/signalfx/collectd-solr)

--- a/modules/smart-agent_solr/README.md
+++ b/modules/smart-agent_solr/README.md
@@ -15,7 +15,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -32,7 +32,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -48,7 +48,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -59,7 +59,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/smart-agent_solr/conf/readme.yaml
+++ b/modules/smart-agent_solr/conf/readme.yaml
@@ -1,6 +1,6 @@
 documentations:
   - name: Smart Agent monitor
-    url: 'https://docs.signalfx.com/en/latest/integrations/agent/monitors/collectd-solr.html'
+    url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-solr.md'
   - name: Collection script
     url: 'https://github.com/signalfx/collectd-solr'
 

--- a/modules/smart-agent_solr/conf/readme.yaml
+++ b/modules/smart-agent_solr/conf/readme.yaml
@@ -1,18 +1,7 @@
 documentations:
   - name: Smart Agent monitor
     url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-solr.md'
-  - name: Collection script
+  - name: Splunk Observability integration
+    url: 'https://docs.splunk.com/Observability/gdi/solr/solr.html'
+  - name: Collectd script
     url: 'https://github.com/signalfx/collectd-solr'
-
-source_doc: |
-  Check the [integration
-  documentation](https://docs.signalfx.com/en/latest/integrations/integrations-reference/integrations.apache.solr.html)
-  in addition to the monitor one which it uses.
-
-  ### Monitors
-
-  The `collectd/zookeeper` monitor requires to enable the following `extraMetrics`:
-
-  * `counter.solr.zookeeper_errors`
-
-  It can collect metrics from Solr only when a Solr instance is running in SolrCloud mode.

--- a/modules/smart-agent_supervisor/README.md
+++ b/modules/smart-agent_supervisor/README.md
@@ -50,8 +50,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -82,15 +82,29 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-[monitors](https://docs.signalfx.com/en/latest/integrations/agent/monitors/_monitor-config.html)
-available in the [SignalFx Smart
-Agent](https://github.com/signalfx/signalfx-agent). Check the [Related documentation](#related-documentation) section for more
-information including the official documentation of this monitor.
+This module deploys detectors using metrics reported by the
+[SignalFx Smart Agent Monitors](https://github.com/signalfx/signalfx-agent#monitors).
+
+Even if the [Smart Agent is deprecated](https://github.com/signalfx/signalfx-agent/blob/main/docs/smartagent-deprecation-notice.md)
+it remains an efficient, lightweight and simple monitoring agent which still works fine.
+See the [official documentation](https://docs.splunk.com/Observability/gdi/smart-agent/smart-agent-resources.html) for more information
+about this agent.
+You might find the related following documentations useful:
+- the global level [agent configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/config-schema.md)
+- the [monitor level configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitor-config.md)
+- the internal [agent configuration tips](https://github.com/claranet/terraform-signalfx-detectors/wiki/Guidance#agent-configuration).
+- the full list of [monitors available](https://github.com/signalfx/signalfx-agent/tree/main/docs/monitors) with their own specific documentation.
+
+In addition, all of these monitors are still available in the [Splunk Otel Collector](https://github.com/signalfx/splunk-otel-collector),
+the Splunk [distro of OpenTelemetry Collector](https://opentelemetry.io/docs/concepts/distributions/) which replaces SignalFx Smart Agent,
+thanks to the internal [Smart Agent Receiver](https://github.com/signalfx/splunk-otel-collector/tree/main/internal/receiver/smartagentreceiver).
+
+As a result:
+- any SignalFx Smart Agent monitor are compatible with the new agent OpenTelemetry Collector and related modules in this repository keep `smart-agent` as source name.
+- any OpenTelemetry receiver not based on an existing Smart Agent monitor is not available from old agent so related modules in this repository use `otel-collector` as source name.
 
 
-There is no SignalFx official integration for `supervisor` but there is still a
-[monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/supervisor.html) to use.
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 ### Monitors
 
@@ -111,8 +125,8 @@ port=localhost:9001
 
 
 To filter only required metrics for the detectors of this module, add the
-[datapointsToExclude](https://docs.signalfx.com/en/latest/integrations/agent/filtering.html) parameter to
-the corresponding monitor configuration:
+[datapointsToExclude](https://docs.splunk.com/observability/gdi/smart-agent/smart-agent-resources.html#filtering-data-using-the-smart-agent)
+parameter to the corresponding monitor configuration:
 
 ```yaml
     datapointsToExclude:
@@ -128,5 +142,7 @@ the corresponding monitor configuration:
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [Smart Agent monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/supervisor.html)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [Smart Agent monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/supervisor.md)
+* [Splunk Observability integration](https://docs.splunk.com/Observability/gdi/supervisor/supervisor.html)
 * [Supervisor state definition](http://supervisord.org/subprocess.html#process-states)

--- a/modules/smart-agent_supervisor/README.md
+++ b/modules/smart-agent_supervisor/README.md
@@ -17,7 +17,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -34,7 +34,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -50,7 +50,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -61,7 +61,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/smart-agent_supervisor/conf/readme.yaml
+++ b/modules/smart-agent_supervisor/conf/readme.yaml
@@ -1,13 +1,12 @@
 documentations:
   - name: Smart Agent monitor
     url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/supervisor.md'
+  - name: Splunk Observability integration
+    url: 'https://docs.splunk.com/Observability/gdi/supervisor/supervisor.html'
   - name: Supervisor state definition
     url: 'http://supervisord.org/subprocess.html#process-states'
 
 source_doc: |
-  There is no SignalFx official integration for `supervisor` but there is still a
-  [monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/supervisor.md) to use.
-
   ### Monitors
 
   This monitor is only available for agent `>= 5.2.0`.

--- a/modules/smart-agent_supervisor/conf/readme.yaml
+++ b/modules/smart-agent_supervisor/conf/readme.yaml
@@ -1,12 +1,12 @@
 documentations:
   - name: Smart Agent monitor
-    url: 'https://docs.signalfx.com/en/latest/integrations/agent/monitors/supervisor.html'
+    url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/supervisor.md'
   - name: Supervisor state definition
     url: 'http://supervisord.org/subprocess.html#process-states'
 
 source_doc: |
   There is no SignalFx official integration for `supervisor` but there is still a
-  [monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/supervisor.html) to use.
+  [monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/supervisor.md) to use.
 
   ### Monitors
 

--- a/modules/smart-agent_system-common/README.md
+++ b/modules/smart-agent_system-common/README.md
@@ -16,7 +16,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -33,7 +33,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -49,7 +49,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -60,7 +60,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf) and [variables-gen.tf](variables-gen.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/smart-agent_system-common/README.md
+++ b/modules/smart-agent_system-common/README.md
@@ -49,8 +49,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -86,15 +86,29 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-[monitors](https://docs.signalfx.com/en/latest/integrations/agent/monitors/_monitor-config.html)
-available in the [SignalFx Smart
-Agent](https://github.com/signalfx/signalfx-agent). Check the [Related documentation](#related-documentation) section for more
-information including the official documentation of this monitor.
+This module deploys detectors using metrics reported by the
+[SignalFx Smart Agent Monitors](https://github.com/signalfx/signalfx-agent#monitors).
+
+Even if the [Smart Agent is deprecated](https://github.com/signalfx/signalfx-agent/blob/main/docs/smartagent-deprecation-notice.md)
+it remains an efficient, lightweight and simple monitoring agent which still works fine.
+See the [official documentation](https://docs.splunk.com/Observability/gdi/smart-agent/smart-agent-resources.html) for more information
+about this agent.
+You might find the related following documentations useful:
+- the global level [agent configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/config-schema.md)
+- the [monitor level configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitor-config.md)
+- the internal [agent configuration tips](https://github.com/claranet/terraform-signalfx-detectors/wiki/Guidance#agent-configuration).
+- the full list of [monitors available](https://github.com/signalfx/signalfx-agent/tree/main/docs/monitors) with their own specific documentation.
+
+In addition, all of these monitors are still available in the [Splunk Otel Collector](https://github.com/signalfx/splunk-otel-collector),
+the Splunk [distro of OpenTelemetry Collector](https://opentelemetry.io/docs/concepts/distributions/) which replaces SignalFx Smart Agent,
+thanks to the internal [Smart Agent Receiver](https://github.com/signalfx/splunk-otel-collector/tree/main/internal/receiver/smartagentreceiver).
+
+As a result:
+- any SignalFx Smart Agent monitor are compatible with the new agent OpenTelemetry Collector and related modules in this repository keep `smart-agent` as source name.
+- any OpenTelemetry receiver not based on an existing Smart Agent monitor is not available from old agent so related modules in this repository use `otel-collector` as source name.
 
 
-There is no one official integration for system generic metrics but instead multiple monitors to fetch
-all useful metrics from `cpu`, `load`, `filesystems` and `memory`.
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 ### Monitors
 
@@ -112,8 +126,8 @@ But we exclude it explicitly in related detector for safety to prevent any alert
 #### Load
 
 You have two choices to use load based detectors:
-  - either keep the `per_cpu_enabled` enabled (variable default value) __and__ define `perCPU: true` in the [load monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/load.html) configuration (for Kubernetes, you can use `loadPerCPU` option from the Helm chart available from `1.2.0` version).
-  - or override the `per_cpu_enabled` to `false` __and__ keep the default configuration for the [load monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/load.html) with `perCPU: false` or not defined
+  - either keep the `per_cpu_enabled` enabled (variable default value) __and__ define `perCPU: true` in the [load monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/load.md) configuration (for Kubernetes, you can use `loadPerCPU` option from the Helm chart available from `1.2.0` version).
+  - or override the `per_cpu_enabled` to `false` __and__ keep the default configuration for the [load monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/load.md) with `perCPU: false` or not defined
 
 In both cases, the goal is to get alerts based on the __ratio__ of load by dividing the original load per the number of CPU/cores which is the only way to get generic and relevant alerts for load.
 It mainly depends if you want to collect 2 metrics instead of 1 and if you want the load one to be raw or already averaged.
@@ -123,8 +137,8 @@ It mainly depends if you want to collect 2 metrics instead of 1 and if you want 
 
 
 To filter only required metrics for the detectors of this module, add the
-[datapointsToExclude](https://docs.signalfx.com/en/latest/integrations/agent/filtering.html) parameter to
-the corresponding monitor configuration:
+[datapointsToExclude](https://docs.splunk.com/observability/gdi/smart-agent/smart-agent-resources.html#filtering-data-using-the-smart-agent)
+parameter to the corresponding monitor configuration:
 
 ```yaml
     datapointsToExclude:
@@ -145,8 +159,11 @@ the corresponding monitor configuration:
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [Smart Agent monitor host-metadata](https://docs.signalfx.com/en/latest/integrations/agent/monitors/host-metadata.html)
-* [Smart Agent monitor cpu](https://docs.signalfx.com/en/latest/integrations/agent/monitors/cpu.html)
-* [Smart Agent monitor load](https://docs.signalfx.com/en/latest/integrations/agent/monitors/load.html)
-* [Smart Agent monitor filesystems](https://docs.signalfx.com/en/latest/integrations/agent/monitors/filesystems.html)
-* [Smart Agent monitor memory](https://docs.signalfx.com/en/latest/integrations/agent/monitors/memory.html)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [Smart Agent monitor host-metadata](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/host-metadata.md)
+* [Smart Agent monitor cpu](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/cpu.md)
+* [Smart Agent monitor load](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/load.md)
+* [Smart Agent monitor filesystems](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/filesystems.md)
+* [Smart Agent monitor memory](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/memory.md)
+* [Splunk Observability integration cpu](https://docs.splunk.com/Observability/gdi/cpu/cpu.html)
+* [Splunk Observability integration load](https://docs.splunk.com/Observability/gdi/load/load.html)

--- a/modules/smart-agent_system-common/conf/readme.yaml
+++ b/modules/smart-agent_system-common/conf/readme.yaml
@@ -1,14 +1,14 @@
 documentations:
   - name: Smart Agent monitor host-metadata
-    url: 'https://docs.signalfx.com/en/latest/integrations/agent/monitors/host-metadata.html'
+    url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/host-metadata.md'
   - name: Smart Agent monitor cpu
-    url: 'https://docs.signalfx.com/en/latest/integrations/agent/monitors/cpu.html'
+    url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/cpu.md'
   - name: Smart Agent monitor load
-    url: 'https://docs.signalfx.com/en/latest/integrations/agent/monitors/load.html'
+    url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/load.md'
   - name: Smart Agent monitor filesystems
-    url: 'https://docs.signalfx.com/en/latest/integrations/agent/monitors/filesystems.html'
+    url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/filesystems.md'
   - name: Smart Agent monitor memory
-    url: 'https://docs.signalfx.com/en/latest/integrations/agent/monitors/memory.html'
+    url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/memory.md'
 
 source_doc: |
   There is no one official integration for system generic metrics but instead multiple monitors to fetch
@@ -30,8 +30,8 @@ source_doc: |
   #### Load
 
   You have two choices to use load based detectors:
-    - either keep the `per_cpu_enabled` enabled (variable default value) __and__ define `perCPU: true` in the [load monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/load.html) configuration (for Kubernetes, you can use `loadPerCPU` option from the Helm chart available from `1.2.0` version).
-    - or override the `per_cpu_enabled` to `false` __and__ keep the default configuration for the [load monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/load.html) with `perCPU: false` or not defined
+    - either keep the `per_cpu_enabled` enabled (variable default value) __and__ define `perCPU: true` in the [load monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/load.md) configuration (for Kubernetes, you can use `loadPerCPU` option from the Helm chart available from `1.2.0` version).
+    - or override the `per_cpu_enabled` to `false` __and__ keep the default configuration for the [load monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/load.md) with `perCPU: false` or not defined
 
   In both cases, the goal is to get alerts based on the __ratio__ of load by dividing the original load per the number of CPU/cores which is the only way to get generic and relevant alerts for load.
   It mainly depends if you want to collect 2 metrics instead of 1 and if you want the load one to be raw or already averaged.

--- a/modules/smart-agent_system-common/conf/readme.yaml
+++ b/modules/smart-agent_system-common/conf/readme.yaml
@@ -9,11 +9,12 @@ documentations:
     url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/filesystems.md'
   - name: Smart Agent monitor memory
     url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/memory.md'
+  - name: Splunk Observability integration cpu
+    url: 'https://docs.splunk.com/Observability/gdi/cpu/cpu.html'
+  - name: Splunk Observability integration load
+    url: 'https://docs.splunk.com/Observability/gdi/load/load.html'
 
 source_doc: |
-  There is no one official integration for system generic metrics but instead multiple monitors to fetch
-  all useful metrics from `cpu`, `load`, `filesystems` and `memory`.
-
   ### Monitors
 
   #### Inodes

--- a/modules/smart-agent_systemd-services/README.md
+++ b/modules/smart-agent_systemd-services/README.md
@@ -16,7 +16,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -33,7 +33,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -49,7 +49,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -60,7 +60,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables-gen.tf](variables-gen.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/smart-agent_systemd-services/README.md
+++ b/modules/smart-agent_systemd-services/README.md
@@ -49,8 +49,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -80,16 +80,31 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-[monitors](https://docs.signalfx.com/en/latest/integrations/agent/monitors/_monitor-config.html)
-available in the [SignalFx Smart
-Agent](https://github.com/signalfx/signalfx-agent). Check the [Related documentation](#related-documentation) section for more
-information including the official documentation of this monitor.
+This module deploys detectors using metrics reported by the
+[SignalFx Smart Agent Monitors](https://github.com/signalfx/signalfx-agent#monitors).
 
+Even if the [Smart Agent is deprecated](https://github.com/signalfx/signalfx-agent/blob/main/docs/smartagent-deprecation-notice.md)
+it remains an efficient, lightweight and simple monitoring agent which still works fine.
+See the [official documentation](https://docs.splunk.com/Observability/gdi/smart-agent/smart-agent-resources.html) for more information
+about this agent.
+You might find the related following documentations useful:
+- the global level [agent configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/config-schema.md)
+- the [monitor level configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitor-config.md)
+- the internal [agent configuration tips](https://github.com/claranet/terraform-signalfx-detectors/wiki/Guidance#agent-configuration).
+- the full list of [monitors available](https://github.com/signalfx/signalfx-agent/tree/main/docs/monitors) with their own specific documentation.
+
+In addition, all of these monitors are still available in the [Splunk Otel Collector](https://github.com/signalfx/splunk-otel-collector),
+the Splunk [distro of OpenTelemetry Collector](https://opentelemetry.io/docs/concepts/distributions/) which replaces SignalFx Smart Agent,
+thanks to the internal [Smart Agent Receiver](https://github.com/signalfx/splunk-otel-collector/tree/main/internal/receiver/smartagentreceiver).
+
+As a result:
+- any SignalFx Smart Agent monitor are compatible with the new agent OpenTelemetry Collector and related modules in this repository keep `smart-agent` as source name.
+- any OpenTelemetry receiver not based on an existing Smart Agent monitor is not available from old agent so related modules in this repository use `otel-collector` as source name.
+
+
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 ### Monitor
-
-The detector of this module is based on metrics reported by the [collectd/systemd](https://docs.signalfx.com/en/latest/integrations/agent/monitors/collectd-systemd.html) monitor.
 
 For example, to monitor the `toto.service` and `titi.service` on your host, your SignalFX agent should look like this:
 
@@ -108,8 +123,8 @@ monitors:
 
 
 To filter only required metrics for the detectors of this module, add the
-[datapointsToExclude](https://docs.signalfx.com/en/latest/integrations/agent/filtering.html) parameter to
-the corresponding monitor configuration:
+[datapointsToExclude](https://docs.splunk.com/observability/gdi/smart-agent/smart-agent-resources.html#filtering-data-using-the-smart-agent)
+parameter to the corresponding monitor configuration:
 
 ```yaml
     datapointsToExclude:
@@ -125,4 +140,6 @@ the corresponding monitor configuration:
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [Smart Agent monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/collectd-systemd.html)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [Smart Agent monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-systemd.md)
+* [Collectd Script](https://github.com/signalfx/collectd-systemd)

--- a/modules/smart-agent_systemd-services/conf/readme.yaml
+++ b/modules/smart-agent_systemd-services/conf/readme.yaml
@@ -1,11 +1,11 @@
 documentations:
   - name: Smart Agent monitor
-    url: 'https://docs.signalfx.com/en/latest/integrations/agent/monitors/collectd-systemd.html'
+    url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-systemd.md'
 
 source_doc: |
   ### Monitor
 
-  The detector of this module is based on metrics reported by the [collectd/systemd](https://docs.signalfx.com/en/latest/integrations/agent/monitors/collectd-systemd.html) monitor.
+  The detector of this module is based on metrics reported by the [collectd/systemd](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-systemd.md) monitor.
 
   For example, to monitor the `toto.service` and `titi.service` on your host, your SignalFX agent should look like this:
 

--- a/modules/smart-agent_systemd-services/conf/readme.yaml
+++ b/modules/smart-agent_systemd-services/conf/readme.yaml
@@ -1,11 +1,11 @@
 documentations:
   - name: Smart Agent monitor
     url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-systemd.md'
+  - name: Collectd Script
+    url: 'https://github.com/signalfx/collectd-systemd'
 
 source_doc: |
   ### Monitor
-
-  The detector of this module is based on metrics reported by the [collectd/systemd](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-systemd.md) monitor.
 
   For example, to monitor the `toto.service` and `titi.service` on your host, your SignalFX agent should look like this:
 

--- a/modules/smart-agent_systemd-timers/README.md
+++ b/modules/smart-agent_systemd-timers/README.md
@@ -49,8 +49,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -82,14 +82,33 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-[monitors](https://docs.signalfx.com/en/latest/integrations/agent/monitors/_monitor-config.html)
-available in the [SignalFx Smart
-Agent](https://github.com/signalfx/signalfx-agent). Check the [Related documentation](#related-documentation) section for more
-information including the official documentation of this monitor.
+This module deploys detectors using metrics reported by the
+[SignalFx Smart Agent Monitors](https://github.com/signalfx/signalfx-agent#monitors).
+
+Even if the [Smart Agent is deprecated](https://github.com/signalfx/signalfx-agent/blob/main/docs/smartagent-deprecation-notice.md)
+it remains an efficient, lightweight and simple monitoring agent which still works fine.
+See the [official documentation](https://docs.splunk.com/Observability/gdi/smart-agent/smart-agent-resources.html) for more information
+about this agent.
+You might find the related following documentations useful:
+- the global level [agent configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/config-schema.md)
+- the [monitor level configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitor-config.md)
+- the internal [agent configuration tips](https://github.com/claranet/terraform-signalfx-detectors/wiki/Guidance#agent-configuration).
+- the full list of [monitors available](https://github.com/signalfx/signalfx-agent/tree/main/docs/monitors) with their own specific documentation.
+
+In addition, all of these monitors are still available in the [Splunk Otel Collector](https://github.com/signalfx/splunk-otel-collector),
+the Splunk [distro of OpenTelemetry Collector](https://opentelemetry.io/docs/concepts/distributions/) which replaces SignalFx Smart Agent,
+thanks to the internal [Smart Agent Receiver](https://github.com/signalfx/splunk-otel-collector/tree/main/internal/receiver/smartagentreceiver).
+
+As a result:
+- any SignalFx Smart Agent monitor are compatible with the new agent OpenTelemetry Collector and related modules in this repository keep `smart-agent` as source name.
+- any OpenTelemetry receiver not based on an existing Smart Agent monitor is not available from old agent so related modules in this repository use `otel-collector` as source name.
 
 
-This module checks Systemd services launched by Systemd timers. The difference with [smart-agent_systemd-services](https://github.com/claranet/terraform-signalfx-detectors/tree/master/modules/smart-agent_systemd-services) is that services launched by timers are not supposed to be always running, and instead can be stopped most of the time.
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
+
+This module checks Systemd services launched by Systemd timers.
+The difference with [smart-agent_systemd-services](https://github.com/claranet/terraform-signalfx-detectors/tree/master/modules/smart-agent_systemd-services)
+is that services launched by timers are not supposed to be always running, and instead can be stopped most of the time.
 
 Detectors are designed to check that the job did not failed (enabled by default), the service have not been removed (disabled by default), and the job have been launched during the past day (disabled by default, you can override the default delay with the `execution_delay_lasting_duration_major` variable).
 
@@ -127,8 +146,8 @@ You can configure the systemd collector in the agent the following way to report
 
 
 To filter only required metrics for the detectors of this module, add the
-[datapointsToExclude](https://docs.signalfx.com/en/latest/integrations/agent/filtering.html) parameter to
-the corresponding monitor configuration:
+[datapointsToExclude](https://docs.splunk.com/observability/gdi/smart-agent/smart-agent-resources.html#filtering-data-using-the-smart-agent)
+parameter to the corresponding monitor configuration:
 
 ```yaml
     datapointsToExclude:
@@ -146,4 +165,6 @@ the corresponding monitor configuration:
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [Smart Agent monitor collectd/systemd](https://docs.signalfx.com/en/latest/integrations/agent/monitors/collectd-systemd.html)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [Smart Agent monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-systemd.md)
+* [Collectd Script](https://github.com/signalfx/collectd-systemd)

--- a/modules/smart-agent_systemd-timers/README.md
+++ b/modules/smart-agent_systemd-timers/README.md
@@ -16,7 +16,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -33,7 +33,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -49,7 +49,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -60,7 +60,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables-gen.tf](variables-gen.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/smart-agent_systemd-timers/conf/readme.yaml
+++ b/modules/smart-agent_systemd-timers/conf/readme.yaml
@@ -1,6 +1,6 @@
 documentations:
   - name: Smart Agent monitor collectd/systemd
-    url: https://docs.signalfx.com/en/latest/integrations/agent/monitors/collectd-systemd.html
+    url: https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-systemd.md
 
 source_doc: |
   This module checks Systemd services launched by Systemd timers. The difference with [smart-agent_systemd-services](https://github.com/claranet/terraform-signalfx-detectors/tree/master/modules/smart-agent_systemd-services) is that services launched by timers are not supposed to be always running, and instead can be stopped most of the time.

--- a/modules/smart-agent_systemd-timers/conf/readme.yaml
+++ b/modules/smart-agent_systemd-timers/conf/readme.yaml
@@ -1,9 +1,13 @@
 documentations:
-  - name: Smart Agent monitor collectd/systemd
-    url: https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-systemd.md
+  - name: Smart Agent monitor
+    url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-systemd.md'
+  - name: Collectd Script
+    url: 'https://github.com/signalfx/collectd-systemd'
 
 source_doc: |
-  This module checks Systemd services launched by Systemd timers. The difference with [smart-agent_systemd-services](https://github.com/claranet/terraform-signalfx-detectors/tree/master/modules/smart-agent_systemd-services) is that services launched by timers are not supposed to be always running, and instead can be stopped most of the time.
+  This module checks Systemd services launched by Systemd timers.
+  The difference with [smart-agent_systemd-services](https://github.com/claranet/terraform-signalfx-detectors/tree/master/modules/smart-agent_systemd-services)
+  is that services launched by timers are not supposed to be always running, and instead can be stopped most of the time.
 
   Detectors are designed to check that the job did not failed (enabled by default), the service have not been removed (disabled by default), and the job have been launched during the past day (disabled by default, you can override the default delay with the `execution_delay_lasting_duration_major` variable).
 

--- a/modules/smart-agent_tomcat/README.md
+++ b/modules/smart-agent_tomcat/README.md
@@ -19,7 +19,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -36,7 +36,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -52,7 +52,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -63,7 +63,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/smart-agent_tomcat/README.md
+++ b/modules/smart-agent_tomcat/README.md
@@ -52,8 +52,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -85,22 +85,34 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-[monitors](https://docs.signalfx.com/en/latest/integrations/agent/monitors/_monitor-config.html)
-available in the [SignalFx Smart
-Agent](https://github.com/signalfx/signalfx-agent). Check the [Related documentation](#related-documentation) section for more
-information including the official documentation of this monitor.
+This module deploys detectors using metrics reported by the
+[SignalFx Smart Agent Monitors](https://github.com/signalfx/signalfx-agent#monitors).
+
+Even if the [Smart Agent is deprecated](https://github.com/signalfx/signalfx-agent/blob/main/docs/smartagent-deprecation-notice.md)
+it remains an efficient, lightweight and simple monitoring agent which still works fine.
+See the [official documentation](https://docs.splunk.com/Observability/gdi/smart-agent/smart-agent-resources.html) for more information
+about this agent.
+You might find the related following documentations useful:
+- the global level [agent configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/config-schema.md)
+- the [monitor level configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitor-config.md)
+- the internal [agent configuration tips](https://github.com/claranet/terraform-signalfx-detectors/wiki/Guidance#agent-configuration).
+- the full list of [monitors available](https://github.com/signalfx/signalfx-agent/tree/main/docs/monitors) with their own specific documentation.
+
+In addition, all of these monitors are still available in the [Splunk Otel Collector](https://github.com/signalfx/splunk-otel-collector),
+the Splunk [distro of OpenTelemetry Collector](https://opentelemetry.io/docs/concepts/distributions/) which replaces SignalFx Smart Agent,
+thanks to the internal [Smart Agent Receiver](https://github.com/signalfx/splunk-otel-collector/tree/main/internal/receiver/smartagentreceiver).
+
+As a result:
+- any SignalFx Smart Agent monitor are compatible with the new agent OpenTelemetry Collector and related modules in this repository keep `smart-agent` as source name.
+- any OpenTelemetry receiver not based on an existing Smart Agent monitor is not available from old agent so related modules in this repository use `otel-collector` as source name.
 
 
-There is no SignalFx official integration for `tomcat` but there is still a
-[monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/collectd-genericjmx.html) to use.
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 ### Agent
 
-The agent requires to [Java
-plugin](https://docs.signalfx.com/en/latest/integrations/integrations-reference/integrations.java.html)
-for Collectd which is already installed in the [SignalFx Smart
-Agent](https://github.com/signalfx/signalfx-agent/).
+The agent requires the [Collectd Java plugin](https://collectd.org/wiki/index.php/Plugin:Java)
+which should already be installed with the [SignalFx Smart Agent](https://github.com/signalfx/signalfx-agent/).
 
 ### Monitors
 
@@ -122,8 +134,8 @@ on your `tomcat` server(s).
 
 
 To filter only required metrics for the detectors of this module, add the
-[datapointsToExclude](https://docs.signalfx.com/en/latest/integrations/agent/filtering.html) parameter to
-the corresponding monitor configuration:
+[datapointsToExclude](https://docs.splunk.com/observability/gdi/smart-agent/smart-agent-resources.html#filtering-data-using-the-smart-agent)
+parameter to the corresponding monitor configuration:
 
 ```yaml
     datapointsToExclude:
@@ -149,5 +161,7 @@ You can use `genericjmx` module as complement to this one to monitor generic JMX
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [Smart Agent monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/collectd-tomcat.html)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [Smart Agent monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-tomcat.md)
+* [Splunk Observability integration](https://docs.splunk.com/Observability/gdi/tomcat/tomcat.html)
 * [Collectd plugin](https://collectd.org/wiki/index.php/Plugin:GenericJMX)

--- a/modules/smart-agent_tomcat/conf/readme.yaml
+++ b/modules/smart-agent_tomcat/conf/readme.yaml
@@ -1,19 +1,16 @@
 documentations:
   - name: Smart Agent monitor
     url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-tomcat.md'
+  - name: Splunk Observability integration
+    url: 'https://docs.splunk.com/Observability/gdi/tomcat/tomcat.html'
   - name: Collectd plugin
     url: 'https://collectd.org/wiki/index.php/Plugin:GenericJMX'
 
 source_doc: |
-  There is no SignalFx official integration for `tomcat` but there is still a
-  [monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-genericjmx.md) to use.
-
   ### Agent
 
-  The agent requires to [Java
-  plugin](https://docs.signalfx.com/en/latest/integrations/integrations-reference/integrations.java.html)
-  for Collectd which is already installed in the [SignalFx Smart
-  Agent](https://github.com/signalfx/signalfx-agent/).
+  The agent requires the [Collectd Java plugin](https://collectd.org/wiki/index.php/Plugin:Java)
+  which should already be installed with the [SignalFx Smart Agent](https://github.com/signalfx/signalfx-agent/).
 
   ### Monitors
 

--- a/modules/smart-agent_tomcat/conf/readme.yaml
+++ b/modules/smart-agent_tomcat/conf/readme.yaml
@@ -1,12 +1,12 @@
 documentations:
   - name: Smart Agent monitor
-    url: 'https://docs.signalfx.com/en/latest/integrations/agent/monitors/collectd-tomcat.html'
+    url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-tomcat.md'
   - name: Collectd plugin
     url: 'https://collectd.org/wiki/index.php/Plugin:GenericJMX'
 
 source_doc: |
   There is no SignalFx official integration for `tomcat` but there is still a
-  [monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/collectd-genericjmx.html) to use.
+  [monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-genericjmx.md) to use.
 
   ### Agent
 

--- a/modules/smart-agent_varnish/README.md
+++ b/modules/smart-agent_varnish/README.md
@@ -18,7 +18,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -35,7 +35,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -51,7 +51,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -62,7 +62,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/smart-agent_varnish/README.md
+++ b/modules/smart-agent_varnish/README.md
@@ -51,8 +51,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -87,15 +87,29 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-[monitors](https://docs.signalfx.com/en/latest/integrations/agent/monitors/_monitor-config.html)
-available in the [SignalFx Smart
-Agent](https://github.com/signalfx/signalfx-agent). Check the [Related documentation](#related-documentation) section for more
-information including the official documentation of this monitor.
+This module deploys detectors using metrics reported by the
+[SignalFx Smart Agent Monitors](https://github.com/signalfx/signalfx-agent#monitors).
+
+Even if the [Smart Agent is deprecated](https://github.com/signalfx/signalfx-agent/blob/main/docs/smartagent-deprecation-notice.md)
+it remains an efficient, lightweight and simple monitoring agent which still works fine.
+See the [official documentation](https://docs.splunk.com/Observability/gdi/smart-agent/smart-agent-resources.html) for more information
+about this agent.
+You might find the related following documentations useful:
+- the global level [agent configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/config-schema.md)
+- the [monitor level configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitor-config.md)
+- the internal [agent configuration tips](https://github.com/claranet/terraform-signalfx-detectors/wiki/Guidance#agent-configuration).
+- the full list of [monitors available](https://github.com/signalfx/signalfx-agent/tree/main/docs/monitors) with their own specific documentation.
+
+In addition, all of these monitors are still available in the [Splunk Otel Collector](https://github.com/signalfx/splunk-otel-collector),
+the Splunk [distro of OpenTelemetry Collector](https://opentelemetry.io/docs/concepts/distributions/) which replaces SignalFx Smart Agent,
+thanks to the internal [Smart Agent Receiver](https://github.com/signalfx/splunk-otel-collector/tree/main/internal/receiver/smartagentreceiver).
+
+As a result:
+- any SignalFx Smart Agent monitor are compatible with the new agent OpenTelemetry Collector and related modules in this repository keep `smart-agent` as source name.
+- any OpenTelemetry receiver not based on an existing Smart Agent monitor is not available from old agent so related modules in this repository use `otel-collector` as source name.
 
 
-There is no SignalFx official integration for `varnish` but there is still a
-[monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/telegraf-varnish.html) to use.
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 ### Monitors
 
@@ -145,8 +159,8 @@ from `SMA` varnishstat section to append to `stats` parameter.
 
 
 To filter only required metrics for the detectors of this module, add the
-[datapointsToExclude](https://docs.signalfx.com/en/latest/integrations/agent/filtering.html) parameter to
-the corresponding monitor configuration:
+[datapointsToExclude](https://docs.splunk.com/observability/gdi/smart-agent/smart-agent-resources.html#filtering-data-using-the-smart-agent)
+parameter to the corresponding monitor configuration:
 
 ```yaml
     datapointsToExclude:
@@ -168,5 +182,8 @@ the corresponding monitor configuration:
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [Smart Agent monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/telegraf-varnish.html)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [Smart Agent monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/telegraf-varnish.md)
+* [Splunk Observability integration](https://docs.splunk.com/Observability/gdi/varnish/telegraf-varnish.html)
+* [Telegraf Plugin](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/varnish)
 * [Varnishstat command](https://varnish-cache.org/docs/trunk/reference/varnishstat.html)

--- a/modules/smart-agent_varnish/conf/readme.yaml
+++ b/modules/smart-agent_varnish/conf/readme.yaml
@@ -1,12 +1,12 @@
 documentations:
   - name: Smart Agent monitor
-    url: 'https://docs.signalfx.com/en/latest/integrations/agent/monitors/telegraf-varnish.html'
+    url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/telegraf-varnish.md'
   - name: Varnishstat command
     url: 'https://varnish-cache.org/docs/trunk/reference/varnishstat.html'
 
 source_doc: |
   There is no SignalFx official integration for `varnish` but there is still a
-  [monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/telegraf-varnish.html) to use.
+  [monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/telegraf-varnish.md) to use.
 
   ### Monitors
 

--- a/modules/smart-agent_varnish/conf/readme.yaml
+++ b/modules/smart-agent_varnish/conf/readme.yaml
@@ -1,13 +1,14 @@
 documentations:
   - name: Smart Agent monitor
     url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/telegraf-varnish.md'
+  - name: Splunk Observability integration
+    url: 'https://docs.splunk.com/Observability/gdi/varnish/telegraf-varnish.html'
+  - name: Telegraf Plugin
+    url: 'https://github.com/influxdata/telegraf/tree/master/plugins/inputs/varnish'
   - name: Varnishstat command
     url: 'https://varnish-cache.org/docs/trunk/reference/varnishstat.html'
 
 source_doc: |
-  There is no SignalFx official integration for `varnish` but there is still a
-  [monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/telegraf-varnish.md) to use.
-
   ### Monitors
 
   This monitor is only available from agent version `>= 5.5.0`

--- a/modules/smart-agent_zookeeper/README.md
+++ b/modules/smart-agent_zookeeper/README.md
@@ -50,8 +50,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -84,16 +84,29 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
-[monitors](https://docs.signalfx.com/en/latest/integrations/agent/monitors/_monitor-config.html)
-available in the [SignalFx Smart
-Agent](https://github.com/signalfx/signalfx-agent). Check the [Related documentation](#related-documentation) section for more
-information including the official documentation of this monitor.
+This module deploys detectors using metrics reported by the
+[SignalFx Smart Agent Monitors](https://github.com/signalfx/signalfx-agent#monitors).
+
+Even if the [Smart Agent is deprecated](https://github.com/signalfx/signalfx-agent/blob/main/docs/smartagent-deprecation-notice.md)
+it remains an efficient, lightweight and simple monitoring agent which still works fine.
+See the [official documentation](https://docs.splunk.com/Observability/gdi/smart-agent/smart-agent-resources.html) for more information
+about this agent.
+You might find the related following documentations useful:
+- the global level [agent configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/config-schema.md)
+- the [monitor level configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitor-config.md)
+- the internal [agent configuration tips](https://github.com/claranet/terraform-signalfx-detectors/wiki/Guidance#agent-configuration).
+- the full list of [monitors available](https://github.com/signalfx/signalfx-agent/tree/main/docs/monitors) with their own specific documentation.
+
+In addition, all of these monitors are still available in the [Splunk Otel Collector](https://github.com/signalfx/splunk-otel-collector),
+the Splunk [distro of OpenTelemetry Collector](https://opentelemetry.io/docs/concepts/distributions/) which replaces SignalFx Smart Agent,
+thanks to the internal [Smart Agent Receiver](https://github.com/signalfx/splunk-otel-collector/tree/main/internal/receiver/smartagentreceiver).
+
+As a result:
+- any SignalFx Smart Agent monitor are compatible with the new agent OpenTelemetry Collector and related modules in this repository keep `smart-agent` as source name.
+- any OpenTelemetry receiver not based on an existing Smart Agent monitor is not available from old agent so related modules in this repository use `otel-collector` as source name.
 
 
-Check the [integration
-documentation](https://docs.signalfx.com/en/latest/integrations/integrations-reference/integrations.zookeeper.html)
-in addition to the monitor one which it uses.
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 ### Monitors
 
@@ -122,8 +135,8 @@ or trousbleshooting purpose.
 
 
 To filter only required metrics for the detectors of this module, add the
-[datapointsToExclude](https://docs.signalfx.com/en/latest/integrations/agent/filtering.html) parameter to
-the corresponding monitor configuration:
+[datapointsToExclude](https://docs.splunk.com/observability/gdi/smart-agent/smart-agent-resources.html#filtering-data-using-the-smart-agent)
+parameter to the corresponding monitor configuration:
 
 ```yaml
     datapointsToExclude:
@@ -142,5 +155,7 @@ the corresponding monitor configuration:
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
-* [Smart Agent monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/collectd-zookeeper.html)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [Smart Agent monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-zookeeper.md)
+* [Splunk Observability integration](https://docs.splunk.com/Observability/gdi/zookeeper/zookeeper.html)
 * [Collection script](https://github.com/signalfx/collectd-zookeeper)

--- a/modules/smart-agent_zookeeper/README.md
+++ b/modules/smart-agent_zookeeper/README.md
@@ -17,7 +17,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -34,7 +34,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -50,7 +50,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -61,7 +61,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 [variables.tf](variables.tf).
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/modules/smart-agent_zookeeper/conf/readme.yaml
+++ b/modules/smart-agent_zookeeper/conf/readme.yaml
@@ -1,6 +1,6 @@
 documentations:
   - name: Smart Agent monitor
-    url: 'https://docs.signalfx.com/en/latest/integrations/agent/monitors/collectd-zookeeper.html'
+    url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-zookeeper.md'
   - name: Collection script
     url: 'https://github.com/signalfx/collectd-zookeeper'
 

--- a/modules/smart-agent_zookeeper/conf/readme.yaml
+++ b/modules/smart-agent_zookeeper/conf/readme.yaml
@@ -1,14 +1,12 @@
 documentations:
   - name: Smart Agent monitor
     url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-zookeeper.md'
+  - name: Splunk Observability integration
+    url: 'https://docs.splunk.com/Observability/gdi/zookeeper/zookeeper.html'
   - name: Collection script
     url: 'https://github.com/signalfx/collectd-zookeeper'
 
 source_doc: |
-  Check the [integration
-  documentation](https://docs.signalfx.com/en/latest/integrations/integrations-reference/integrations.zookeeper.html)
-  in addition to the monitor one which it uses.
-
   ### Monitors
 
   The `collectd/zookeeper` monitor requires to enable the following `extraMetrics`:

--- a/scripts/templates/readme.md.j2
+++ b/scripts/templates/readme.md.j2
@@ -9,7 +9,7 @@
 ## How to use this module?
 
 This directory defines a [Terraform](https://www.terraform.io/)
-[module](https://www.terraform.io/docs/modules/usage.html) you can use in your
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
 existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
 `module` configuration and setting its `source` parameter to URL of this folder:
 
@@ -21,7 +21,7 @@ Note the following parameters:
 
 * `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
   Terraform uses it to specify subfolders within a Git repo (see [module
-  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
   this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
   like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
   [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
@@ -37,7 +37,7 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
   [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
@@ -48,7 +48,7 @@ These 3 parameters alongs with all variables defined in [common-variables.tf](co
 [modules](../) in this repository. Other variables, specific to this module, are available in
 {% for var_file in var_files %}{% if var_files|length > 1 and not loop.first %} and {% endif %}[{{ var_file }}]({{ var_file }}){% endfor %}.
 In general, the default configuration "works" but all of these Terraform
-[variables](https://www.terraform.io/docs/configuration/variables.html) make it possible to
+[variables](https://www.terraform.io/language/values/variables) make it possible to
 customize the detectors behavior to better fit your needs.
 
 Most of them represent usual tips and rules detailled in the

--- a/scripts/templates/readme.md.j2
+++ b/scripts/templates/readme.md.j2
@@ -66,43 +66,73 @@ This module creates the following SignalFx detectors which could contain one or 
 
 ## How to collect required metrics?
 
-This module uses metrics available from
+This module deploys detectors using metrics reported by the
 {% if source_type == 'smart-agent' -%}
-[monitors](https://docs.signalfx.com/en/latest/integrations/agent/monitors/_monitor-config.html)
-available in the [SignalFx Smart
-Agent](https://github.com/signalfx/signalfx-agent). Check the [Related documentation](#related-documentation) section for more
-information including the official documentation of this monitor.
+[SignalFx Smart Agent Monitors](https://github.com/signalfx/signalfx-agent#monitors).
+
+Even if the [Smart Agent is deprecated](https://github.com/signalfx/signalfx-agent/blob/main/docs/smartagent-deprecation-notice.md)
+it remains an efficient, lightweight and simple monitoring agent which still works fine.
+See the [official documentation](https://docs.splunk.com/Observability/gdi/smart-agent/smart-agent-resources.html) for more information
+about this agent.
+You might find the related following documentations useful:
+- the global level [agent configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/config-schema.md)
+- the [monitor level configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitor-config.md)
+- the internal [agent configuration tips](https://github.com/claranet/terraform-signalfx-detectors/wiki/Guidance#agent-configuration).
+- the full list of [monitors available](https://github.com/signalfx/signalfx-agent/tree/main/docs/monitors) with their own specific documentation.
+
+In addition, all of these monitors are still available in the [Splunk Otel Collector](https://github.com/signalfx/splunk-otel-collector),
+the Splunk [distro of OpenTelemetry Collector](https://opentelemetry.io/docs/concepts/distributions/) which replaces SignalFx Smart Agent,
+thanks to the internal [Smart Agent Receiver](https://github.com/signalfx/splunk-otel-collector/tree/main/internal/receiver/smartagentreceiver).
+
+As a result:
+- any SignalFx Smart Agent monitor are compatible with the new agent OpenTelemetry Collector and related modules in this repository keep `smart-agent` as source name.
+- any OpenTelemetry receiver not based on an existing Smart Agent monitor is not available from old agent so related modules in this repository use `otel-collector` as source name.
 {% elif source_type == 'otel-collector' -%}
-the [receivers](https://github.com/open-telemetry/opentelemetry-collector/blob/master/receiver/README.md)
-in the [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector-contrib).
-It can be embedded in the software to monitor or it can be a binary to install and configure it separately.
+[Receivers](https://github.com/open-telemetry/opentelemetry-collector/blob/master/receiver/README.md) of the [OpenTelemetry
+Collector](https://opentelemetry.io/docs/collector/), a new vendor-agnostic agent which replaces the [SignalFx Smart
+Agent](https://github.com/signalfx/signalfx-agent/) in Splunk Observability (fka SignalFx).
+
+It is surely more powerful but therefore more complex so give a look to the [official documentation](https://opentelemetry.io/docs/collector/configuration/)
+to learn how to configure Otel Collector and your receivers properly.
+
+The full list of available receivers are distributed through different sources:
+- the [officially supported receivers](https://github.com/open-telemetry/opentelemetry-collector/tree/main/receiver) from the core repository
+- the [contributions based receivers](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver) which represents
+a superset of the core repository.
+- the [splunk specific receivers](https://github.com/signalfx/splunk-otel-collector/tree/main/internal/receiver) from the Splunk distro of
+the OpenTelemetry Collector based on the contributions repository.
 {% elif source_type == 'prometheus-exporter' -%}
-the scraping of a server following the [OpenMetrics convention](https://openmetrics.io/) based on and compatible with [the Prometheus
+scraping of a server following the [OpenMetrics convention](https://openmetrics.io/) based on and compatible with [the Prometheus
 exposition format](https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/exposition_formats.md#openmetrics-text-format).
-They are generally called "Prometheus Exporter" which can be fetched by both the [SignalFx Smart Agent](https://github.com/signalfx/signalfx-agent)
-thanks to its [prometheus exporter monitor](https://docs.signalfx.com/en/latest/integrations/agent/monitors/prometheus-exporter.html) and the
+
+They are generally called `Prometheus Exporters` which can be fetched by both the [SignalFx Smart Agent](https://github.com/signalfx/signalfx-agent)
+thanks to its [prometheus exporter monitor](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/prometheus-exporter.md) and the
 [OpenTelemetry Collector](https://github.com/signalfx/splunk-otel-collector) using its [prometheus
 receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/prometheusreceiver) or its derivates.
+
+These exporters could be embedded directly in the tool you want to monitor (e.g. nginx ingress) or must be installed next to it as
+a separate program configured to connect, create metrics and expose them as server.
 {% elif source_type == 'fame' -%}
-the [Function for Azure Monitoring Extension](https://github.com/claranet/fame), an Azure Function App written in Python which allows to
-run Log Analytics queries and send result to Splunk Observability as metrics. More information available in the [dedicated
-readme](https://github.com/claranet/fame/blob/master/README.md).
+the [Function for Azure Monitoring Extension](https://github.com/claranet/fame), an Azure Function App written in Python by Claranet
+which allows to run Log Analytics queries and send result to Splunk Observability as metrics.
+
+More information available in the [dedicated readme](https://github.com/claranet/fame/blob/master/README.md).
 {% elif source_type == 'integration_aws' -%}
-the [AWS integration](https://docs.signalfx.com/en/latest/integrations/amazon-web-services.html) configurable
-with this Terraform [module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/aws).
+[AWS integration](https://docs.splunk.com/Observability/gdi/get-data-in/connect/aws/aws.html) configurable
+with [this Terraform module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/aws).
 {% elif source_type == 'integration_azure' -%}
-the [Azure integration](https://docs.signalfx.com/en/latest/integrations/azure-info.html) configurable
-with this Terraform [module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/azure).
+[Azure integration](https://docs.splunk.com/Observability/gdi/get-data-in/connect/azure/azure.html) configurable
+with [this Terraform module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/azure).
 {% elif source_type == 'integration_gcp' -%}
-the [GCP integration](https://docs.signalfx.com/en/latest/integrations/google-cloud-platform.html) configurable
-with this Terraform [module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/gcp).
+[GCP integration](https://docs.splunk.com/Observability/gdi/get-data-in/connect/gcp.html) configurable
+with [this Terraform module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/gcp).
 {% elif source_type == 'integration_newrelic' -%}
-the [NewRelic integration](https://docs.signalfx.com/en/latest/integrations/integrations-reference/integrations.new.relic.html)
+[NewRelic integration](https://github.com/signalfx/integrations/blob/master/newrelic/README.md).
 {% else -%}
-[SignalFx
-organization](https://docs.signalfx.com/en/latest/integrations/integrations-reference/integrations.signalfx.organization.metrics.html).
-There are always available and do not need any configuration to work.
+[Splunk Observability organization](https://docs.splunk.com/Observability/admin/org-metrics.html) always available out the box.
 {%- endif %}
+
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
 
 {% if source_doc is defined and source_doc is not none -%}
 {{ source_doc }}
@@ -149,6 +179,7 @@ Here is the list of required metrics for detectors in this module.
 
 * [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
 * [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
 {% if documentations is defined and documentations is not none -%}
 {% for documentation in documentations -%}
 * [{{ documentation.name}}]({{ documentation.url }})

--- a/scripts/templates/readme.md.j2
+++ b/scripts/templates/readme.md.j2
@@ -37,8 +37,8 @@ Note the following parameters:
   [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
 
 * `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
-  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an
-  available [detector rule severity](https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity)
+  of a Terraform [object](https://www.terraform.io/docs/configuration/types.html#object-) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
   and its value is a list of recipients. Every recipients must respect the [detector notification
   format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
   Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
@@ -142,8 +142,8 @@ Check the [Related documentation](#related-documentation) section for more detai
 
 {% if source_type == 'smart-agent' %}
 To filter only required metrics for the detectors of this module, add the
-[datapointsToExclude](https://docs.signalfx.com/en/latest/integrations/agent/filtering.html) parameter to
-the corresponding monitor configuration:
+[datapointsToExclude](https://docs.splunk.com/observability/gdi/smart-agent/smart-agent-resources.html#filtering-data-using-the-smart-agent)
+parameter to the corresponding monitor configuration:
 
 ```yaml
     datapointsToExclude:

--- a/scripts/templates/values.yaml
+++ b/scripts/templates/values.yaml
@@ -89,14 +89,14 @@ value_unit:
 
 ## @param runbook_url - string - optional
 ## Define a default runbook_url for all rules of the detector, see:
-## https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#runbook
+## https://docs.splunk.com/Observability/alerts-detectors-notifications/create-detectors-for-alerts.html#runbook
 ## If not defined, an empty string will be used as variable to allow the
 ## use to set its custom one.
 runbook_url:
 
 ## @param tip - string - optional
 ## Define a default tip for all rules of the detector, see:
-## https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#tip
+## https://docs.splunk.com/Observability/alerts-detectors-notifications/create-detectors-for-alerts.html#tip
 ## If not defined, an empty string will be used as variable to allow the
 ## use to set its custom one.
 tip:
@@ -130,9 +130,9 @@ signals:
     metric:
 
     ## @param formula - string - optional
-    ## The signalflow formula which could use previous signals and
-    ## analytics functions and methods, see:
-    ## https://dev.splunk.com/observability/docs/signalflow/function_method_list
+    ## The signalflow formula which could use previous signals and analytics
+    ## functions (https://dev.splunk.com/observability/docs/signalflow/functions)
+    ## or methods (https://dev.splunk.com/observability/docs/signalflow/methods)
     #
     formula:
 
@@ -166,7 +166,7 @@ signals:
 #
 rules:
   ## @param {{severity}} - object - optional
-  ## The severity: https://docs.signalfx.com/en/latest/detect-alert/set-up-detectors.html#severity
+  ## The severity: https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity
   ## Used as label to publish alerts depending on the detector type like "detect()"
   ## block for "threshold" detector type.
   #


### PR DESCRIPTION
This PR aims to fix broken links now docs.signalfx.com is dead.

It also include some related improvement like adding the splunk observability doc link in addition to signalfx smart agent monitor one.

The CI will fails to keep this PR clean for review, see https://github.com/claranet/terraform-signalfx-detectors/pull/383 for fixed state