### PR TITLE
Max delay generator

### DIFF
--- a/modules/integration_aws-alb/detectors-gen.tf
+++ b/modules/integration_aws-alb/detectors-gen.tf
@@ -5,8 +5,6 @@ resource "signalfx_detector" "heartbeat" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
-  max_delay = 900
-
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     base_filtering = filter('namespace', 'AWS/ApplicationELB')
@@ -25,6 +23,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.heartbeat_max_delay
 }
 
 resource "signalfx_detector" "latency" {
@@ -69,6 +69,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.latency_max_delay
 }
 
 resource "signalfx_detector" "alb_5xx" {
@@ -115,6 +117,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.alb_5xx_max_delay
 }
 
 resource "signalfx_detector" "alb_4xx" {
@@ -161,6 +165,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.alb_4xx_max_delay
 }
 
 resource "signalfx_detector" "target_5xx" {
@@ -207,6 +213,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.target_5xx_max_delay
 }
 
 resource "signalfx_detector" "target_4xx" {
@@ -253,6 +261,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.target_4xx_max_delay
 }
 
 resource "signalfx_detector" "healthy" {
@@ -299,5 +309,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.healthy_max_delay
 }
 

--- a/modules/integration_aws-alb/variables-gen.tf
+++ b/modules/integration_aws-alb/variables-gen.tf
@@ -12,6 +12,12 @@ variable "heartbeat_aggregation_function" {
   default     = ".mean(by=['LoadBalancer'])"
 }
 
+variable "heartbeat_max_delay" {
+  description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = 900
+}
+
 variable "heartbeat_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -54,6 +60,12 @@ variable "latency_transformation_function" {
   description = "Transformation function for latency detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ""
+}
+
+variable "latency_max_delay" {
+  description = "Enforce max delay for latency detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "latency_tip" {
@@ -140,6 +152,12 @@ variable "alb_5xx_transformation_function" {
   default     = ""
 }
 
+variable "alb_5xx_max_delay" {
+  description = "Enforce max delay for alb_5xx detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "alb_5xx_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -222,6 +240,12 @@ variable "alb_4xx_transformation_function" {
   description = "Transformation function for alb_4xx detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ""
+}
+
+variable "alb_4xx_max_delay" {
+  description = "Enforce max delay for alb_4xx detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "alb_4xx_tip" {
@@ -308,6 +332,12 @@ variable "target_5xx_transformation_function" {
   default     = ""
 }
 
+variable "target_5xx_max_delay" {
+  description = "Enforce max delay for target_5xx detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "target_5xx_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -392,6 +422,12 @@ variable "target_4xx_transformation_function" {
   default     = ""
 }
 
+variable "target_4xx_max_delay" {
+  description = "Enforce max delay for target_4xx detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "target_4xx_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -474,6 +510,12 @@ variable "healthy_transformation_function" {
   description = "Transformation function for healthy detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ""
+}
+
+variable "healthy_max_delay" {
+  description = "Enforce max delay for healthy detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "healthy_tip" {

--- a/modules/integration_aws-apigateway/detectors-gen.tf
+++ b/modules/integration_aws-apigateway/detectors-gen.tf
@@ -40,6 +40,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.latency_max_delay
 }
 
 resource "signalfx_detector" "http_5xx" {
@@ -86,6 +88,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.http_5xx_max_delay
 }
 
 resource "signalfx_detector" "http_4xx" {
@@ -132,5 +136,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.http_4xx_max_delay
 }
 

--- a/modules/integration_aws-apigateway/variables-gen.tf
+++ b/modules/integration_aws-apigateway/variables-gen.tf
@@ -18,6 +18,12 @@ variable "latency_transformation_function" {
   default     = ""
 }
 
+variable "latency_max_delay" {
+  description = "Enforce max delay for latency detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "latency_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -102,6 +108,12 @@ variable "http_5xx_transformation_function" {
   default     = ""
 }
 
+variable "http_5xx_max_delay" {
+  description = "Enforce max delay for http_5xx detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "http_5xx_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -184,6 +196,12 @@ variable "http_4xx_transformation_function" {
   description = "Transformation function for http_4xx detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ""
+}
+
+variable "http_4xx_max_delay" {
+  description = "Enforce max delay for http_4xx detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "http_4xx_tip" {

--- a/modules/integration_aws-efs/detectors-gen.tf
+++ b/modules/integration_aws-efs/detectors-gen.tf
@@ -41,6 +41,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.used_space_max_delay
 }
 
 resource "signalfx_detector" "io_limit" {
@@ -85,6 +87,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.io_limit_max_delay
 }
 
 resource "signalfx_detector" "read_throughput" {
@@ -131,6 +135,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.read_throughput_max_delay
 }
 
 resource "signalfx_detector" "write_throughput" {
@@ -177,6 +183,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.write_throughput_max_delay
 }
 
 resource "signalfx_detector" "percent_of_permitted_throughput" {
@@ -223,6 +231,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.percent_of_permitted_throughput_max_delay
 }
 
 resource "signalfx_detector" "burst_credit_balance" {
@@ -254,5 +264,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.burst_credit_balance_max_delay
 }
 

--- a/modules/integration_aws-efs/variables-gen.tf
+++ b/modules/integration_aws-efs/variables-gen.tf
@@ -18,6 +18,12 @@ variable "used_space_transformation_function" {
   default     = ".max(over='15m')"
 }
 
+variable "used_space_max_delay" {
+  description = "Enforce max delay for used_space detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "used_space_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -98,6 +104,12 @@ variable "io_limit_transformation_function" {
   description = "Transformation function for io_limit detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ".mean(over='30m')"
+}
+
+variable "io_limit_max_delay" {
+  description = "Enforce max delay for io_limit detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "io_limit_tip" {
@@ -186,6 +198,12 @@ variable "read_throughput_transformation_function" {
   default     = ".max(over='15m')"
 }
 
+variable "read_throughput_max_delay" {
+  description = "Enforce max delay for read_throughput detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "read_throughput_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -268,6 +286,12 @@ variable "write_throughput_transformation_function" {
   default     = ".max(over='15m')"
 }
 
+variable "write_throughput_max_delay" {
+  description = "Enforce max delay for write_throughput detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "write_throughput_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -348,6 +372,12 @@ variable "percent_of_permitted_throughput_transformation_function" {
   description = "Transformation function for percent_of_permitted_throughput detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ".mean(over='30m')"
+}
+
+variable "percent_of_permitted_throughput_max_delay" {
+  description = "Enforce max delay for percent_of_permitted_throughput detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "percent_of_permitted_throughput_tip" {
@@ -434,6 +464,12 @@ variable "burst_credit_balance_transformation_function" {
   description = "Transformation function for burst_credit_balance detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ".mean(over='5m')"
+}
+
+variable "burst_credit_balance_max_delay" {
+  description = "Enforce max delay for burst_credit_balance detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "burst_credit_balance_tip" {

--- a/modules/integration_aws-elasticache-memcached/detectors-gen.tf
+++ b/modules/integration_aws-elasticache-memcached/detectors-gen.tf
@@ -40,6 +40,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.cpu_max_delay
 }
 
 resource "signalfx_detector" "hit_ratio" {
@@ -86,5 +88,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.hit_ratio_max_delay
 }
 

--- a/modules/integration_aws-elasticache-memcached/variables-gen.tf
+++ b/modules/integration_aws-elasticache-memcached/variables-gen.tf
@@ -18,6 +18,12 @@ variable "cpu_transformation_function" {
   default     = ""
 }
 
+variable "cpu_max_delay" {
+  description = "Enforce max delay for cpu detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "cpu_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -100,6 +106,12 @@ variable "hit_ratio_transformation_function" {
   description = "Transformation function for hit_ratio detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ""
+}
+
+variable "hit_ratio_max_delay" {
+  description = "Enforce max delay for hit_ratio detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "hit_ratio_tip" {

--- a/modules/integration_aws-elasticache-redis/detectors-gen.tf
+++ b/modules/integration_aws-elasticache-redis/detectors-gen.tf
@@ -42,6 +42,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.cache_hits_max_delay
 }
 
 resource "signalfx_detector" "cpu_high" {
@@ -86,6 +88,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.cpu_high_max_delay
 }
 
 resource "signalfx_detector" "replication_lag" {
@@ -130,6 +134,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.replication_lag_max_delay
 }
 
 resource "signalfx_detector" "commands" {
@@ -158,5 +164,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.commands_max_delay
 }
 

--- a/modules/integration_aws-elasticache-redis/variables-gen.tf
+++ b/modules/integration_aws-elasticache-redis/variables-gen.tf
@@ -18,6 +18,12 @@ variable "cache_hits_transformation_function" {
   default     = ""
 }
 
+variable "cache_hits_max_delay" {
+  description = "Enforce max delay for cache_hits detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "cache_hits_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -100,6 +106,12 @@ variable "cpu_high_transformation_function" {
   description = "Transformation function for cpu_high detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ""
+}
+
+variable "cpu_high_max_delay" {
+  description = "Enforce max delay for cpu_high detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "cpu_high_tip" {
@@ -186,6 +198,12 @@ variable "replication_lag_transformation_function" {
   default     = ""
 }
 
+variable "replication_lag_max_delay" {
+  description = "Enforce max delay for replication_lag detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "replication_lag_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -268,6 +286,12 @@ variable "commands_transformation_function" {
   description = "Transformation function for commands detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ".sum(over='15m')"
+}
+
+variable "commands_max_delay" {
+  description = "Enforce max delay for commands detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "commands_tip" {

--- a/modules/integration_aws-elasticsearch/detectors-gen.tf
+++ b/modules/integration_aws-elasticsearch/detectors-gen.tf
@@ -40,5 +40,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.jvm_memory_pressure_max_delay
 }
 

--- a/modules/integration_aws-elasticsearch/variables-gen.tf
+++ b/modules/integration_aws-elasticsearch/variables-gen.tf
@@ -18,6 +18,12 @@ variable "jvm_memory_pressure_transformation_function" {
   default     = ".min(over='15m')"
 }
 
+variable "jvm_memory_pressure_max_delay" {
+  description = "Enforce max delay for jvm_memory_pressure detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "jvm_memory_pressure_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string

--- a/modules/integration_aws-elb/detectors-gen.tf
+++ b/modules/integration_aws-elb/detectors-gen.tf
@@ -5,8 +5,6 @@ resource "signalfx_detector" "heartbeat" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
-  max_delay = 900
-
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     base_filtering = filter('namespace', 'AWS/ELB')
@@ -25,6 +23,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.heartbeat_max_delay
 }
 
 resource "signalfx_detector" "backend_latency" {
@@ -69,6 +69,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.backend_latency_max_delay
 }
 
 resource "signalfx_detector" "elb_5xx" {
@@ -115,6 +117,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.elb_5xx_max_delay
 }
 
 resource "signalfx_detector" "elb_4xx" {
@@ -161,6 +165,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.elb_4xx_max_delay
 }
 
 resource "signalfx_detector" "backend_5xx" {
@@ -207,6 +213,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.backend_5xx_max_delay
 }
 
 resource "signalfx_detector" "backend_4xx" {
@@ -253,6 +261,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.backend_4xx_max_delay
 }
 
 resource "signalfx_detector" "healthy" {
@@ -299,5 +309,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.healthy_max_delay
 }
 

--- a/modules/integration_aws-elb/variables-gen.tf
+++ b/modules/integration_aws-elb/variables-gen.tf
@@ -12,6 +12,12 @@ variable "heartbeat_aggregation_function" {
   default     = ".mean(by=['LoadBalancerName'])"
 }
 
+variable "heartbeat_max_delay" {
+  description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = 900
+}
+
 variable "heartbeat_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -54,6 +60,12 @@ variable "backend_latency_transformation_function" {
   description = "Transformation function for backend_latency detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ""
+}
+
+variable "backend_latency_max_delay" {
+  description = "Enforce max delay for backend_latency detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "backend_latency_tip" {
@@ -140,6 +152,12 @@ variable "elb_5xx_transformation_function" {
   default     = ""
 }
 
+variable "elb_5xx_max_delay" {
+  description = "Enforce max delay for elb_5xx detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "elb_5xx_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -222,6 +240,12 @@ variable "elb_4xx_transformation_function" {
   description = "Transformation function for elb_4xx detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ""
+}
+
+variable "elb_4xx_max_delay" {
+  description = "Enforce max delay for elb_4xx detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "elb_4xx_tip" {
@@ -308,6 +332,12 @@ variable "backend_5xx_transformation_function" {
   default     = ""
 }
 
+variable "backend_5xx_max_delay" {
+  description = "Enforce max delay for backend_5xx detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "backend_5xx_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -392,6 +422,12 @@ variable "backend_4xx_transformation_function" {
   default     = ""
 }
 
+variable "backend_4xx_max_delay" {
+  description = "Enforce max delay for backend_4xx detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "backend_4xx_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -474,6 +510,12 @@ variable "healthy_transformation_function" {
   description = "Transformation function for healthy detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ""
+}
+
+variable "healthy_max_delay" {
+  description = "Enforce max delay for healthy detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "healthy_tip" {

--- a/modules/integration_aws-lambda/detectors-gen.tf
+++ b/modules/integration_aws-lambda/detectors-gen.tf
@@ -42,6 +42,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.pct_errors_max_delay
 }
 
 resource "signalfx_detector" "throttles" {
@@ -81,6 +83,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.throttles_max_delay
 }
 
 resource "signalfx_detector" "invocations" {
@@ -107,5 +111,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.invocations_max_delay
 }
 

--- a/modules/integration_aws-lambda/variables-gen.tf
+++ b/modules/integration_aws-lambda/variables-gen.tf
@@ -18,6 +18,12 @@ variable "pct_errors_transformation_function" {
   default     = ""
 }
 
+variable "pct_errors_max_delay" {
+  description = "Enforce max delay for pct_errors detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "pct_errors_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -102,6 +108,12 @@ variable "throttles_transformation_function" {
   default     = ".sum(over='1h')"
 }
 
+variable "throttles_max_delay" {
+  description = "Enforce max delay for throttles detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "throttles_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -184,6 +196,12 @@ variable "invocations_transformation_function" {
   description = "Transformation function for invocations detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ".sum(over='1h')"
+}
+
+variable "invocations_max_delay" {
+  description = "Enforce max delay for invocations detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "invocations_tip" {

--- a/modules/integration_aws-redshift/detectors-gen.tf
+++ b/modules/integration_aws-redshift/detectors-gen.tf
@@ -5,8 +5,6 @@ resource "signalfx_detector" "heartbeat" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
-  max_delay = 900
-
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     base_filtering = filter('namespace', 'AWS/Redshift')
@@ -25,6 +23,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.heartbeat_max_delay
 }
 
 resource "signalfx_detector" "cpu_usage" {
@@ -69,6 +69,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.cpu_usage_max_delay
 }
 
 resource "signalfx_detector" "storage_usage" {
@@ -113,5 +115,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.storage_usage_max_delay
 }
 

--- a/modules/integration_aws-redshift/variables-gen.tf
+++ b/modules/integration_aws-redshift/variables-gen.tf
@@ -12,6 +12,12 @@ variable "heartbeat_aggregation_function" {
   default     = ".mean(by=['ClusterIdentifier'])"
 }
 
+variable "heartbeat_max_delay" {
+  description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = 900
+}
+
 variable "heartbeat_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -54,6 +60,12 @@ variable "cpu_usage_transformation_function" {
   description = "Transformation function for cpu_usage detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ""
+}
+
+variable "cpu_usage_max_delay" {
+  description = "Enforce max delay for cpu_usage detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "cpu_usage_tip" {
@@ -138,6 +150,12 @@ variable "storage_usage_transformation_function" {
   description = "Transformation function for storage_usage detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ""
+}
+
+variable "storage_usage_max_delay" {
+  description = "Enforce max delay for storage_usage detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "storage_usage_tip" {

--- a/modules/integration_azure-application-gateway/detectors-gen.tf
+++ b/modules/integration_azure-application-gateway/detectors-gen.tf
@@ -22,5 +22,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.capacity_units_max_delay
 }
 

--- a/modules/integration_azure-application-gateway/variables-gen.tf
+++ b/modules/integration_azure-application-gateway/variables-gen.tf
@@ -18,6 +18,12 @@ variable "capacity_units_transformation_function" {
   default     = ".max(over='15m')"
 }
 
+variable "capacity_units_max_delay" {
+  description = "Enforce max delay for capacity_units detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "capacity_units_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string

--- a/modules/integration_azure-container-instance/detectors-gen.tf
+++ b/modules/integration_azure-container-instance/detectors-gen.tf
@@ -5,8 +5,6 @@ resource "signalfx_detector" "heartbeat" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
-  max_delay = 900
-
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     base_filtering = filter('resource_type', 'Microsoft.ContainerInstance/containerGroups') and filter('primary_aggregation_type', 'true')
@@ -25,5 +23,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.heartbeat_max_delay
 }
 

--- a/modules/integration_azure-container-instance/variables-gen.tf
+++ b/modules/integration_azure-container-instance/variables-gen.tf
@@ -12,6 +12,12 @@ variable "heartbeat_aggregation_function" {
   default     = ".mean(by=['azure_resource_name', 'azure_resource_group_name', 'azure_region'])"
 }
 
+variable "heartbeat_max_delay" {
+  description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = 900
+}
+
 variable "heartbeat_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string

--- a/modules/integration_azure-datafactory/detectors-gen.tf
+++ b/modules/integration_azure-datafactory/detectors-gen.tf
@@ -42,6 +42,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.activity_error_rate_max_delay
 }
 
 resource "signalfx_detector" "pipeline_error_rate" {
@@ -88,6 +90,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.pipeline_error_rate_max_delay
 }
 
 resource "signalfx_detector" "trigger_error_rate" {
@@ -129,6 +133,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.trigger_error_rate_max_delay
 }
 
 resource "signalfx_detector" "available_memory" {
@@ -174,6 +180,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.available_memory_max_delay
 }
 
 resource "signalfx_detector" "cpu_percentage" {
@@ -218,5 +226,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.cpu_percentage_max_delay
 }
 

--- a/modules/integration_azure-datafactory/variables-gen.tf
+++ b/modules/integration_azure-datafactory/variables-gen.tf
@@ -18,6 +18,12 @@ variable "activity_error_rate_transformation_function" {
   default     = ".min(over='5m')"
 }
 
+variable "activity_error_rate_max_delay" {
+  description = "Enforce max delay for activity_error_rate detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "activity_error_rate_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -100,6 +106,12 @@ variable "pipeline_error_rate_transformation_function" {
   description = "Transformation function for pipeline_error_rate detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ".min(over='5m')"
+}
+
+variable "pipeline_error_rate_max_delay" {
+  description = "Enforce max delay for pipeline_error_rate detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "pipeline_error_rate_tip" {
@@ -186,6 +198,12 @@ variable "trigger_error_rate_transformation_function" {
   default     = ".min(over='5m')"
 }
 
+variable "trigger_error_rate_max_delay" {
+  description = "Enforce max delay for trigger_error_rate detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "trigger_error_rate_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -270,6 +288,12 @@ variable "available_memory_transformation_function" {
   default     = ".min(over='15m')"
 }
 
+variable "available_memory_max_delay" {
+  description = "Enforce max delay for available_memory detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "available_memory_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -352,6 +376,12 @@ variable "cpu_percentage_transformation_function" {
   description = "Transformation function for cpu_percentage detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ".min(over='15m')"
+}
+
+variable "cpu_percentage_max_delay" {
+  description = "Enforce max delay for cpu_percentage detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "cpu_percentage_tip" {

--- a/modules/integration_azure-event-hub/detectors-gen.tf
+++ b/modules/integration_azure-event-hub/detectors-gen.tf
@@ -55,5 +55,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.throttled_requests_max_delay
 }
 

--- a/modules/integration_azure-event-hub/variables-gen.tf
+++ b/modules/integration_azure-event-hub/variables-gen.tf
@@ -18,6 +18,12 @@ variable "throttled_requests_transformation_function" {
   default     = ".min(over='15m')"
 }
 
+variable "throttled_requests_max_delay" {
+  description = "Enforce max delay for throttled_requests detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "throttled_requests_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string

--- a/modules/integration_azure-express-route/detectors-gen.tf
+++ b/modules/integration_azure-express-route/detectors-gen.tf
@@ -5,8 +5,6 @@ resource "signalfx_detector" "heartbeat" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
-  max_delay = 900
-
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     base_filtering = filter('resource_type', 'Microsoft.Network/expressRouteCircuits') and filter('primary_aggregation_type', 'true')
@@ -25,6 +23,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.heartbeat_max_delay
 }
 
 resource "signalfx_detector" "bgp_availability" {
@@ -77,6 +77,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.bgp_availability_max_delay
 }
 
 resource "signalfx_detector" "arp_availability" {
@@ -129,5 +131,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.arp_availability_max_delay
 }
 

--- a/modules/integration_azure-express-route/variables-gen.tf
+++ b/modules/integration_azure-express-route/variables-gen.tf
@@ -18,6 +18,12 @@ variable "heartbeat_transformation_function" {
   default     = ""
 }
 
+variable "heartbeat_max_delay" {
+  description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = 900
+}
+
 variable "heartbeat_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -60,6 +66,12 @@ variable "bgp_availability_transformation_function" {
   description = "Transformation function for bgp_availability detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ""
+}
+
+variable "bgp_availability_max_delay" {
+  description = "Enforce max delay for bgp_availability detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "bgp_availability_tip" {
@@ -167,6 +179,12 @@ variable "arp_availability_transformation_function" {
   description = "Transformation function for arp_availability detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ""
+}
+
+variable "arp_availability_max_delay" {
+  description = "Enforce max delay for arp_availability detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "arp_availability_tip" {

--- a/modules/integration_azure-firewall/detectors-gen.tf
+++ b/modules/integration_azure-firewall/detectors-gen.tf
@@ -5,8 +5,6 @@ resource "signalfx_detector" "heartbeat" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
-  max_delay = 900
-
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     base_filtering = filter('resource_type', 'Microsoft.Network/azureFirewalls') and filter('primary_aggregation_type', 'true')
@@ -25,6 +23,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.heartbeat_max_delay
 }
 
 resource "signalfx_detector" "snat_port_utilization" {
@@ -64,6 +64,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.snat_port_utilization_max_delay
 }
 
 resource "signalfx_detector" "throughput" {
@@ -130,6 +132,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.throughput_max_delay
 }
 
 resource "signalfx_detector" "health_state" {
@@ -169,5 +173,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.health_state_max_delay
 }
 

--- a/modules/integration_azure-firewall/variables-gen.tf
+++ b/modules/integration_azure-firewall/variables-gen.tf
@@ -18,6 +18,12 @@ variable "heartbeat_transformation_function" {
   default     = ""
 }
 
+variable "heartbeat_max_delay" {
+  description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = 900
+}
+
 variable "heartbeat_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -60,6 +66,12 @@ variable "snat_port_utilization_transformation_function" {
   description = "Transformation function for snat_port_utilization detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ""
+}
+
+variable "snat_port_utilization_max_delay" {
+  description = "Enforce max delay for snat_port_utilization detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "snat_port_utilization_tip" {
@@ -144,6 +156,12 @@ variable "throughput_transformation_function" {
   description = "Transformation function for throughput detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ""
+}
+
+variable "throughput_max_delay" {
+  description = "Enforce max delay for throughput detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "throughput_tip" {
@@ -276,6 +294,12 @@ variable "health_state_transformation_function" {
   description = "Transformation function for health_state detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ""
+}
+
+variable "health_state_max_delay" {
+  description = "Enforce max delay for health_state detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "health_state_tip" {

--- a/modules/integration_azure-functions/detectors-gen.tf
+++ b/modules/integration_azure-functions/detectors-gen.tf
@@ -37,5 +37,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.errors_max_delay
 }
 

--- a/modules/integration_azure-functions/variables-gen.tf
+++ b/modules/integration_azure-functions/variables-gen.tf
@@ -18,6 +18,12 @@ variable "errors_transformation_function" {
   default     = ""
 }
 
+variable "errors_max_delay" {
+  description = "Enforce max delay for errors detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "errors_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string

--- a/modules/integration_azure-mariadb/detectors-gen.tf
+++ b/modules/integration_azure-mariadb/detectors-gen.tf
@@ -5,8 +5,6 @@ resource "signalfx_detector" "heartbeat" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
-  max_delay = 900
-
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     base_filtering = filter('resource_type', 'Microsoft.DBforMariaDB/servers') and filter('primary_aggregation_type', 'true')
@@ -25,6 +23,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.heartbeat_max_delay
 }
 
 resource "signalfx_detector" "cpu" {
@@ -69,6 +69,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.cpu_max_delay
 }
 
 resource "signalfx_detector" "storage" {
@@ -113,6 +115,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.storage_max_delay
 }
 
 resource "signalfx_detector" "io" {
@@ -157,6 +161,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.io_max_delay
 }
 
 resource "signalfx_detector" "memory" {
@@ -201,6 +207,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.memory_max_delay
 }
 
 resource "signalfx_detector" "replication_lag" {
@@ -245,5 +253,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.replication_lag_max_delay
 }
 

--- a/modules/integration_azure-mariadb/variables-gen.tf
+++ b/modules/integration_azure-mariadb/variables-gen.tf
@@ -18,6 +18,12 @@ variable "heartbeat_transformation_function" {
   default     = ""
 }
 
+variable "heartbeat_max_delay" {
+  description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = 900
+}
+
 variable "heartbeat_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -60,6 +66,12 @@ variable "cpu_transformation_function" {
   description = "Transformation function for cpu detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ""
+}
+
+variable "cpu_max_delay" {
+  description = "Enforce max delay for cpu detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "cpu_tip" {
@@ -146,6 +158,12 @@ variable "storage_transformation_function" {
   default     = ""
 }
 
+variable "storage_max_delay" {
+  description = "Enforce max delay for storage detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "storage_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -228,6 +246,12 @@ variable "io_transformation_function" {
   description = "Transformation function for io detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ""
+}
+
+variable "io_max_delay" {
+  description = "Enforce max delay for io detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "io_tip" {
@@ -314,6 +338,12 @@ variable "memory_transformation_function" {
   default     = ""
 }
 
+variable "memory_max_delay" {
+  description = "Enforce max delay for memory detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "memory_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -396,6 +426,12 @@ variable "replication_lag_transformation_function" {
   description = "Transformation function for replication_lag detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ""
+}
+
+variable "replication_lag_max_delay" {
+  description = "Enforce max delay for replication_lag detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "replication_lag_tip" {

--- a/modules/integration_azure-mysql/detectors-gen.tf
+++ b/modules/integration_azure-mysql/detectors-gen.tf
@@ -5,8 +5,6 @@ resource "signalfx_detector" "heartbeat" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
-  max_delay = 900
-
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     base_filtering = filter('resource_type', 'Microsoft.DBforMySQL/servers') and filter('primary_aggregation_type', 'true')
@@ -25,6 +23,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.heartbeat_max_delay
 }
 
 resource "signalfx_detector" "cpu" {
@@ -69,6 +69,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.cpu_max_delay
 }
 
 resource "signalfx_detector" "storage" {
@@ -113,6 +115,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.storage_max_delay
 }
 
 resource "signalfx_detector" "io" {
@@ -157,6 +161,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.io_max_delay
 }
 
 resource "signalfx_detector" "memory" {
@@ -201,6 +207,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.memory_max_delay
 }
 
 resource "signalfx_detector" "replication_lag" {
@@ -245,5 +253,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.replication_lag_max_delay
 }
 

--- a/modules/integration_azure-mysql/variables-gen.tf
+++ b/modules/integration_azure-mysql/variables-gen.tf
@@ -18,6 +18,12 @@ variable "heartbeat_transformation_function" {
   default     = ""
 }
 
+variable "heartbeat_max_delay" {
+  description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = 900
+}
+
 variable "heartbeat_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -60,6 +66,12 @@ variable "cpu_transformation_function" {
   description = "Transformation function for cpu detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ""
+}
+
+variable "cpu_max_delay" {
+  description = "Enforce max delay for cpu detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "cpu_tip" {
@@ -146,6 +158,12 @@ variable "storage_transformation_function" {
   default     = ""
 }
 
+variable "storage_max_delay" {
+  description = "Enforce max delay for storage detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "storage_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -228,6 +246,12 @@ variable "io_transformation_function" {
   description = "Transformation function for io detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ""
+}
+
+variable "io_max_delay" {
+  description = "Enforce max delay for io detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "io_tip" {
@@ -314,6 +338,12 @@ variable "memory_transformation_function" {
   default     = ""
 }
 
+variable "memory_max_delay" {
+  description = "Enforce max delay for memory detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "memory_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -396,6 +426,12 @@ variable "replication_lag_transformation_function" {
   description = "Transformation function for replication_lag detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ""
+}
+
+variable "replication_lag_max_delay" {
+  description = "Enforce max delay for replication_lag detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "replication_lag_tip" {

--- a/modules/integration_azure-service-bus/detectors-gen.tf
+++ b/modules/integration_azure-service-bus/detectors-gen.tf
@@ -35,5 +35,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.deadlettered_messages_max_delay
 }
 

--- a/modules/integration_azure-service-bus/variables-gen.tf
+++ b/modules/integration_azure-service-bus/variables-gen.tf
@@ -18,6 +18,12 @@ variable "deadlettered_messages_transformation_function" {
   default     = ".min(over='5m')"
 }
 
+variable "deadlettered_messages_max_delay" {
+  description = "Enforce max delay for deadlettered_messages detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "deadlettered_messages_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string

--- a/modules/integration_azure-storage-account-blob/detectors-gen.tf
+++ b/modules/integration_azure-storage-account-blob/detectors-gen.tf
@@ -42,6 +42,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.requests_error_rate_max_delay
 }
 
 resource "signalfx_detector" "latency_e2e" {
@@ -87,5 +89,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.latency_e2e_max_delay
 }
 

--- a/modules/integration_azure-storage-account-blob/variables-gen.tf
+++ b/modules/integration_azure-storage-account-blob/variables-gen.tf
@@ -18,6 +18,12 @@ variable "requests_error_rate_transformation_function" {
   default     = ".min(over='15m')"
 }
 
+variable "requests_error_rate_max_delay" {
+  description = "Enforce max delay for requests_error_rate detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "requests_error_rate_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -100,6 +106,12 @@ variable "latency_e2e_transformation_function" {
   description = "Transformation function for latency_e2e detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ".min(over='15m')"
+}
+
+variable "latency_e2e_max_delay" {
+  description = "Enforce max delay for latency_e2e detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "latency_e2e_tip" {

--- a/modules/integration_azure-storage-account/detectors-gen.tf
+++ b/modules/integration_azure-storage-account/detectors-gen.tf
@@ -36,6 +36,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.count_max_delay
 }
 
 resource "signalfx_detector" "capacity" {
@@ -81,6 +83,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.capacity_max_delay
 }
 
 resource "signalfx_detector" "ingress" {
@@ -126,6 +130,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.ingress_max_delay
 }
 
 resource "signalfx_detector" "egress" {
@@ -171,6 +177,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.egress_max_delay
 }
 
 resource "signalfx_detector" "requests_rate" {
@@ -210,5 +218,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.requests_rate_max_delay
 }
 

--- a/modules/integration_azure-storage-account/variables-gen.tf
+++ b/modules/integration_azure-storage-account/variables-gen.tf
@@ -18,6 +18,12 @@ variable "count_transformation_function" {
   default     = ".min(over='1d')"
 }
 
+variable "count_max_delay" {
+  description = "Enforce max delay for count detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "count_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -100,6 +106,12 @@ variable "capacity_transformation_function" {
   description = "Transformation function for capacity detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ".min(over='1d')"
+}
+
+variable "capacity_max_delay" {
+  description = "Enforce max delay for capacity detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "capacity_tip" {
@@ -186,6 +198,12 @@ variable "ingress_transformation_function" {
   default     = ".min(over='15m')"
 }
 
+variable "ingress_max_delay" {
+  description = "Enforce max delay for ingress detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "ingress_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -270,6 +288,12 @@ variable "egress_transformation_function" {
   default     = ".min(over='15m')"
 }
 
+variable "egress_max_delay" {
+  description = "Enforce max delay for egress detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "egress_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -352,6 +376,12 @@ variable "requests_rate_transformation_function" {
   description = "Transformation function for requests_rate detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ".min(over='15m')"
+}
+
+variable "requests_rate_max_delay" {
+  description = "Enforce max delay for requests_rate detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "requests_rate_tip" {

--- a/modules/integration_gcp-load-balancing/detectors-gen.tf
+++ b/modules/integration_gcp-load-balancing/detectors-gen.tf
@@ -42,6 +42,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.error_rate_5xx_max_delay
 }
 
 resource "signalfx_detector" "error_rate_4xx" {
@@ -88,6 +90,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.error_rate_4xx_max_delay
 }
 
 resource "signalfx_detector" "backend_latency_service" {
@@ -132,6 +136,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.backend_latency_service_max_delay
 }
 
 resource "signalfx_detector" "backend_latency_bucket" {
@@ -176,6 +182,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.backend_latency_bucket_max_delay
 }
 
 resource "signalfx_detector" "request_count" {
@@ -215,5 +223,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.request_count_max_delay
 }
 

--- a/modules/integration_gcp-load-balancing/variables-gen.tf
+++ b/modules/integration_gcp-load-balancing/variables-gen.tf
@@ -18,6 +18,12 @@ variable "error_rate_5xx_transformation_function" {
   default     = ""
 }
 
+variable "error_rate_5xx_max_delay" {
+  description = "Enforce max delay for error_rate_5xx detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "error_rate_5xx_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -100,6 +106,12 @@ variable "error_rate_4xx_transformation_function" {
   description = "Transformation function for error_rate_4xx detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ""
+}
+
+variable "error_rate_4xx_max_delay" {
+  description = "Enforce max delay for error_rate_4xx detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "error_rate_4xx_tip" {
@@ -186,6 +198,12 @@ variable "backend_latency_service_transformation_function" {
   default     = ""
 }
 
+variable "backend_latency_service_max_delay" {
+  description = "Enforce max delay for backend_latency_service detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "backend_latency_service_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -270,6 +288,12 @@ variable "backend_latency_bucket_transformation_function" {
   default     = ""
 }
 
+variable "backend_latency_bucket_max_delay" {
+  description = "Enforce max delay for backend_latency_bucket detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "backend_latency_bucket_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -352,6 +376,12 @@ variable "request_count_transformation_function" {
   description = "Transformation function for request_count detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ""
+}
+
+variable "request_count_max_delay" {
+  description = "Enforce max delay for request_count detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "request_count_tip" {

--- a/modules/prometheus-exporter_oracledb/detectors-gen.tf
+++ b/modules/prometheus-exporter_oracledb/detectors-gen.tf
@@ -5,8 +5,6 @@ resource "signalfx_detector" "heartbeat" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
-  max_delay = 900
-
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('oracledb_up', filter=${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
@@ -24,6 +22,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.heartbeat_max_delay
 }
 
 resource "signalfx_detector" "dbisdown" {
@@ -49,5 +49,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.dbisdown_max_delay
 }
 

--- a/modules/prometheus-exporter_oracledb/variables-gen.tf
+++ b/modules/prometheus-exporter_oracledb/variables-gen.tf
@@ -18,6 +18,12 @@ variable "heartbeat_transformation_function" {
   default     = ""
 }
 
+variable "heartbeat_max_delay" {
+  description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = 900
+}
+
 variable "heartbeat_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -60,6 +66,12 @@ variable "dbisdown_transformation_function" {
   description = "Transformation function for dbisdown detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ".max(over='10m')"
+}
+
+variable "dbisdown_max_delay" {
+  description = "Enforce max delay for dbisdown detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "dbisdown_tip" {

--- a/modules/prometheus-exporter_squid/detectors-gen.tf
+++ b/modules/prometheus-exporter_squid/detectors-gen.tf
@@ -5,8 +5,6 @@ resource "signalfx_detector" "heartbeat" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
-  max_delay = 900
-
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('squid_up', filter=${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
@@ -24,6 +22,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.heartbeat_max_delay
 }
 
 resource "signalfx_detector" "status" {
@@ -49,6 +49,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.status_max_delay
 }
 
 resource "signalfx_detector" "server_errors" {
@@ -89,6 +91,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.server_errors_max_delay
 }
 
 resource "signalfx_detector" "total_requests" {
@@ -114,5 +118,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.total_requests_max_delay
 }
 

--- a/modules/prometheus-exporter_squid/variables-gen.tf
+++ b/modules/prometheus-exporter_squid/variables-gen.tf
@@ -18,6 +18,12 @@ variable "heartbeat_transformation_function" {
   default     = ""
 }
 
+variable "heartbeat_max_delay" {
+  description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = 900
+}
+
 variable "heartbeat_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -60,6 +66,12 @@ variable "status_transformation_function" {
   description = "Transformation function for status detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ""
+}
+
+variable "status_max_delay" {
+  description = "Enforce max delay for status detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "status_tip" {
@@ -115,6 +127,12 @@ variable "server_errors_transformation_function" {
   description = "Transformation function for server_errors detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ""
+}
+
+variable "server_errors_max_delay" {
+  description = "Enforce max delay for server_errors detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "server_errors_tip" {
@@ -199,6 +217,12 @@ variable "total_requests_transformation_function" {
   description = "Transformation function for total_requests detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ""
+}
+
+variable "total_requests_max_delay" {
+  description = "Enforce max delay for total_requests detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "total_requests_tip" {

--- a/modules/prometheus-exporter_wallix-bastion/detectors-gen.tf
+++ b/modules/prometheus-exporter_wallix-bastion/detectors-gen.tf
@@ -5,8 +5,6 @@ resource "signalfx_detector" "heartbeat" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
-  max_delay = 900
-
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('wallix_bastion_up', filter=${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
@@ -24,6 +22,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.heartbeat_max_delay
 }
 
 resource "signalfx_detector" "status" {
@@ -49,6 +49,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.status_max_delay
 }
 
 resource "signalfx_detector" "current_sessions" {
@@ -87,6 +89,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.current_sessions_max_delay
 }
 
 resource "signalfx_detector" "encryption_status" {
@@ -113,6 +117,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.encryption_status_max_delay
 }
 
 resource "signalfx_detector" "license" {
@@ -138,5 +144,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.license_max_delay
 }
 

--- a/modules/prometheus-exporter_wallix-bastion/variables-gen.tf
+++ b/modules/prometheus-exporter_wallix-bastion/variables-gen.tf
@@ -18,6 +18,12 @@ variable "heartbeat_transformation_function" {
   default     = ""
 }
 
+variable "heartbeat_max_delay" {
+  description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = 900
+}
+
 variable "heartbeat_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -60,6 +66,12 @@ variable "status_transformation_function" {
   description = "Transformation function for status detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ""
+}
+
+variable "status_max_delay" {
+  description = "Enforce max delay for status detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "status_tip" {
@@ -115,6 +127,12 @@ variable "current_sessions_transformation_function" {
   description = "Transformation function for current_sessions detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ".mean(over='5m')"
+}
+
+variable "current_sessions_max_delay" {
+  description = "Enforce max delay for current_sessions detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "current_sessions_tip" {
@@ -201,6 +219,12 @@ variable "encryption_status_transformation_function" {
   default     = ""
 }
 
+variable "encryption_status_max_delay" {
+  description = "Enforce max delay for encryption_status detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "encryption_status_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -254,6 +278,12 @@ variable "license_transformation_function" {
   description = "Transformation function for license detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ""
+}
+
+variable "license_max_delay" {
+  description = "Enforce max delay for license detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "license_tip" {

--- a/modules/smart-agent_apache/detectors-gen.tf
+++ b/modules/smart-agent_apache/detectors-gen.tf
@@ -5,8 +5,6 @@ resource "signalfx_detector" "heartbeat" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
-  max_delay = 900
-
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('apache_connections', filter=${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
@@ -24,6 +22,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.heartbeat_max_delay
 }
 
 resource "signalfx_detector" "busy_workers" {
@@ -64,5 +64,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.busy_workers_max_delay
 }
 

--- a/modules/smart-agent_apache/variables-gen.tf
+++ b/modules/smart-agent_apache/variables-gen.tf
@@ -12,6 +12,12 @@ variable "heartbeat_aggregation_function" {
   default     = ""
 }
 
+variable "heartbeat_max_delay" {
+  description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = 900
+}
+
 variable "heartbeat_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -54,6 +60,12 @@ variable "busy_workers_transformation_function" {
   description = "Transformation function for busy_workers detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ".mean(over='10m')"
+}
+
+variable "busy_workers_max_delay" {
+  description = "Enforce max delay for busy_workers detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "busy_workers_tip" {

--- a/modules/smart-agent_cassandra-nodetool/detectors-gen.tf
+++ b/modules/smart-agent_cassandra-nodetool/detectors-gen.tf
@@ -34,6 +34,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.node_status_max_delay
 }
 
 resource "signalfx_detector" "node_state" {
@@ -59,5 +61,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.node_state_max_delay
 }
 

--- a/modules/smart-agent_cassandra-nodetool/variables-gen.tf
+++ b/modules/smart-agent_cassandra-nodetool/variables-gen.tf
@@ -18,6 +18,12 @@ variable "node_status_transformation_function" {
   default     = ".min(over='10m')"
 }
 
+variable "node_status_max_delay" {
+  description = "Enforce max delay for node_status detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "node_status_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -100,6 +106,12 @@ variable "node_state_transformation_function" {
   description = "Transformation function for node_state detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ".min(over='1h')"
+}
+
+variable "node_state_max_delay" {
+  description = "Enforce max delay for node_state detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "node_state_tip" {

--- a/modules/smart-agent_cassandra/detectors-gen.tf
+++ b/modules/smart-agent_cassandra/detectors-gen.tf
@@ -5,8 +5,6 @@ resource "signalfx_detector" "heartbeat" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
-  max_delay = 900
-
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('counter.cassandra.Storage.Load.Count', filter=${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
@@ -24,6 +22,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.heartbeat_max_delay
 }
 
 resource "signalfx_detector" "read_latency_99th_percentile" {
@@ -67,6 +67,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.read_latency_99th_percentile_max_delay
 }
 
 resource "signalfx_detector" "write_latency_99th_percentile" {
@@ -110,6 +112,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.write_latency_99th_percentile_max_delay
 }
 
 resource "signalfx_detector" "read_latency_real_time" {
@@ -155,6 +159,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.read_latency_real_time_max_delay
 }
 
 resource "signalfx_detector" "write_latency_real_time" {
@@ -200,6 +206,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.write_latency_real_time_max_delay
 }
 
 resource "signalfx_detector" "transactional_read_latency_99th_percentile" {
@@ -243,6 +251,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.transactional_read_latency_99th_percentile_max_delay
 }
 
 resource "signalfx_detector" "transactional_write_latency_99th_percentile" {
@@ -286,6 +296,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.transactional_write_latency_99th_percentile_max_delay
 }
 
 resource "signalfx_detector" "transactional_read_latency_real_time" {
@@ -331,6 +343,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.transactional_read_latency_real_time_max_delay
 }
 
 resource "signalfx_detector" "transactional_write_latency_real_time" {
@@ -376,6 +390,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.transactional_write_latency_real_time_max_delay
 }
 
 resource "signalfx_detector" "storage_exceptions_count" {
@@ -401,5 +417,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.storage_exceptions_count_max_delay
 }
 

--- a/modules/smart-agent_cassandra/variables-gen.tf
+++ b/modules/smart-agent_cassandra/variables-gen.tf
@@ -18,6 +18,12 @@ variable "heartbeat_transformation_function" {
   default     = ".mean(by=['cluster'])"
 }
 
+variable "heartbeat_max_delay" {
+  description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = 900
+}
+
 variable "heartbeat_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -60,6 +66,12 @@ variable "read_latency_99th_percentile_transformation_function" {
   description = "Transformation function for read_latency_99th_percentile detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ""
+}
+
+variable "read_latency_99th_percentile_max_delay" {
+  description = "Enforce max delay for read_latency_99th_percentile detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "read_latency_99th_percentile_tip" {
@@ -146,6 +158,12 @@ variable "write_latency_99th_percentile_transformation_function" {
   default     = ""
 }
 
+variable "write_latency_99th_percentile_max_delay" {
+  description = "Enforce max delay for write_latency_99th_percentile detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "write_latency_99th_percentile_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -228,6 +246,12 @@ variable "read_latency_real_time_transformation_function" {
   description = "Transformation function for read_latency_real_time detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ""
+}
+
+variable "read_latency_real_time_max_delay" {
+  description = "Enforce max delay for read_latency_real_time detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "read_latency_real_time_tip" {
@@ -314,6 +338,12 @@ variable "write_latency_real_time_transformation_function" {
   default     = ""
 }
 
+variable "write_latency_real_time_max_delay" {
+  description = "Enforce max delay for write_latency_real_time detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "write_latency_real_time_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -396,6 +426,12 @@ variable "transactional_read_latency_99th_percentile_transformation_function" {
   description = "Transformation function for transactional_read_latency_99th_percentile detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ""
+}
+
+variable "transactional_read_latency_99th_percentile_max_delay" {
+  description = "Enforce max delay for transactional_read_latency_99th_percentile detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "transactional_read_latency_99th_percentile_tip" {
@@ -482,6 +518,12 @@ variable "transactional_write_latency_99th_percentile_transformation_function" {
   default     = ""
 }
 
+variable "transactional_write_latency_99th_percentile_max_delay" {
+  description = "Enforce max delay for transactional_write_latency_99th_percentile detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "transactional_write_latency_99th_percentile_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -564,6 +606,12 @@ variable "transactional_read_latency_real_time_transformation_function" {
   description = "Transformation function for transactional_read_latency_real_time detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ""
+}
+
+variable "transactional_read_latency_real_time_max_delay" {
+  description = "Enforce max delay for transactional_read_latency_real_time detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "transactional_read_latency_real_time_tip" {
@@ -650,6 +698,12 @@ variable "transactional_write_latency_real_time_transformation_function" {
   default     = ""
 }
 
+variable "transactional_write_latency_real_time_max_delay" {
+  description = "Enforce max delay for transactional_write_latency_real_time detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "transactional_write_latency_real_time_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -732,6 +786,12 @@ variable "storage_exceptions_count_transformation_function" {
   description = "Transformation function for storage_exceptions_count detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ".sum(over='5m')"
+}
+
+variable "storage_exceptions_count_max_delay" {
+  description = "Enforce max delay for storage_exceptions_count detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "storage_exceptions_count_tip" {

--- a/modules/smart-agent_couchbase/detectors-gen.tf
+++ b/modules/smart-agent_couchbase/detectors-gen.tf
@@ -41,6 +41,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.memory_used_max_delay
 }
 
 resource "signalfx_detector" "out_of_memory_errors" {
@@ -66,6 +68,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.out_of_memory_errors_max_delay
 }
 
 resource "signalfx_detector" "disk_write_queue" {
@@ -104,5 +108,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.disk_write_queue_max_delay
 }
 

--- a/modules/smart-agent_couchbase/variables-gen.tf
+++ b/modules/smart-agent_couchbase/variables-gen.tf
@@ -18,6 +18,12 @@ variable "memory_used_transformation_function" {
   default     = ".min(over='15m')"
 }
 
+variable "memory_used_max_delay" {
+  description = "Enforce max delay for memory_used detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "memory_used_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -102,6 +108,12 @@ variable "out_of_memory_errors_transformation_function" {
   default     = ".min(over='15m')"
 }
 
+variable "out_of_memory_errors_max_delay" {
+  description = "Enforce max delay for out_of_memory_errors detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "out_of_memory_errors_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -155,6 +167,12 @@ variable "disk_write_queue_transformation_function" {
   description = "Transformation function for disk_write_queue detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ".min(over='15m')"
+}
+
+variable "disk_write_queue_max_delay" {
+  description = "Enforce max delay for disk_write_queue detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "disk_write_queue_tip" {

--- a/modules/smart-agent_health-checker/detectors-gen.tf
+++ b/modules/smart-agent_health-checker/detectors-gen.tf
@@ -21,6 +21,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.value_max_delay
 }
 
 resource "signalfx_detector" "status" {
@@ -46,5 +48,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.status_max_delay
 }
 

--- a/modules/smart-agent_health-checker/variables-gen.tf
+++ b/modules/smart-agent_health-checker/variables-gen.tf
@@ -18,6 +18,12 @@ variable "value_transformation_function" {
   default     = ""
 }
 
+variable "value_max_delay" {
+  description = "Enforce max delay for value detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "value_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -71,6 +77,12 @@ variable "status_transformation_function" {
   description = "Transformation function for status detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ""
+}
+
+variable "status_max_delay" {
+  description = "Enforce max delay for status detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "status_tip" {

--- a/modules/smart-agent_http/detectors-gen.tf
+++ b/modules/smart-agent_http/detectors-gen.tf
@@ -5,8 +5,6 @@ resource "signalfx_detector" "heartbeat" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
-  max_delay = 900
-
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('http.status_code', filter=${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
@@ -24,6 +22,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.heartbeat_max_delay
 }
 
 resource "signalfx_detector" "http_code_matched" {
@@ -49,6 +49,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.http_code_matched_max_delay
 }
 
 resource "signalfx_detector" "http_regex_matched" {
@@ -74,6 +76,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.http_regex_matched_max_delay
 }
 
 resource "signalfx_detector" "http_response_time" {
@@ -112,6 +116,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.http_response_time_max_delay
 }
 
 resource "signalfx_detector" "http_content_length" {
@@ -142,6 +148,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.http_content_length_max_delay
 }
 
 resource "signalfx_detector" "certificate_expiration_date" {
@@ -186,6 +194,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.certificate_expiration_date_max_delay
 }
 
 resource "signalfx_detector" "invalid_tls_certificate" {
@@ -216,5 +226,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.invalid_tls_certificate_max_delay
 }
 

--- a/modules/smart-agent_http/variables-gen.tf
+++ b/modules/smart-agent_http/variables-gen.tf
@@ -12,6 +12,12 @@ variable "heartbeat_aggregation_function" {
   default     = ""
 }
 
+variable "heartbeat_max_delay" {
+  description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = 900
+}
+
 variable "heartbeat_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -54,6 +60,12 @@ variable "http_code_matched_transformation_function" {
   description = "Transformation function for http_code_matched detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ""
+}
+
+variable "http_code_matched_max_delay" {
+  description = "Enforce max delay for http_code_matched detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "http_code_matched_tip" {
@@ -111,6 +123,12 @@ variable "http_regex_matched_transformation_function" {
   default     = ""
 }
 
+variable "http_regex_matched_max_delay" {
+  description = "Enforce max delay for http_regex_matched detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "http_regex_matched_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -164,6 +182,12 @@ variable "http_response_time_transformation_function" {
   description = "Transformation function for http_response_time detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ""
+}
+
+variable "http_response_time_max_delay" {
+  description = "Enforce max delay for http_response_time detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "http_response_time_tip" {
@@ -250,6 +274,12 @@ variable "http_content_length_transformation_function" {
   default     = ""
 }
 
+variable "http_content_length_max_delay" {
+  description = "Enforce max delay for http_content_length detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "http_content_length_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -303,6 +333,12 @@ variable "certificate_expiration_date_transformation_function" {
   description = "Transformation function for certificate_expiration_date detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ""
+}
+
+variable "certificate_expiration_date_max_delay" {
+  description = "Enforce max delay for certificate_expiration_date detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "certificate_expiration_date_tip" {
@@ -387,6 +423,12 @@ variable "invalid_tls_certificate_transformation_function" {
   description = "Transformation function for invalid_tls_certificate detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ""
+}
+
+variable "invalid_tls_certificate_max_delay" {
+  description = "Enforce max delay for invalid_tls_certificate detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "invalid_tls_certificate_tip" {

--- a/modules/smart-agent_kubernetes-common/detectors-gen.tf
+++ b/modules/smart-agent_kubernetes-common/detectors-gen.tf
@@ -5,8 +5,6 @@ resource "signalfx_detector" "heartbeat" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
-  max_delay = 900
-
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('kubernetes.node_ready', filter=${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
@@ -24,6 +22,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.heartbeat_max_delay
 }
 
 resource "signalfx_detector" "hpa_capacity" {
@@ -51,6 +51,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.hpa_capacity_max_delay
 }
 
 resource "signalfx_detector" "node_ready" {
@@ -90,6 +92,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.node_ready_max_delay
 }
 
 resource "signalfx_detector" "pod_phase_status" {
@@ -142,6 +146,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.pod_phase_status_max_delay
 }
 
 resource "signalfx_detector" "terminated" {
@@ -168,6 +174,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.terminated_max_delay
 }
 
 resource "signalfx_detector" "oom_killed" {
@@ -195,6 +203,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.oom_killed_max_delay
 }
 
 resource "signalfx_detector" "deployment_crashloopbackoff" {
@@ -221,6 +231,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.deployment_crashloopbackoff_max_delay
 }
 
 resource "signalfx_detector" "daemonset_crashloopbackoff" {
@@ -247,6 +259,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.daemonset_crashloopbackoff_max_delay
 }
 
 resource "signalfx_detector" "job_failed" {
@@ -275,6 +289,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.job_failed_max_delay
 }
 
 resource "signalfx_detector" "daemonset_scheduled" {
@@ -302,6 +318,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.daemonset_scheduled_max_delay
 }
 
 resource "signalfx_detector" "daemonset_ready" {
@@ -329,6 +347,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.daemonset_ready_max_delay
 }
 
 resource "signalfx_detector" "daemonset_misscheduled" {
@@ -354,6 +374,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.daemonset_misscheduled_max_delay
 }
 
 resource "signalfx_detector" "deployment_available" {
@@ -381,6 +403,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.deployment_available_max_delay
 }
 
 resource "signalfx_detector" "replicaset_available" {
@@ -408,6 +432,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.replicaset_available_max_delay
 }
 
 resource "signalfx_detector" "replication_controller_available" {
@@ -435,6 +461,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.replication_controller_available_max_delay
 }
 
 resource "signalfx_detector" "statefulset_ready" {
@@ -462,5 +490,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.statefulset_ready_max_delay
 }
 

--- a/modules/smart-agent_kubernetes-common/variables-gen.tf
+++ b/modules/smart-agent_kubernetes-common/variables-gen.tf
@@ -12,6 +12,12 @@ variable "heartbeat_aggregation_function" {
   default     = ".mean(by=['kubernetes_cluster'])"
 }
 
+variable "heartbeat_max_delay" {
+  description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = 900
+}
+
 variable "heartbeat_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -54,6 +60,12 @@ variable "hpa_capacity_transformation_function" {
   description = "Transformation function for hpa_capacity detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ""
+}
+
+variable "hpa_capacity_max_delay" {
+  description = "Enforce max delay for hpa_capacity detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "hpa_capacity_tip" {
@@ -111,6 +123,12 @@ variable "node_ready_transformation_function" {
   description = "Transformation function for node_ready detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ""
+}
+
+variable "node_ready_max_delay" {
+  description = "Enforce max delay for node_ready detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "node_ready_tip" {
@@ -195,6 +213,12 @@ variable "pod_phase_status_transformation_function" {
   description = "Transformation function for pod_phase_status detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ""
+}
+
+variable "pod_phase_status_max_delay" {
+  description = "Enforce max delay for pod_phase_status detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "pod_phase_status_tip" {
@@ -304,6 +328,12 @@ variable "terminated_transformation_function" {
   default     = ""
 }
 
+variable "terminated_max_delay" {
+  description = "Enforce max delay for terminated detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "terminated_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -357,6 +387,12 @@ variable "oom_killed_transformation_function" {
   description = "Transformation function for oom_killed detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ""
+}
+
+variable "oom_killed_max_delay" {
+  description = "Enforce max delay for oom_killed detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "oom_killed_tip" {
@@ -414,6 +450,12 @@ variable "deployment_crashloopbackoff_transformation_function" {
   default     = ".sum(over='15m')"
 }
 
+variable "deployment_crashloopbackoff_max_delay" {
+  description = "Enforce max delay for deployment_crashloopbackoff detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "deployment_crashloopbackoff_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -467,6 +509,12 @@ variable "daemonset_crashloopbackoff_transformation_function" {
   description = "Transformation function for daemonset_crashloopbackoff detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ".sum(over='15m')"
+}
+
+variable "daemonset_crashloopbackoff_max_delay" {
+  description = "Enforce max delay for daemonset_crashloopbackoff detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "daemonset_crashloopbackoff_tip" {
@@ -524,6 +572,12 @@ variable "job_failed_transformation_function" {
   default     = ""
 }
 
+variable "job_failed_max_delay" {
+  description = "Enforce max delay for job_failed detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "job_failed_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -577,6 +631,12 @@ variable "daemonset_scheduled_transformation_function" {
   description = "Transformation function for daemonset_scheduled detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ""
+}
+
+variable "daemonset_scheduled_max_delay" {
+  description = "Enforce max delay for daemonset_scheduled detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "daemonset_scheduled_tip" {
@@ -634,6 +694,12 @@ variable "daemonset_ready_transformation_function" {
   default     = ""
 }
 
+variable "daemonset_ready_max_delay" {
+  description = "Enforce max delay for daemonset_ready detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "daemonset_ready_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -687,6 +753,12 @@ variable "daemonset_misscheduled_transformation_function" {
   description = "Transformation function for daemonset_misscheduled detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ""
+}
+
+variable "daemonset_misscheduled_max_delay" {
+  description = "Enforce max delay for daemonset_misscheduled detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "daemonset_misscheduled_tip" {
@@ -744,6 +816,12 @@ variable "deployment_available_transformation_function" {
   default     = ""
 }
 
+variable "deployment_available_max_delay" {
+  description = "Enforce max delay for deployment_available detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "deployment_available_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -797,6 +875,12 @@ variable "replicaset_available_transformation_function" {
   description = "Transformation function for replicaset_available detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ""
+}
+
+variable "replicaset_available_max_delay" {
+  description = "Enforce max delay for replicaset_available detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "replicaset_available_tip" {
@@ -854,6 +938,12 @@ variable "replication_controller_available_transformation_function" {
   default     = ""
 }
 
+variable "replication_controller_available_max_delay" {
+  description = "Enforce max delay for replication_controller_available detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "replication_controller_available_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -907,6 +997,12 @@ variable "statefulset_ready_transformation_function" {
   description = "Transformation function for statefulset_ready detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ""
+}
+
+variable "statefulset_ready_max_delay" {
+  description = "Enforce max delay for statefulset_ready detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "statefulset_ready_tip" {

--- a/modules/smart-agent_kubernetes-workloads-count/detectors-gen.tf
+++ b/modules/smart-agent_kubernetes-workloads-count/detectors-gen.tf
@@ -45,5 +45,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.workloads_count_max_delay
 }
 

--- a/modules/smart-agent_kubernetes-workloads-count/variables-gen.tf
+++ b/modules/smart-agent_kubernetes-workloads-count/variables-gen.tf
@@ -18,6 +18,12 @@ variable "workloads_count_transformation_function" {
   default     = ".min(over='30m')"
 }
 
+variable "workloads_count_max_delay" {
+  description = "Enforce max delay for workloads_count detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "workloads_count_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string

--- a/modules/smart-agent_mdadm/detectors-gen.tf
+++ b/modules/smart-agent_mdadm/detectors-gen.tf
@@ -34,6 +34,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.disk_failed_max_delay
 }
 
 resource "signalfx_detector" "disk_missing" {
@@ -72,5 +74,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.disk_missing_max_delay
 }
 

--- a/modules/smart-agent_mdadm/variables-gen.tf
+++ b/modules/smart-agent_mdadm/variables-gen.tf
@@ -18,6 +18,12 @@ variable "disk_failed_transformation_function" {
   default     = ".min(over='1m')"
 }
 
+variable "disk_failed_max_delay" {
+  description = "Enforce max delay for disk_failed detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "disk_failed_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -100,6 +106,12 @@ variable "disk_missing_transformation_function" {
   description = "Transformation function for disk_missing detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ".min(over='1m')"
+}
+
+variable "disk_missing_max_delay" {
+  description = "Enforce max delay for disk_missing detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "disk_missing_tip" {

--- a/modules/smart-agent_nagios-status-check/detectors-gen.tf
+++ b/modules/smart-agent_nagios-status-check/detectors-gen.tf
@@ -47,5 +47,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.status_check_max_delay
 }
 

--- a/modules/smart-agent_nagios-status-check/variables-gen.tf
+++ b/modules/smart-agent_nagios-status-check/variables-gen.tf
@@ -18,6 +18,12 @@ variable "status_check_transformation_function" {
   default     = ""
 }
 
+variable "status_check_max_delay" {
+  description = "Enforce max delay for status_check detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "status_check_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string

--- a/modules/smart-agent_nginx-ingress/detectors-gen.tf
+++ b/modules/smart-agent_nginx-ingress/detectors-gen.tf
@@ -39,6 +39,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.latency_max_delay
 }
 
 resource "signalfx_detector" "http_5xx" {
@@ -84,6 +86,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.http_5xx_max_delay
 }
 
 resource "signalfx_detector" "http_4xx" {
@@ -129,5 +133,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.http_4xx_max_delay
 }
 

--- a/modules/smart-agent_nginx-ingress/variables-gen.tf
+++ b/modules/smart-agent_nginx-ingress/variables-gen.tf
@@ -18,6 +18,12 @@ variable "latency_transformation_function" {
   default     = ""
 }
 
+variable "latency_max_delay" {
+  description = "Enforce max delay for latency detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "latency_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -102,6 +108,12 @@ variable "http_5xx_transformation_function" {
   default     = ""
 }
 
+variable "http_5xx_max_delay" {
+  description = "Enforce max delay for http_5xx detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "http_5xx_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -184,6 +196,12 @@ variable "http_4xx_transformation_function" {
   description = "Transformation function for http_4xx detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ""
+}
+
+variable "http_4xx_max_delay" {
+  description = "Enforce max delay for http_4xx detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "http_4xx_tip" {

--- a/modules/smart-agent_nginx/detectors-nginx.tf
+++ b/modules/smart-agent_nginx/detectors-nginx.tf
@@ -1,7 +1,6 @@
 resource "signalfx_detector" "heartbeat" {
   name = format("%s %s", local.detector_name_prefix, "Nginx heartbeat")
 
-
   authorized_writer_teams = var.authorized_writer_teams
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))

--- a/modules/smart-agent_processes/detectors-gen.tf
+++ b/modules/smart-agent_processes/detectors-gen.tf
@@ -34,5 +34,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.processes_max_delay
 }
 

--- a/modules/smart-agent_processes/variables-gen.tf
+++ b/modules/smart-agent_processes/variables-gen.tf
@@ -18,6 +18,12 @@ variable "processes_transformation_function" {
   default     = ".max(over='15m')"
 }
 
+variable "processes_max_delay" {
+  description = "Enforce max delay for processes detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "processes_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string

--- a/modules/smart-agent_rabbitmq-queue/detectors-gen.tf
+++ b/modules/smart-agent_rabbitmq-queue/detectors-gen.tf
@@ -35,6 +35,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.messages_ready_max_delay
 }
 
 resource "signalfx_detector" "messages_unacknowledged" {
@@ -74,6 +76,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.messages_unacknowledged_max_delay
 }
 
 resource "signalfx_detector" "messages_ack_rate" {
@@ -114,6 +118,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.messages_ack_rate_max_delay
 }
 
 resource "signalfx_detector" "consumer_use" {
@@ -154,5 +160,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.consumer_use_max_delay
 }
 

--- a/modules/smart-agent_rabbitmq-queue/variables-gen.tf
+++ b/modules/smart-agent_rabbitmq-queue/variables-gen.tf
@@ -18,6 +18,12 @@ variable "messages_ready_transformation_function" {
   default     = ""
 }
 
+variable "messages_ready_max_delay" {
+  description = "Enforce max delay for messages_ready detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "messages_ready_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -100,6 +106,12 @@ variable "messages_unacknowledged_transformation_function" {
   description = "Transformation function for messages_unacknowledged detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ""
+}
+
+variable "messages_unacknowledged_max_delay" {
+  description = "Enforce max delay for messages_unacknowledged detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "messages_unacknowledged_tip" {
@@ -186,6 +198,12 @@ variable "messages_ack_rate_transformation_function" {
   default     = ""
 }
 
+variable "messages_ack_rate_max_delay" {
+  description = "Enforce max delay for messages_ack_rate detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "messages_ack_rate_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -268,6 +286,12 @@ variable "consumer_use_transformation_function" {
   description = "Transformation function for consumer_use detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ""
+}
+
+variable "consumer_use_max_delay" {
+  description = "Enforce max delay for consumer_use detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "consumer_use_tip" {

--- a/modules/smart-agent_system-common/detectors-gen.tf
+++ b/modules/smart-agent_system-common/detectors-gen.tf
@@ -5,8 +5,6 @@ resource "signalfx_detector" "heartbeat" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
-  max_delay = 900
-
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('cpu.utilization', filter=${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
@@ -24,6 +22,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.heartbeat_max_delay
 }
 
 resource "signalfx_detector" "cpu" {
@@ -67,6 +67,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.cpu_max_delay
 }
 
 resource "signalfx_detector" "load" {
@@ -107,6 +109,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.load_max_delay
 }
 
 resource "signalfx_detector" "disk_space" {
@@ -150,6 +154,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.disk_space_max_delay
 }
 
 resource "signalfx_detector" "disk_inodes" {
@@ -193,6 +199,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.disk_inodes_max_delay
 }
 
 resource "signalfx_detector" "memory" {
@@ -236,5 +244,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.memory_max_delay
 }
 

--- a/modules/smart-agent_system-common/detectors-system.tf
+++ b/modules/smart-agent_system-common/detectors-system.tf
@@ -5,7 +5,6 @@ resource "signalfx_detector" "disk_running_out" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
-
   program_text = <<-EOF
     from signalfx.detectors.countdown import countdown
     signal = data('disk.utilization', filter=${module.filtering.signalflow}).publish('signal')

--- a/modules/smart-agent_system-common/variables-gen.tf
+++ b/modules/smart-agent_system-common/variables-gen.tf
@@ -12,6 +12,12 @@ variable "heartbeat_aggregation_function" {
   default     = ""
 }
 
+variable "heartbeat_max_delay" {
+  description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = 900
+}
+
 variable "heartbeat_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -54,6 +60,12 @@ variable "cpu_transformation_function" {
   description = "Transformation function for cpu detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ".min(over='1h')"
+}
+
+variable "cpu_max_delay" {
+  description = "Enforce max delay for cpu detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "cpu_tip" {
@@ -140,6 +152,12 @@ variable "load_transformation_function" {
   default     = ".min(over='30m')"
 }
 
+variable "load_max_delay" {
+  description = "Enforce max delay for load detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "load_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -222,6 +240,12 @@ variable "disk_space_transformation_function" {
   description = "Transformation function for disk_space detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ".max(over='5m')"
+}
+
+variable "disk_space_max_delay" {
+  description = "Enforce max delay for disk_space detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "disk_space_tip" {
@@ -308,6 +332,12 @@ variable "disk_inodes_transformation_function" {
   default     = ".max(over='5m')"
 }
 
+variable "disk_inodes_max_delay" {
+  description = "Enforce max delay for disk_inodes detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "disk_inodes_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -390,6 +420,12 @@ variable "memory_transformation_function" {
   description = "Transformation function for memory detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ".min(over='5m')"
+}
+
+variable "memory_max_delay" {
+  description = "Enforce max delay for memory detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "memory_tip" {

--- a/modules/smart-agent_systemd-services/detectors-gen.tf
+++ b/modules/smart-agent_systemd-services/detectors-gen.tf
@@ -21,5 +21,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.aliveness_max_delay
 }
 

--- a/modules/smart-agent_systemd-services/variables-gen.tf
+++ b/modules/smart-agent_systemd-services/variables-gen.tf
@@ -18,6 +18,12 @@ variable "aliveness_transformation_function" {
   default     = ""
 }
 
+variable "aliveness_max_delay" {
+  description = "Enforce max delay for aliveness detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "aliveness_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string

--- a/modules/smart-agent_systemd-timers/detectors-gen.tf
+++ b/modules/smart-agent_systemd-timers/detectors-gen.tf
@@ -5,8 +5,6 @@ resource "signalfx_detector" "heartbeat" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
-  max_delay = 900
-
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('gauge.substate.failed', filter=${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
@@ -24,6 +22,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.heartbeat_max_delay
 }
 
 resource "signalfx_detector" "execution_delay" {
@@ -51,6 +51,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.execution_delay_max_delay
 }
 
 resource "signalfx_detector" "last_execution_state" {
@@ -76,5 +78,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.last_execution_state_max_delay
 }
 

--- a/modules/smart-agent_systemd-timers/variables-gen.tf
+++ b/modules/smart-agent_systemd-timers/variables-gen.tf
@@ -12,6 +12,12 @@ variable "heartbeat_aggregation_function" {
   default     = ""
 }
 
+variable "heartbeat_max_delay" {
+  description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = 900
+}
+
 variable "heartbeat_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -54,6 +60,12 @@ variable "execution_delay_transformation_function" {
   description = "Transformation function for execution_delay detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ""
+}
+
+variable "execution_delay_max_delay" {
+  description = "Enforce max delay for execution_delay detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "execution_delay_tip" {
@@ -109,6 +121,12 @@ variable "last_execution_state_transformation_function" {
   description = "Transformation function for last_execution_state detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ""
+}
+
+variable "last_execution_state_max_delay" {
+  description = "Enforce max delay for last_execution_state detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "last_execution_state_tip" {

--- a/scripts/templates/detector.tf.j2
+++ b/scripts/templates/detector.tf.j2
@@ -16,10 +16,6 @@ resource "signalfx_detector" "{{ id }}" {
   authorized_writer_teams = var.authorized_writer_teams
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
-  {%- if type == 'heartbeat' %}
-
-  max_delay = 900
-  {%- endif %}
 
 {%- for key, signal in signals.items() -%}
   {%- if loop.last -%}
@@ -103,5 +99,7 @@ EOF
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
   {%- endfor %}
+
+  max_delay = var.{{ id }}_max_delay
 }
 

--- a/scripts/templates/values.yaml
+++ b/scripts/templates/values.yaml
@@ -101,6 +101,12 @@ runbook_url:
 ## use to set its custom one.
 tip:
 
+## @param max_delay - number - optional
+## Define a default max_delay for this detector, see:
+## https://docs.splunk.com/Observability/alerts-detectors-notifications/detector-options.html#max-delay
+## If not defined, it will be set to null expect for heartbeat which enforce 900.
+max_delay:
+
 ## @param disabled - bool - optional
 ## Allows to disable all alerting rules defined in this detector
 ## Only works if set to `true`.

--- a/scripts/templates/variables.tf.j2
+++ b/scripts/templates/variables.tf.j2
@@ -36,6 +36,12 @@ variable "{{ id }}_transformation_function" {
 
 {% endif -%}
 
+variable "{{ id }}_max_delay" {
+  description = "Enforce max delay for {{ id }} detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = {% if max_delay is number %}{{ max_delay }}{% else %}{% if type == 'heartbeat' %}900{% else %}null{% endif %}{% endif %}
+}
+
 variable "{{ id }}_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string


### PR DESCRIPTION
part of https://github.com/claranet/terraform-signalfx-detectors/issues/375 resolution.

It adds support for configurable `max_delay` into generator.

I already updated the doc to add the new related variable: https://github.com/claranet/terraform-signalfx-detectors/wiki/Variables#max_delay

The CI will fail to keep the PR clean for review, another PR will be submit to auto update generated detectors.