### PR TITLE
add max_delay variables to handmade detectors

### DIFF
--- a/modules/integration_aws-beanstalk/detectors-beanstalk.tf
+++ b/modules/integration_aws-beanstalk/detectors-beanstalk.tf
@@ -5,8 +5,6 @@ resource "signalfx_detector" "heartbeat" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
-  max_delay = 900
-
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('EnvironmentHealth', filter=filter('stat', 'mean') and filter('namespace', 'AWS/ElasticBeanstalk') and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
@@ -24,6 +22,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.heartbeat_max_delay
 }
 
 resource "signalfx_detector" "health" {
@@ -62,6 +62,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.health_max_delay
 }
 
 resource "signalfx_detector" "latency_p90" {
@@ -100,6 +102,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.latency_p90_max_delay
 }
 
 resource "signalfx_detector" "app_5xx_error_rate" {
@@ -141,6 +145,7 @@ EOF
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
 
+  max_delay = var.app_5xx_error_rate_max_delay
 }
 
 resource "signalfx_detector" "root_filesystem_usage" {
@@ -179,5 +184,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.root_filesystem_usage_max_delay
 }
 

--- a/modules/integration_aws-beanstalk/variables.tf
+++ b/modules/integration_aws-beanstalk/variables.tf
@@ -2,6 +2,12 @@
 
 # Heartbeat detector
 
+variable "heartbeat_max_delay" {
+  description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = 900
+}
+
 variable "heartbeat_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -39,6 +45,12 @@ variable "heartbeat_aggregation_function" {
 }
 
 # Health detector
+
+variable "health_max_delay" {
+  description = "Enforce max delay for health detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "health_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -102,6 +114,12 @@ variable "health_threshold_major" {
 
 # Latency_p90 detector
 
+variable "latency_p90_max_delay" {
+  description = "Enforce max delay for latency_p90 detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "latency_p90_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -164,6 +182,12 @@ variable "latency_p90_threshold_major" {
 
 # app_5xx_error_rate detector
 
+variable "app_5xx_error_rate_max_delay" {
+  description = "Enforce max delay for app_5xx_error_rate detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "app_5xx_error_rate_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -225,6 +249,12 @@ variable "app_5xx_error_rate_threshold_major" {
 }
 
 # Root_filesystem_usage detector
+
+variable "root_filesystem_usage_max_delay" {
+  description = "Enforce max delay for root_filesystem_usage detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "root_filesystem_usage_tip" {
   description = "Suggested first course of action or any note useful for incident handling"

--- a/modules/integration_aws-ecs-cluster/detectors-ecs-cluster.tf
+++ b/modules/integration_aws-ecs-cluster/detectors-ecs-cluster.tf
@@ -5,8 +5,6 @@ resource "signalfx_detector" "heartbeat" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
-  max_delay = 900
-
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('CPUReservation', filter=filter('namespace', 'AWS/ECS') and filter('stat', 'mean') and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
@@ -24,6 +22,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.heartbeat_max_delay
 }
 
 resource "signalfx_detector" "cpu_utilization" {
@@ -62,6 +62,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.cpu_utilization_max_delay
 }
 
 resource "signalfx_detector" "memory_utilization" {
@@ -100,5 +102,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.memory_utilization_max_delay
 }
 

--- a/modules/integration_aws-ecs-cluster/variables.tf
+++ b/modules/integration_aws-ecs-cluster/variables.tf
@@ -2,6 +2,12 @@
 
 # Heartbeat detector
 
+variable "heartbeat_max_delay" {
+  description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = 900
+}
+
 variable "heartbeat_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -39,6 +45,12 @@ variable "heartbeat_aggregation_function" {
 }
 
 # CPU_utilization detector
+
+variable "cpu_utilization_max_delay" {
+  description = "Enforce max delay for cpu_utilization detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "cpu_utilization_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -101,6 +113,12 @@ variable "cpu_utilization_threshold_major" {
 }
 
 # Memory_utilization detector
+
+variable "memory_utilization_max_delay" {
+  description = "Enforce max delay for memory_utilization detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "memory_utilization_tip" {
   description = "Suggested first course of action or any note useful for incident handling"

--- a/modules/integration_aws-ecs-service/detectors-ecs-service.tf
+++ b/modules/integration_aws-ecs-service/detectors-ecs-service.tf
@@ -5,8 +5,6 @@ resource "signalfx_detector" "heartbeat" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
-  max_delay = 900
-
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('CPUUtilization', filter=filter('namespace', 'AWS/ECS') and filter('stat', 'mean') and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
@@ -24,6 +22,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.heartbeat_max_delay
 }
 
 # Monitors related to services
@@ -63,6 +63,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.cpu_utilization_max_delay
 }
 
 resource "signalfx_detector" "memory_utilization" {
@@ -101,5 +103,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.memory_utilization_max_delay
 }
 

--- a/modules/integration_aws-ecs-service/variables.tf
+++ b/modules/integration_aws-ecs-service/variables.tf
@@ -2,6 +2,12 @@
 
 # Heartbeat detector
 
+variable "heartbeat_max_delay" {
+  description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = 900
+}
+
 variable "heartbeat_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -39,6 +45,12 @@ variable "heartbeat_aggregation_function" {
 }
 
 # CPU_utilization detector
+
+variable "cpu_utilization_max_delay" {
+  description = "Enforce max delay for cpu_utilization detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "cpu_utilization_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -101,6 +113,12 @@ variable "cpu_utilization_threshold_major" {
 }
 
 # Memory_utilization detector
+
+variable "memory_utilization_max_delay" {
+  description = "Enforce max delay for memory_utilization detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "memory_utilization_tip" {
   description = "Suggested first course of action or any note useful for incident handling"

--- a/modules/integration_aws-elasticache-common/detectors-elasticache.tf
+++ b/modules/integration_aws-elasticache-common/detectors-elasticache.tf
@@ -5,8 +5,6 @@ resource "signalfx_detector" "heartbeat" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
-  max_delay = 900
-
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('CPUUtilization', filter=filter('stat', 'mean') and filter('namespace', 'AWS/ElastiCache') and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
@@ -24,6 +22,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.heartbeat_max_delay
 }
 
 resource "signalfx_detector" "evictions" {
@@ -62,6 +62,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.evictions_max_delay
 }
 
 resource "signalfx_detector" "max_connection" {
@@ -87,6 +89,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.max_connection_max_delay
 }
 
 resource "signalfx_detector" "no_connection" {
@@ -112,6 +116,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.no_connection_max_delay
 }
 
 resource "signalfx_detector" "swap" {
@@ -150,6 +156,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.swap_max_delay
 }
 
 resource "signalfx_detector" "free_memory" {
@@ -188,6 +196,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.free_memory_max_delay
 }
 
 resource "signalfx_detector" "evictions_growing" {
@@ -226,5 +236,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.evictions_growing_max_delay
 }
 

--- a/modules/integration_aws-elasticache-common/variables.tf
+++ b/modules/integration_aws-elasticache-common/variables.tf
@@ -2,6 +2,12 @@
 
 # Heartbeat detector
 
+variable "heartbeat_max_delay" {
+  description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = 900
+}
+
 variable "heartbeat_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -39,6 +45,12 @@ variable "heartbeat_aggregation_function" {
 }
 
 # Evictions detector
+
+variable "evictions_max_delay" {
+  description = "Enforce max delay for evictions detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "evictions_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -102,6 +114,12 @@ variable "evictions_threshold_major" {
 
 # Max_connection detector
 
+variable "max_connection_max_delay" {
+  description = "Enforce max delay for max_connection detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "max_connection_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -152,6 +170,12 @@ variable "max_connection_threshold_critical" {
 
 # No_connection detector
 
+variable "no_connection_max_delay" {
+  description = "Enforce max delay for no_connection detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "no_connection_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -201,6 +225,12 @@ variable "no_connection_threshold_critical" {
 }
 
 # Swap detector
+
+variable "swap_max_delay" {
+  description = "Enforce max delay for swap detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "swap_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -264,6 +294,12 @@ variable "swap_threshold_major" {
 
 # Free_memory detector
 
+variable "free_memory_max_delay" {
+  description = "Enforce max delay for free_memory detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "free_memory_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -325,6 +361,12 @@ variable "free_memory_threshold_minor" {
 }
 
 # Evictions_growing detector
+
+variable "evictions_growing_max_delay" {
+  description = "Enforce max delay for evictions_growing detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "evictions_growing_tip" {
   description = "Suggested first course of action or any note useful for incident handling"

--- a/modules/integration_aws-elasticsearch/detectors-elasticsearch.tf
+++ b/modules/integration_aws-elasticsearch/detectors-elasticsearch.tf
@@ -5,8 +5,6 @@ resource "signalfx_detector" "heartbeat" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
-  max_delay = 900
-
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('Nodes', filter=filter('namespace', 'AWS/ES') and filter('stat', 'mean') and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
@@ -24,6 +22,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.heartbeat_max_delay
 }
 
 resource "signalfx_detector" "cluster_status" {
@@ -63,6 +63,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.cluster_status_max_delay
 }
 
 resource "signalfx_detector" "free_space" {
@@ -107,6 +109,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.free_space_max_delay
 }
 
 resource "signalfx_detector" "cpu_90_15min" {
@@ -145,5 +149,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.cpu_90_15min_max_delay
 }
 

--- a/modules/integration_aws-elasticsearch/variables.tf
+++ b/modules/integration_aws-elasticsearch/variables.tf
@@ -2,6 +2,12 @@
 
 # Heartbeat detector
 
+variable "heartbeat_max_delay" {
+  description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = 900
+}
+
 variable "heartbeat_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -39,6 +45,12 @@ variable "heartbeat_aggregation_function" {
 }
 
 # Cluster_status detector
+
+variable "cluster_status_max_delay" {
+  description = "Enforce max delay for cluster_status detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "cluster_status_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -89,6 +101,12 @@ variable "cluster_status_transformation_function" {
 }
 
 # Free_space detector
+
+variable "free_space_max_delay" {
+  description = "Enforce max delay for free_space detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "free_space_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -151,6 +169,12 @@ variable "free_space_threshold_major" {
 }
 
 # CPU_90_15min detector
+
+variable "cpu_90_15min_max_delay" {
+  description = "Enforce max delay for cpu_90_15min detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "cpu_90_15min_tip" {
   description = "Suggested first course of action or any note useful for incident handling"

--- a/modules/integration_aws-kinesis-firehose/detectors-kinesis-firehose.tf
+++ b/modules/integration_aws-kinesis-firehose/detectors-kinesis-firehose.tf
@@ -5,8 +5,6 @@ resource "signalfx_detector" "heartbeat" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
-  max_delay = 900
-
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('ResourceCount', filter=filter('stat', 'mean') and filter('namespace', 'AWS/Kinesis') and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
@@ -24,6 +22,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.heartbeat_max_delay
 }
 
 resource "signalfx_detector" "incoming_records" {
@@ -62,5 +62,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.incoming_records_max_delay
 }
 

--- a/modules/integration_aws-kinesis-firehose/variables.tf
+++ b/modules/integration_aws-kinesis-firehose/variables.tf
@@ -2,6 +2,12 @@
 
 # Heartbeat detector
 
+variable "heartbeat_max_delay" {
+  description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = 900
+}
+
 variable "heartbeat_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -39,6 +45,12 @@ variable "heartbeat_aggregation_function" {
 }
 
 # incoming_records detector
+
+variable "incoming_records_max_delay" {
+  description = "Enforce max delay for incoming_records detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "incoming_records_tip" {
   description = "Suggested first course of action or any note useful for incident handling"

--- a/modules/integration_aws-nlb/detectors-nlb.tf
+++ b/modules/integration_aws-nlb/detectors-nlb.tf
@@ -5,8 +5,6 @@ resource "signalfx_detector" "heartbeat" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
-  max_delay = 900
-
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('ConsumedLCUs', filter=filter('stat', 'mean') and filter('namespace', 'AWS/NetworkELB') and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
@@ -24,6 +22,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.heartbeat_max_delay
 }
 
 resource "signalfx_detector" "no_healthy_instances" {
@@ -64,5 +64,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.no_healthy_instances_max_delay
 }
 

--- a/modules/integration_aws-nlb/variables.tf
+++ b/modules/integration_aws-nlb/variables.tf
@@ -2,6 +2,12 @@
 
 # Heartbeat detector
 
+variable "heartbeat_max_delay" {
+  description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = 900
+}
+
 variable "heartbeat_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -39,6 +45,12 @@ variable "heartbeat_aggregation_function" {
 }
 
 # No_healthy_instances detector
+
+variable "no_healthy_instances_max_delay" {
+  description = "Enforce max delay for no_healthy_instances detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "no_healthy_instances_tip" {
   description = "Suggested first course of action or any note useful for incident handling"

--- a/modules/integration_aws-rds-aurora-mysql/detectors-rds-aurora-mysql.tf
+++ b/modules/integration_aws-rds-aurora-mysql/detectors-rds-aurora-mysql.tf
@@ -34,5 +34,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.aurora_mysql_replica_lag_max_delay
 }
 

--- a/modules/integration_aws-rds-aurora-mysql/variables.tf
+++ b/modules/integration_aws-rds-aurora-mysql/variables.tf
@@ -2,6 +2,12 @@
 
 # Aurora_mysql_replica_lag detector
 
+variable "aurora_mysql_replica_lag_max_delay" {
+  description = "Enforce max delay for aurora_mysql_replica_lag detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "aurora_mysql_replica_lag_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string

--- a/modules/integration_aws-rds-aurora-postgresql/detectors-rds-aurora-postgresql.tf
+++ b/modules/integration_aws-rds-aurora-postgresql/detectors-rds-aurora-postgresql.tf
@@ -34,5 +34,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.aurora_postgresql_replica_lag_max_delay
 }
 

--- a/modules/integration_aws-rds-aurora-postgresql/variables.tf
+++ b/modules/integration_aws-rds-aurora-postgresql/variables.tf
@@ -2,6 +2,12 @@
 
 # aurora_postgresql_replica_lag detector
 
+variable "aurora_postgresql_replica_lag_max_delay" {
+  description = "Enforce max delay for aurora_postgresql_replica_lag detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "aurora_postgresql_replica_lag_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string

--- a/modules/integration_aws-rds-common/detectors-rds-common.tf
+++ b/modules/integration_aws-rds-common/detectors-rds-common.tf
@@ -5,8 +5,6 @@ resource "signalfx_detector" "heartbeat" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
-  max_delay = 900
-
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('CPUUtilization', filter=filter('stat', 'mean') and filter('namespace', 'AWS/RDS') and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
@@ -24,6 +22,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.heartbeat_max_delay
 }
 
 resource "signalfx_detector" "cpu_90_15min" {
@@ -62,6 +62,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.cpu_90_15min_max_delay
 }
 
 resource "signalfx_detector" "free_space_low" {
@@ -106,6 +108,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.free_space_low_max_delay
 }
 
 resource "signalfx_detector" "replica_lag" {
@@ -144,5 +148,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.replica_lag_max_delay
 }
 

--- a/modules/integration_aws-rds-common/variables.tf
+++ b/modules/integration_aws-rds-common/variables.tf
@@ -2,6 +2,12 @@
 
 # Heartbeat detector
 
+variable "heartbeat_max_delay" {
+  description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = 900
+}
+
 variable "heartbeat_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -39,6 +45,12 @@ variable "heartbeat_aggregation_function" {
 }
 
 # CPU_90_15min detector
+
+variable "cpu_90_15min_max_delay" {
+  description = "Enforce max delay for cpu_90_15min detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "cpu_90_15min_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -102,6 +114,12 @@ variable "cpu_90_15min_threshold_major" {
 
 # Free_space_low detector
 
+variable "free_space_low_max_delay" {
+  description = "Enforce max delay for free_space_low detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "free_space_low_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -163,6 +181,12 @@ variable "free_space_low_threshold_major" {
 }
 
 # Replica_lag detector
+
+variable "replica_lag_max_delay" {
+  description = "Enforce max delay for replica_lag detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "replica_lag_tip" {
   description = "Suggested first course of action or any note useful for incident handling"

--- a/modules/integration_aws-sqs/detectors-sqs.tf
+++ b/modules/integration_aws-sqs/detectors-sqs.tf
@@ -5,8 +5,6 @@ resource "signalfx_detector" "heartbeat" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
-  max_delay = 900
-
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('NumberOfMessagesReceived', filter=filter('stat', 'mean') and filter('namespace', 'AWS/SQS') and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
@@ -24,6 +22,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.heartbeat_max_delay
 }
 
 resource "signalfx_detector" "visible_messages" {
@@ -62,6 +62,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.visible_messages_max_delay
 }
 
 resource "signalfx_detector" "age_of_oldest_message" {
@@ -100,5 +102,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.age_of_oldest_message_max_delay
 }
 

--- a/modules/integration_aws-sqs/variables.tf
+++ b/modules/integration_aws-sqs/variables.tf
@@ -2,6 +2,12 @@
 
 # Heartbeat detector
 
+variable "heartbeat_max_delay" {
+  description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = 900
+}
+
 variable "heartbeat_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -39,6 +45,12 @@ variable "heartbeat_aggregation_function" {
 }
 
 # Visible_messages detectors
+
+variable "visible_messages_max_delay" {
+  description = "Enforce max delay for visible_messages detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "visible_messages_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -101,6 +113,12 @@ variable "visible_messages_threshold_major" {
 }
 
 # Age_of_oldest_message detectors
+
+variable "age_of_oldest_message_max_delay" {
+  description = "Enforce max delay for age_of_oldest_message detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "age_of_oldest_message_tip" {
   description = "Suggested first course of action or any note useful for incident handling"

--- a/modules/integration_aws-vpn/detectors-vpn.tf
+++ b/modules/integration_aws-vpn/detectors-vpn.tf
@@ -5,8 +5,6 @@ resource "signalfx_detector" "heartbeat" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
-  max_delay = 900
-
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('TunnelState', filter=filter('stat', 'mean') and filter('namespace', 'AWS/VPN') and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
@@ -24,6 +22,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.heartbeat_max_delay
 }
 
 resource "signalfx_detector" "VPN_status" {
@@ -49,5 +49,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.vpn_status_max_delay
 }
 

--- a/modules/integration_aws-vpn/variables.tf
+++ b/modules/integration_aws-vpn/variables.tf
@@ -2,6 +2,12 @@
 
 # Heartbeat detector
 
+variable "heartbeat_max_delay" {
+  description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = 900
+}
+
 variable "heartbeat_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -39,6 +45,12 @@ variable "heartbeat_aggregation_function" {
 }
 
 # VPN_status detector
+
+variable "vpn_status_max_delay" {
+  description = "Enforce max delay for vpn_status detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "vpn_status_tip" {
   description = "Suggested first course of action or any note useful for incident handling"

--- a/modules/integration_azure-api-management-service/detectors-api-management-service.tf
+++ b/modules/integration_azure-api-management-service/detectors-api-management-service.tf
@@ -5,8 +5,6 @@ resource "signalfx_detector" "heartbeat" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
-  max_delay = 900
-
   program_text = <<-EOF
         from signalfx.detectors.not_reporting import not_reporting
         base_filter = filter('resource_type', 'Microsoft.ApiManagement/service') and filter('primary_aggregation_type', 'true')
@@ -25,6 +23,8 @@ resource "signalfx_detector" "heartbeat" {
     parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.heartbeat_max_delay
 }
 
 resource "signalfx_detector" "capacity" {
@@ -60,6 +60,8 @@ resource "signalfx_detector" "capacity" {
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.capacity_max_delay
 }
 
 resource "signalfx_detector" "gateway_requests_duration" {
@@ -95,6 +97,8 @@ resource "signalfx_detector" "gateway_requests_duration" {
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.gateway_requests_duration_max_delay
 }
 
 resource "signalfx_detector" "backend_requests_duration" {
@@ -130,4 +134,6 @@ resource "signalfx_detector" "backend_requests_duration" {
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.backend_requests_duration_max_delay
 }

--- a/modules/integration_azure-api-management-service/variables.tf
+++ b/modules/integration_azure-api-management-service/variables.tf
@@ -26,6 +26,12 @@ variable "heartbeat_aggregation_function" {
   default     = ".mean(by=['azure_resource_name', 'azure_resource_group_name', 'azure_region'])"
 }
 
+variable "heartbeat_max_delay" {
+  description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = 900
+}
+
 variable "heartbeat_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -86,6 +92,12 @@ variable "capacity_threshold_major" {
   description = "Major threshold for capacity detector (in %)"
   type        = number
   default     = 90
+}
+
+variable "capacity_max_delay" {
+  description = "Enforce max delay for capacity detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "capacity_tip" {
@@ -150,6 +162,12 @@ variable "gateway_requests_duration_threshold_major" {
   default     = 1
 }
 
+variable "gateway_requests_duration_max_delay" {
+  description = "Enforce max delay for gateway_requests_duration detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "gateway_requests_duration_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -210,6 +228,12 @@ variable "backend_requests_duration_threshold_major" {
   description = "Major threshold for backend requests duration detector (in s)"
   type        = number
   default     = 1
+}
+
+variable "backend_requests_duration_max_delay" {
+  description = "Enforce max delay for backend_requests_duration detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "backend_requests_duration_tip" {

--- a/modules/integration_azure-app-service-plan/detectors-azure-app-service-plan.tf
+++ b/modules/integration_azure-app-service-plan/detectors-azure-app-service-plan.tf
@@ -5,8 +5,6 @@ resource "signalfx_detector" "heartbeat" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
-  max_delay = 900
-
   program_text = <<-EOF
         from signalfx.detectors.not_reporting import not_reporting
         base_filter = filter('resource_type', 'Microsoft.Web/serverFarms') and filter('primary_aggregation_type', 'true')
@@ -25,6 +23,8 @@ resource "signalfx_detector" "heartbeat" {
     parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.heartbeat_max_delay
 }
 
 resource "signalfx_detector" "cpu_percentage" {
@@ -64,6 +64,8 @@ resource "signalfx_detector" "cpu_percentage" {
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.cpu_percentage_max_delay
 }
 
 resource "signalfx_detector" "memory_percentage" {
@@ -103,4 +105,6 @@ resource "signalfx_detector" "memory_percentage" {
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.memory_percentage_max_delay
 }

--- a/modules/integration_azure-app-service-plan/variables.tf
+++ b/modules/integration_azure-app-service-plan/variables.tf
@@ -2,6 +2,12 @@
 
 # Heartbeat detector
 
+variable "heartbeat_max_delay" {
+  description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = 900
+}
+
 variable "heartbeat_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -39,6 +45,12 @@ variable "heartbeat_aggregation_function" {
 }
 
 # CPU_percentage detector
+
+variable "cpu_percentage_max_delay" {
+  description = "Enforce max delay for cpu_percentage detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "cpu_percentage_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -107,6 +119,12 @@ variable "cpu_percentage_threshold_major" {
 }
 
 # memory_percentage detector
+
+variable "memory_percentage_max_delay" {
+  description = "Enforce max delay for memory_percentage detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "memory_percentage_tip" {
   description = "Suggested first course of action or any note useful for incident handling"

--- a/modules/integration_azure-app-service/detectors-app-services.tf
+++ b/modules/integration_azure-app-service/detectors-app-services.tf
@@ -5,8 +5,6 @@ resource "signalfx_detector" "heartbeat" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
-  max_delay = 900
-
   program_text = <<-EOF
         from signalfx.detectors.not_reporting import not_reporting
         base_filter = filter('resource_type', 'Microsoft.Web/sites') and filter('is_Azure_Function', 'false') and filter('primary_aggregation_type', 'true')
@@ -25,6 +23,8 @@ resource "signalfx_detector" "heartbeat" {
     parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.heartbeat_max_delay
 }
 
 resource "signalfx_detector" "response_time" {
@@ -65,6 +65,7 @@ resource "signalfx_detector" "response_time" {
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
 
+  max_delay = var.response_time_max_delay
 }
 
 resource "signalfx_detector" "memory_usage_count" {
@@ -105,6 +106,7 @@ resource "signalfx_detector" "memory_usage_count" {
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
 
+  max_delay = var.memory_usage_count_max_delay
 }
 
 resource "signalfx_detector" "http_5xx_errors_count" {
@@ -147,6 +149,7 @@ resource "signalfx_detector" "http_5xx_errors_count" {
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
 
+  max_delay = var.http_5xx_errors_count_max_delay
 }
 
 resource "signalfx_detector" "http_4xx_errors_count" {
@@ -188,6 +191,8 @@ resource "signalfx_detector" "http_4xx_errors_count" {
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.http_4xx_errors_count_max_delay
 }
 
 resource "signalfx_detector" "http_success_status_rate" {
@@ -230,4 +235,6 @@ resource "signalfx_detector" "http_success_status_rate" {
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.http_success_status_rate_max_delay
 }

--- a/modules/integration_azure-app-service/variables.tf
+++ b/modules/integration_azure-app-service/variables.tf
@@ -2,6 +2,12 @@
 
 # Heartbeat detector
 
+variable "heartbeat_max_delay" {
+  description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = 900
+}
+
 variable "heartbeat_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -39,6 +45,12 @@ variable "heartbeat_aggregation_function" {
 }
 
 # Response_time detector
+
+variable "response_time_max_delay" {
+  description = "Enforce max delay for response_time detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "response_time_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -108,6 +120,12 @@ variable "response_time_threshold_major" {
 
 # Memory_usage_count detector
 
+variable "memory_usage_count_max_delay" {
+  description = "Enforce max delay for memory_usage_count detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "memory_usage_count_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -175,6 +193,12 @@ variable "memory_usage_count_threshold_major" {
 }
 
 # Http_5xx_errors_count detector
+
+variable "http_5xx_errors_count_max_delay" {
+  description = "Enforce max delay for http_5xx_errors_count detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "http_5xx_errors_count_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -244,6 +268,12 @@ variable "http_5xx_errors_count_threshold_major" {
 
 # http_4xx_errors_count detector
 
+variable "http_4xx_errors_count_max_delay" {
+  description = "Enforce max delay for http_4xx_errors_count detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "http_4xx_errors_count_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -311,6 +341,12 @@ variable "http_4xx_errors_count_threshold_major" {
 }
 
 # Http_success_status_rate detector
+
+variable "http_success_status_rate_max_delay" {
+  description = "Enforce max delay for http_success_status_rate detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "http_success_status_rate_tip" {
   description = "Suggested first course of action or any note useful for incident handling"

--- a/modules/integration_azure-application-gateway/detectors-app-gateway.tf
+++ b/modules/integration_azure-application-gateway/detectors-app-gateway.tf
@@ -5,8 +5,6 @@ resource "signalfx_detector" "heartbeat" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
-  max_delay = 900
-
   program_text = <<-EOF
         from signalfx.detectors.not_reporting import not_reporting
         base_filter = filter('resource_type', 'Microsoft.Network/applicationGateways') and filter('primary_aggregation_type', 'true')
@@ -25,6 +23,8 @@ resource "signalfx_detector" "heartbeat" {
     parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.heartbeat_max_delay
 }
 
 resource "signalfx_detector" "total_requests" {
@@ -52,6 +52,7 @@ resource "signalfx_detector" "total_requests" {
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
 
+  max_delay = var.total_requests_max_delay
 }
 
 resource "signalfx_detector" "backend_connect_time" {
@@ -91,6 +92,8 @@ resource "signalfx_detector" "backend_connect_time" {
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.backend_connect_time_max_delay
 }
 
 resource "signalfx_detector" "failed_requests" {
@@ -133,6 +136,8 @@ resource "signalfx_detector" "failed_requests" {
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.failed_requests_max_delay
 }
 
 resource "signalfx_detector" "unhealthy_host_ratio" {
@@ -174,6 +179,8 @@ resource "signalfx_detector" "unhealthy_host_ratio" {
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.unhealthy_host_ratio_max_delay
 }
 
 resource "signalfx_detector" "http_4xx_errors" {
@@ -215,6 +222,8 @@ resource "signalfx_detector" "http_4xx_errors" {
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.http_4xx_errors_max_delay
 }
 
 resource "signalfx_detector" "http_5xx_errors" {
@@ -256,6 +265,8 @@ resource "signalfx_detector" "http_5xx_errors" {
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.http_5xx_errors_max_delay
 }
 
 resource "signalfx_detector" "backend_http_4xx_errors" {
@@ -297,6 +308,8 @@ resource "signalfx_detector" "backend_http_4xx_errors" {
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.backend_http_4xx_errors_max_delay
 }
 
 resource "signalfx_detector" "backend_http_5xx_errors" {
@@ -338,4 +351,6 @@ resource "signalfx_detector" "backend_http_5xx_errors" {
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.backend_http_5xx_errors_max_delay
 }

--- a/modules/integration_azure-application-gateway/variables.tf
+++ b/modules/integration_azure-application-gateway/variables.tf
@@ -2,6 +2,12 @@
 
 # Heartbeat detector
 
+variable "heartbeat_max_delay" {
+  description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = 900
+}
+
 variable "heartbeat_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -39,6 +45,12 @@ variable "heartbeat_aggregation_function" {
 }
 
 # Total_requests detector
+
+variable "total_requests_max_delay" {
+  description = "Enforce max delay for total_requests detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "total_requests_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -83,6 +95,12 @@ variable "total_requests_lasting_duration_critical" {
 }
 
 # backend_connect_time detector
+
+variable "backend_connect_time_max_delay" {
+  description = "Enforce max delay for backend_connect_time detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "backend_connect_time_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -152,6 +170,12 @@ variable "backend_connect_time_threshold_major" {
 
 # Failed_requests detector
 
+variable "failed_requests_max_delay" {
+  description = "Enforce max delay for failed_requests detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "failed_requests_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -219,6 +243,12 @@ variable "failed_requests_threshold_major" {
 }
 
 # Unhealthy_host_ratio detector
+
+variable "unhealthy_host_ratio_max_delay" {
+  description = "Enforce max delay for unhealthy_host_ratio detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "unhealthy_host_ratio_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -288,6 +318,12 @@ variable "unhealthy_host_ratio_threshold_major" {
 
 # Http_4xx_errors detector
 
+variable "http_4xx_errors_max_delay" {
+  description = "Enforce max delay for http_4xx_errors detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "http_4xx_errors_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -355,6 +391,12 @@ variable "http_4xx_errors_threshold_major" {
 }
 
 # Http_5xx_errors detector
+
+variable "http_5xx_errors_max_delay" {
+  description = "Enforce max delay for http_5xx_errors detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "http_5xx_errors_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -424,6 +466,12 @@ variable "http_5xx_errors_threshold_major" {
 
 # Backend_http_4xx_errors detector
 
+variable "backend_http_4xx_errors_max_delay" {
+  description = "Enforce max delay for backend_http_4xx_errors detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "backend_http_4xx_errors_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -491,6 +539,12 @@ variable "backend_http_4xx_errors_threshold_major" {
 }
 
 # Backend_http_5xx_errors detector
+
+variable "backend_http_5xx_errors_max_delay" {
+  description = "Enforce max delay for backend_http_5xx_errors detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "backend_http_5xx_errors_tip" {
   description = "Suggested first course of action or any note useful for incident handling"

--- a/modules/integration_azure-azure-search/detectors-azure-search.tf
+++ b/modules/integration_azure-azure-search/detectors-azure-search.tf
@@ -35,6 +35,8 @@ resource "signalfx_detector" "search_latency" {
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.search_latency_max_delay
 }
 
 resource "signalfx_detector" "search_throttled_queries_rate" {
@@ -75,4 +77,5 @@ resource "signalfx_detector" "search_throttled_queries_rate" {
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
 
+  max_delay = var.search_throttled_queries_rate_max_delay
 }

--- a/modules/integration_azure-azure-search/variables.tf
+++ b/modules/integration_azure-azure-search/variables.tf
@@ -2,6 +2,12 @@
 
 # Search_latency detector
 
+variable "search_latency_max_delay" {
+  description = "Enforce max delay for search_latency detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "search_latency_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -69,6 +75,12 @@ variable "search_latency_threshold_major" {
 }
 
 # search_throttled_queries_rate detector
+
+variable "search_throttled_queries_rate_max_delay" {
+  description = "Enforce max delay for search_throttled_queries_rate detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "search_throttled_queries_rate_tip" {
   description = "Suggested first course of action or any note useful for incident handling"

--- a/modules/integration_azure-cosmos-db/detectors-cosmosdb.tf
+++ b/modules/integration_azure-cosmos-db/detectors-cosmosdb.tf
@@ -5,8 +5,6 @@ resource "signalfx_detector" "heartbeat" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
-  max_delay = 900
-
   program_text = <<-EOF
         from signalfx.detectors.not_reporting import not_reporting
         base_filter = filter('resource_type', 'Microsoft.DocumentDB/databaseAccounts') and filter('primary_aggregation_type', 'true')
@@ -25,6 +23,8 @@ resource "signalfx_detector" "heartbeat" {
     parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.heartbeat_max_delay
 }
 
 resource "signalfx_detector" "db_4xx_requests" {
@@ -66,6 +66,8 @@ resource "signalfx_detector" "db_4xx_requests" {
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.db_4xx_requests_max_delay
 }
 
 resource "signalfx_detector" "db_5xx_requests" {
@@ -107,6 +109,8 @@ resource "signalfx_detector" "db_5xx_requests" {
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.db_5xx_requests_max_delay
 }
 
 resource "signalfx_detector" "scaling" {
@@ -148,6 +152,8 @@ resource "signalfx_detector" "scaling" {
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.scaling_max_delay
 }
 
 resource "signalfx_detector" "used_rus_capacity" {
@@ -187,4 +193,6 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.used_rus_capacity_max_delay
 }

--- a/modules/integration_azure-cosmos-db/variables.tf
+++ b/modules/integration_azure-cosmos-db/variables.tf
@@ -2,6 +2,12 @@
 
 # Heartbeat detector
 
+variable "heartbeat_max_delay" {
+  description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = 900
+}
+
 variable "heartbeat_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -39,6 +45,12 @@ variable "heartbeat_aggregation_function" {
 }
 
 # db_4xx_requests detector
+
+variable "db_4xx_requests_max_delay" {
+  description = "Enforce max delay for db_4xx_requests detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "db_4xx_requests_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -108,6 +120,12 @@ variable "db_4xx_requests_threshold_major" {
 
 # db_5xx_requests detector
 
+variable "db_5xx_requests_max_delay" {
+  description = "Enforce max delay for db_5xx_requests detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "db_5xx_requests_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -175,6 +193,12 @@ variable "db_5xx_requests_threshold_major" {
 }
 
 # Scaling detector
+
+variable "scaling_max_delay" {
+  description = "Enforce max delay for scaling detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "scaling_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -260,6 +284,12 @@ variable "used_rus_capacity_transformation_function" {
   description = "Transformation function for used_rus_capacity detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ".max(over='15m')"
+}
+
+variable "used_rus_capacity_max_delay" {
+  description = "Enforce max delay for used_rus_capacity detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "used_rus_capacity_tip" {

--- a/modules/integration_azure-functions/detectors-functions.tf
+++ b/modules/integration_azure-functions/detectors-functions.tf
@@ -5,8 +5,6 @@ resource "signalfx_detector" "heartbeat" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
-  max_delay = 900
-
   program_text = <<-EOF
         from signalfx.detectors.not_reporting import not_reporting
         base_filter = filter('resource_type', 'Microsoft.Web/sites') and filter('is_Azure_Function', 'true') and filter('primary_aggregation_type', 'true')
@@ -25,6 +23,8 @@ resource "signalfx_detector" "heartbeat" {
     parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.heartbeat_max_delay
 }
 
 resource "signalfx_detector" "http_5xx_errors_rate" {
@@ -66,6 +66,8 @@ resource "signalfx_detector" "http_5xx_errors_rate" {
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.http_5xx_errors_rate_max_delay
 }
 
 resource "signalfx_detector" "high_connections_count" {
@@ -105,6 +107,8 @@ resource "signalfx_detector" "high_connections_count" {
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.high_connections_count_max_delay
 }
 
 resource "signalfx_detector" "high_threads_count" {
@@ -144,4 +148,6 @@ resource "signalfx_detector" "high_threads_count" {
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.high_threads_count_max_delay
 }

--- a/modules/integration_azure-functions/variables.tf
+++ b/modules/integration_azure-functions/variables.tf
@@ -2,6 +2,12 @@
 
 # Heartbeat detector
 
+variable "heartbeat_max_delay" {
+  description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = 900
+}
+
 variable "heartbeat_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -39,6 +45,12 @@ variable "heartbeat_aggregation_function" {
 }
 
 # http_5xx_errors_rate detector
+
+variable "http_5xx_errors_rate_max_delay" {
+  description = "Enforce max delay for http_5xx_errors_rate detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "http_5xx_errors_rate_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -108,6 +120,12 @@ variable "http_5xx_errors_rate_threshold_major" {
 
 # High_connections_count detector
 
+variable "high_connections_count_max_delay" {
+  description = "Enforce max delay for high_connections_count detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "high_connections_count_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -175,6 +193,12 @@ variable "high_connections_count_threshold_major" {
 }
 
 # High_threads_count detector
+
+variable "high_threads_count_max_delay" {
+  description = "Enforce max delay for high_threads_count detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "high_threads_count_tip" {
   description = "Suggested first course of action or any note useful for incident handling"

--- a/modules/integration_azure-key-vault/detectors-keyvault.tf
+++ b/modules/integration_azure-key-vault/detectors-keyvault.tf
@@ -37,6 +37,8 @@ resource "signalfx_detector" "api_result" {
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.api_result_max_delay
 }
 
 resource "signalfx_detector" "api_latency" {
@@ -76,4 +78,6 @@ resource "signalfx_detector" "api_latency" {
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.api_latency_max_delay
 }

--- a/modules/integration_azure-key-vault/variables.tf
+++ b/modules/integration_azure-key-vault/variables.tf
@@ -2,6 +2,12 @@
 
 # api_result detector
 
+variable "api_result_max_delay" {
+  description = "Enforce max delay for api_result detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "api_result_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -69,6 +75,12 @@ variable "api_result_threshold_major" {
 }
 
 # api_latency detector
+
+variable "api_latency_max_delay" {
+  description = "Enforce max delay for api_latency detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "api_latency_tip" {
   description = "Suggested first course of action or any note useful for incident handling"

--- a/modules/integration_azure-load-balancer/detectors-load-balancer.tf
+++ b/modules/integration_azure-load-balancer/detectors-load-balancer.tf
@@ -5,8 +5,6 @@ resource "signalfx_detector" "heartbeat" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
-  max_delay = 900
-
   program_text = <<-EOF
         from signalfx.detectors.not_reporting import not_reporting
         base_filter = filter('resource_type', 'Microsoft.Network/loadBalancers') and filter('primary_aggregation_type', 'true')
@@ -25,4 +23,6 @@ resource "signalfx_detector" "heartbeat" {
     parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.heartbeat_max_delay
 }

--- a/modules/integration_azure-load-balancer/variables.tf
+++ b/modules/integration_azure-load-balancer/variables.tf
@@ -2,6 +2,12 @@
 
 # Heartbeat detector
 
+variable "heartbeat_max_delay" {
+  description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = 900
+}
+
 variable "heartbeat_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string

--- a/modules/integration_azure-postgresql/detectors-postgresql.tf
+++ b/modules/integration_azure-postgresql/detectors-postgresql.tf
@@ -5,8 +5,6 @@ resource "signalfx_detector" "heartbeat" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
-  max_delay = 900
-
   program_text = <<-EOF
         from signalfx.detectors.not_reporting import not_reporting
         base_filter = filter('resource_type', 'Microsoft.DB*orPostgreSQL/servers') and filter('primary_aggregation_type', 'true')
@@ -25,6 +23,8 @@ resource "signalfx_detector" "heartbeat" {
     parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.heartbeat_max_delay
 }
 
 resource "signalfx_detector" "cpu_usage" {
@@ -64,6 +64,8 @@ resource "signalfx_detector" "cpu_usage" {
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.cpu_usage_max_delay
 }
 
 resource "signalfx_detector" "no_connection" {
@@ -89,6 +91,8 @@ resource "signalfx_detector" "no_connection" {
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.no_connection_max_delay
 }
 
 resource "signalfx_detector" "storage_usage" {
@@ -128,6 +132,8 @@ resource "signalfx_detector" "storage_usage" {
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.storage_usage_max_delay
 }
 
 resource "signalfx_detector" "io_consumption" {
@@ -167,6 +173,8 @@ resource "signalfx_detector" "io_consumption" {
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.io_consumption_max_delay
 }
 
 resource "signalfx_detector" "memory_usage" {
@@ -206,6 +214,8 @@ resource "signalfx_detector" "memory_usage" {
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.memory_usage_max_delay
 }
 
 resource "signalfx_detector" "serverlog_storage_usage" {
@@ -241,5 +251,7 @@ resource "signalfx_detector" "serverlog_storage_usage" {
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.serverlog_storage_usage_max_delay
 }
 

--- a/modules/integration_azure-postgresql/variables.tf
+++ b/modules/integration_azure-postgresql/variables.tf
@@ -2,6 +2,12 @@
 
 # Heartbeat detector
 
+variable "heartbeat_max_delay" {
+  description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = 900
+}
+
 variable "heartbeat_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -39,6 +45,12 @@ variable "heartbeat_aggregation_function" {
 }
 
 # CPU_usage detector
+
+variable "cpu_usage_max_delay" {
+  description = "Enforce max delay for cpu_usage detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "cpu_usage_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -108,6 +120,12 @@ variable "cpu_usage_threshold_major" {
 
 # no_connection detector
 
+variable "no_connection_max_delay" {
+  description = "Enforce max delay for no_connection detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "no_connection_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -151,6 +169,12 @@ variable "no_connection_lasting_duration_critical" {
 }
 
 # storage_usage detectors
+
+variable "storage_usage_max_delay" {
+  description = "Enforce max delay for storage_usage detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "storage_usage_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -220,6 +244,12 @@ variable "storage_usage_threshold_major" {
 
 # io_consumption detector
 
+variable "io_consumption_max_delay" {
+  description = "Enforce max delay for io_consumption detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "io_consumption_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -288,6 +318,12 @@ variable "io_consumption_threshold_major" {
 
 # memory_usage detector
 
+variable "memory_usage_max_delay" {
+  description = "Enforce max delay for memory_usage detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "memory_usage_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -355,6 +391,12 @@ variable "memory_usage_threshold_major" {
 }
 
 # serverlog_storage_usage detectors
+
+variable "serverlog_storage_usage_max_delay" {
+  description = "Enforce max delay for serverlog_storage_usage detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "serverlog_storage_usage_tip" {
   description = "Suggested first course of action or any note useful for incident handling"

--- a/modules/integration_azure-redis/detectors-azure-redis.tf
+++ b/modules/integration_azure-redis/detectors-azure-redis.tf
@@ -5,8 +5,6 @@ resource "signalfx_detector" "heartbeat" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
-  max_delay = 900
-
   program_text = <<-EOF
         from signalfx.detectors.not_reporting import not_reporting
         base_filter = filter('resource_type', 'Microsoft.Cache/Redis') and filter('primary_aggregation_type', 'true')
@@ -25,6 +23,8 @@ resource "signalfx_detector" "heartbeat" {
     parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.heartbeat_max_delay
 }
 
 resource "signalfx_detector" "evictedkeys" {
@@ -64,6 +64,8 @@ resource "signalfx_detector" "evictedkeys" {
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.evictedkeys_max_delay
 }
 
 resource "signalfx_detector" "percent_processor_time" {
@@ -103,6 +105,8 @@ resource "signalfx_detector" "percent_processor_time" {
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.percent_processor_time_max_delay
 }
 
 resource "signalfx_detector" "load" {
@@ -142,4 +146,6 @@ resource "signalfx_detector" "load" {
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.load_max_delay
 }

--- a/modules/integration_azure-redis/variables.tf
+++ b/modules/integration_azure-redis/variables.tf
@@ -2,6 +2,12 @@
 
 # Heartbeat detector
 
+variable "heartbeat_max_delay" {
+  description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = 900
+}
+
 variable "heartbeat_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -39,6 +45,12 @@ variable "heartbeat_aggregation_function" {
 }
 
 # Evictedkeys detector
+
+variable "evictedkeys_max_delay" {
+  description = "Enforce max delay for evictedkeys detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "evictedkeys_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -108,6 +120,12 @@ variable "evictedkeys_threshold_major" {
 
 # percent_processor_time detector
 
+variable "percent_processor_time_max_delay" {
+  description = "Enforce max delay for percent_processor_time detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "percent_processor_time_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -175,6 +193,12 @@ variable "percent_processor_time_threshold_major" {
 }
 
 # load detector
+
+variable "load_max_delay" {
+  description = "Enforce max delay for load detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "load_tip" {
   description = "Suggested first course of action or any note useful for incident handling"

--- a/modules/integration_azure-service-bus/detectors-service-bus.tf
+++ b/modules/integration_azure-service-bus/detectors-service-bus.tf
@@ -5,8 +5,6 @@ resource "signalfx_detector" "heartbeat" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
-  max_delay = 900
-
   program_text = <<-EOF
         from signalfx.detectors.not_reporting import not_reporting
         base_filter = filter('resource_type', 'Microsoft.ServiceBus/namespaces') and filter('primary_aggregation_type', 'true')
@@ -25,6 +23,8 @@ resource "signalfx_detector" "heartbeat" {
     parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.heartbeat_max_delay
 }
 
 resource "signalfx_detector" "active_connections" {
@@ -52,6 +52,7 @@ resource "signalfx_detector" "active_connections" {
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
 
+  max_delay = var.active_connections_max_delay
 }
 
 resource "signalfx_detector" "user_errors" {
@@ -93,6 +94,8 @@ resource "signalfx_detector" "user_errors" {
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.user_errors_max_delay
 }
 
 resource "signalfx_detector" "server_errors" {
@@ -134,6 +137,8 @@ resource "signalfx_detector" "server_errors" {
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.server_errors_max_delay
 }
 
 resource "signalfx_detector" "throttled_requests" {
@@ -175,4 +180,6 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.throttled_requests_max_delay
 }

--- a/modules/integration_azure-service-bus/variables.tf
+++ b/modules/integration_azure-service-bus/variables.tf
@@ -2,6 +2,12 @@
 
 # Heartbeat detector
 
+variable "heartbeat_max_delay" {
+  description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = 900
+}
+
 variable "heartbeat_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -39,6 +45,12 @@ variable "heartbeat_aggregation_function" {
 }
 
 # Active_connections detector
+
+variable "active_connections_max_delay" {
+  description = "Enforce max delay for active_connections detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "active_connections_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -89,6 +101,12 @@ variable "active_connections_threshold_critical" {
 }
 
 # User_errors detector
+
+variable "user_errors_max_delay" {
+  description = "Enforce max delay for user_errors detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "user_errors_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -157,6 +175,12 @@ variable "user_errors_threshold_major" {
 }
 
 # Server_errors detector
+
+variable "server_errors_max_delay" {
+  description = "Enforce max delay for server_errors detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "server_errors_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -242,6 +266,12 @@ variable "throttled_requests_transformation_function" {
   description = "Transformation function for throttled_requests detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ".max(over='5m')"
+}
+
+variable "throttled_requests_max_delay" {
+  description = "Enforce max delay for throttled_requests detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "throttled_requests_tip" {

--- a/modules/integration_azure-sql-database/detectors-sql-database.tf
+++ b/modules/integration_azure-sql-database/detectors-sql-database.tf
@@ -5,8 +5,6 @@ resource "signalfx_detector" "heartbeat" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
-  max_delay = 900
-
   program_text = <<-EOF
         from signalfx.detectors.not_reporting import not_reporting
         base_filter = filter('resource_type', 'Microsoft.Sql/servers/databases') and filter('primary_aggregation_type', 'true')
@@ -25,6 +23,8 @@ resource "signalfx_detector" "heartbeat" {
     parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.heartbeat_max_delay
 }
 
 resource "signalfx_detector" "cpu" {
@@ -64,6 +64,8 @@ resource "signalfx_detector" "cpu" {
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.cpu_max_delay
 }
 
 resource "signalfx_detector" "free_space" {
@@ -103,6 +105,8 @@ resource "signalfx_detector" "free_space" {
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.free_space_max_delay
 }
 
 resource "signalfx_detector" "dtu_consumption" {
@@ -142,6 +146,8 @@ resource "signalfx_detector" "dtu_consumption" {
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.dtu_consumption_max_delay
 }
 
 resource "signalfx_detector" "deadlocks_count" {
@@ -168,4 +174,6 @@ resource "signalfx_detector" "deadlocks_count" {
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.deadlocks_count_max_delay
 }

--- a/modules/integration_azure-sql-database/variables.tf
+++ b/modules/integration_azure-sql-database/variables.tf
@@ -2,6 +2,12 @@
 
 # Heartbeat detector
 
+variable "heartbeat_max_delay" {
+  description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = 900
+}
+
 variable "heartbeat_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -39,6 +45,12 @@ variable "heartbeat_aggregation_function" {
 }
 
 # cpu detector
+
+variable "cpu_max_delay" {
+  description = "Enforce max delay for cpu detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "cpu_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -108,6 +120,12 @@ variable "cpu_threshold_major" {
 
 # free_space detector
 
+variable "free_space_max_delay" {
+  description = "Enforce max delay for free_space detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "free_space_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -176,6 +194,12 @@ variable "free_space_threshold_major" {
 
 # dtu_consumption detector
 
+variable "dtu_consumption_max_delay" {
+  description = "Enforce max delay for dtu_consumption detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "dtu_consumption_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -243,6 +267,12 @@ variable "dtu_consumption_threshold_major" {
 }
 
 # deadlocks_count detector
+
+variable "deadlocks_count_max_delay" {
+  description = "Enforce max delay for deadlocks_count detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "deadlocks_count_tip" {
   description = "Suggested first course of action or any note useful for incident handling"

--- a/modules/integration_azure-sql-elastic-pool/detectors-sql-elasticpool.tf
+++ b/modules/integration_azure-sql-elastic-pool/detectors-sql-elasticpool.tf
@@ -5,8 +5,6 @@ resource "signalfx_detector" "heartbeat" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
-  max_delay = 900
-
   program_text = <<-EOF
         from signalfx.detectors.not_reporting import not_reporting
         base_filter = filter('resource_type', 'Microsoft.Sql/servers/elasticpools') and filter('primary_aggregation_type', 'true')
@@ -25,6 +23,8 @@ resource "signalfx_detector" "heartbeat" {
     parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.heartbeat_max_delay
 }
 
 resource "signalfx_detector" "cpu" {
@@ -64,6 +64,8 @@ resource "signalfx_detector" "cpu" {
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.cpu_max_delay
 }
 
 resource "signalfx_detector" "free_space" {
@@ -103,6 +105,8 @@ resource "signalfx_detector" "free_space" {
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.free_space_max_delay
 }
 
 resource "signalfx_detector" "dtu_consumption" {
@@ -142,4 +146,6 @@ resource "signalfx_detector" "dtu_consumption" {
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.dtu_consumption_max_delay
 }

--- a/modules/integration_azure-sql-elastic-pool/variables.tf
+++ b/modules/integration_azure-sql-elastic-pool/variables.tf
@@ -2,6 +2,12 @@
 
 # Heartbeat detector
 
+variable "heartbeat_max_delay" {
+  description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = 900
+}
+
 variable "heartbeat_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -39,6 +45,12 @@ variable "heartbeat_aggregation_function" {
 }
 
 # cpu detector
+
+variable "cpu_max_delay" {
+  description = "Enforce max delay for cpu detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "cpu_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -108,6 +120,12 @@ variable "cpu_threshold_major" {
 
 # free_space detector
 
+variable "free_space_max_delay" {
+  description = "Enforce max delay for free_space detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "free_space_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -175,6 +193,12 @@ variable "free_space_threshold_major" {
 }
 
 # dtu_consumption detector
+
+variable "dtu_consumption_max_delay" {
+  description = "Enforce max delay for dtu_consumption detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "dtu_consumption_tip" {
   description = "Suggested first course of action or any note useful for incident handling"

--- a/modules/integration_azure-storage-account-capacity/detectors-azure-storage.tf
+++ b/modules/integration_azure-storage-account-capacity/detectors-azure-storage.tf
@@ -35,4 +35,6 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.used_capacity_max_delay
 }

--- a/modules/integration_azure-storage-account-capacity/variables.tf
+++ b/modules/integration_azure-storage-account-capacity/variables.tf
@@ -20,6 +20,12 @@ variable "used_capacity_transformation_function" {
   default     = ".max(over='12h')"
 }
 
+variable "used_capacity_max_delay" {
+  description = "Enforce max delay for used_capacity detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "used_capacity_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string

--- a/modules/integration_azure-stream-analytics/detectors-stream-analytics.tf
+++ b/modules/integration_azure-stream-analytics/detectors-stream-analytics.tf
@@ -5,8 +5,6 @@ resource "signalfx_detector" "heartbeat" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
-  max_delay = 900
-
   program_text = <<-EOF
         from signalfx.detectors.not_reporting import not_reporting
         base_filter = filter('resource_type', 'Microsoft.StreamAnalytics/streamingjobs') and filter('primary_aggregation_type', 'true')
@@ -25,6 +23,8 @@ resource "signalfx_detector" "heartbeat" {
     parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.heartbeat_max_delay
 }
 
 resource "signalfx_detector" "su_utilization" {
@@ -64,6 +64,8 @@ resource "signalfx_detector" "su_utilization" {
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.su_utilization_max_delay
 }
 
 resource "signalfx_detector" "failed_function_requests" {
@@ -105,6 +107,8 @@ resource "signalfx_detector" "failed_function_requests" {
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.failed_function_requests_max_delay
 }
 
 resource "signalfx_detector" "conversion_errors" {
@@ -144,6 +148,8 @@ resource "signalfx_detector" "conversion_errors" {
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.conversion_errors_max_delay
 }
 
 resource "signalfx_detector" "runtime_errors" {
@@ -183,4 +189,6 @@ resource "signalfx_detector" "runtime_errors" {
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.runtime_errors_max_delay
 }

--- a/modules/integration_azure-stream-analytics/variables.tf
+++ b/modules/integration_azure-stream-analytics/variables.tf
@@ -2,6 +2,12 @@
 
 # Heartbeat detector
 
+variable "heartbeat_max_delay" {
+  description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = 900
+}
+
 variable "heartbeat_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -39,6 +45,12 @@ variable "heartbeat_aggregation_function" {
 }
 
 # SU_utilization detector
+
+variable "su_utilization_max_delay" {
+  description = "Enforce max delay for su_utilization detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "su_utilization_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -108,6 +120,12 @@ variable "su_utilization_threshold_major" {
 
 # failed_function_requests detector
 
+variable "failed_function_requests_max_delay" {
+  description = "Enforce max delay for failed_function_requests detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "failed_function_requests_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -176,6 +194,12 @@ variable "failed_function_requests_threshold_major" {
 
 # Conversion_errors detector
 
+variable "conversion_errors_max_delay" {
+  description = "Enforce max delay for conversion_errors detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "conversion_errors_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -243,6 +267,12 @@ variable "conversion_errors_threshold_major" {
 }
 
 # Runtime_errors detector
+
+variable "runtime_errors_max_delay" {
+  description = "Enforce max delay for runtime_errors detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "runtime_errors_tip" {
   description = "Suggested first course of action or any note useful for incident handling"

--- a/modules/integration_azure-virtual-machine-scaleset/detectors-virtual-machine-scaleset.tf
+++ b/modules/integration_azure-virtual-machine-scaleset/detectors-virtual-machine-scaleset.tf
@@ -5,8 +5,6 @@ resource "signalfx_detector" "heartbeat" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
-  max_delay = 900
-
   program_text = <<-EOF
         from signalfx.detectors.not_reporting import not_reporting
         base_filter = filter('resource_type', 'Microsoft.Compute/virtualMachineScaleSets') and filter('primary_aggregation_type', 'true')
@@ -25,4 +23,6 @@ resource "signalfx_detector" "heartbeat" {
     parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.heartbeat_max_delay
 }

--- a/modules/integration_azure-virtual-machine-scaleset/variables.tf
+++ b/modules/integration_azure-virtual-machine-scaleset/variables.tf
@@ -2,6 +2,12 @@
 
 # Heartbeat detector
 
+variable "heartbeat_max_delay" {
+  description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = 900
+}
+
 variable "heartbeat_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string

--- a/modules/integration_azure-virtual-machine/detectors-virtual-machine.tf
+++ b/modules/integration_azure-virtual-machine/detectors-virtual-machine.tf
@@ -5,8 +5,6 @@ resource "signalfx_detector" "heartbeat" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
-  max_delay = 900
-
   program_text = <<-EOF
         from signalfx.detectors.not_reporting import not_reporting
         base_filter = filter('resource_type', 'Microsoft.Compute/virtualMachines') and filter('primary_aggregation_type', 'true') and ${local.not_running_vm_filters_azure}
@@ -25,6 +23,8 @@ resource "signalfx_detector" "heartbeat" {
     parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.heartbeat_max_delay
 }
 
 resource "signalfx_detector" "cpu_usage" {
@@ -64,6 +64,8 @@ resource "signalfx_detector" "cpu_usage" {
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.cpu_usage_max_delay
 }
 
 resource "signalfx_detector" "credit_cpu" {
@@ -105,4 +107,6 @@ resource "signalfx_detector" "credit_cpu" {
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.credit_cpu_max_delay
 }

--- a/modules/integration_azure-virtual-machine/variables.tf
+++ b/modules/integration_azure-virtual-machine/variables.tf
@@ -2,6 +2,12 @@
 
 # Heartbeat detector
 
+variable "heartbeat_max_delay" {
+  description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = 900
+}
+
 variable "heartbeat_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -39,6 +45,12 @@ variable "heartbeat_aggregation_function" {
 }
 
 # CPU_usage detector
+
+variable "cpu_usage_max_delay" {
+  description = "Enforce max delay for cpu_usage detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "cpu_usage_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -107,6 +119,12 @@ variable "cpu_usage_threshold_major" {
 }
 
 # Credit_cpu detector
+
+variable "credit_cpu_max_delay" {
+  description = "Enforce max delay for credit_cpu detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "credit_cpu_tip" {
   description = "Suggested first course of action or any note useful for incident handling"

--- a/modules/integration_gcp-bigquery/detectors-big-query.tf
+++ b/modules/integration_gcp-bigquery/detectors-big-query.tf
@@ -38,6 +38,7 @@ EOF
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
 
+  max_delay = var.concurrent_queries_max_delay
 }
 
 resource "signalfx_detector" "execution_time" {
@@ -80,6 +81,7 @@ EOF
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
 
+  max_delay = var.execution_time_max_delay
 }
 
 resource "signalfx_detector" "scanned_bytes" {
@@ -122,6 +124,7 @@ EOF
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
 
+  max_delay = var.scanned_bytes_max_delay
 }
 
 resource "signalfx_detector" "scanned_bytes_billed" {
@@ -164,6 +167,7 @@ EOF
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
 
+  max_delay = var.scanned_bytes_billed_max_delay
 }
 
 resource "signalfx_detector" "available_slots" {
@@ -206,6 +210,7 @@ EOF
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
 
+  max_delay = var.available_slots_max_delay
 }
 
 resource "signalfx_detector" "stored_bytes" {
@@ -248,6 +253,7 @@ EOF
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
 
+  max_delay = var.stored_bytes_max_delay
 }
 
 resource "signalfx_detector" "table_count" {
@@ -290,6 +296,7 @@ EOF
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
 
+  max_delay = var.table_count_max_delay
 }
 
 resource "signalfx_detector" "uploaded_bytes" {
@@ -332,6 +339,7 @@ EOF
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
 
+  max_delay = var.uploaded_bytes_max_delay
 }
 
 resource "signalfx_detector" "uploaded_bytes_billed" {
@@ -374,4 +382,5 @@ EOF
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
 
+  max_delay = var.uploaded_bytes_billed_max_delay
 }

--- a/modules/integration_gcp-bigquery/variables.tf
+++ b/modules/integration_gcp-bigquery/variables.tf
@@ -7,6 +7,12 @@ variable "gcp_project_id" {
 
 # Concurrent_queries detector
 
+variable "concurrent_queries_max_delay" {
+  description = "Enforce max delay for concurrent_queries detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "concurrent_queries_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -86,6 +92,12 @@ variable "concurrent_queries_clear_duration" {
 }
 
 # Execution_time detector
+
+variable "execution_time_max_delay" {
+  description = "Enforce max delay for execution_time detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "execution_time_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -167,6 +179,12 @@ variable "execution_time_clear_duration" {
 
 # Scanned_bytes detector
 
+variable "scanned_bytes_max_delay" {
+  description = "Enforce max delay for scanned_bytes detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "scanned_bytes_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -246,6 +264,12 @@ variable "scanned_bytes_clear_duration" {
 }
 
 # Scanned_bytes_billed detector
+
+variable "scanned_bytes_billed_max_delay" {
+  description = "Enforce max delay for scanned_bytes_billed detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "scanned_bytes_billed_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -327,6 +351,12 @@ variable "scanned_bytes_billed_clear_duration" {
 
 # Available_slots detector
 
+variable "available_slots_max_delay" {
+  description = "Enforce max delay for available_slots detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "available_slots_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -406,6 +436,12 @@ variable "available_slots_clear_duration" {
 }
 
 # Stored_bytes detector
+
+variable "stored_bytes_max_delay" {
+  description = "Enforce max delay for stored_bytes detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "stored_bytes_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -487,6 +523,12 @@ variable "stored_bytes_clear_duration" {
 
 # table_count detector
 
+variable "table_count_max_delay" {
+  description = "Enforce max delay for table_count detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "table_count_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -567,6 +609,12 @@ variable "table_count_clear_duration" {
 
 # uploaded_bytes detector
 
+variable "uploaded_bytes_max_delay" {
+  description = "Enforce max delay for uploaded_bytes detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "uploaded_bytes_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -646,6 +694,12 @@ variable "uploaded_bytes_clear_duration" {
 }
 
 # uploaded_bytes_billed detector
+
+variable "uploaded_bytes_billed_max_delay" {
+  description = "Enforce max delay for uploaded_bytes_billed detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "uploaded_bytes_billed_tip" {
   description = "Suggested first course of action or any note useful for incident handling"

--- a/modules/integration_gcp-cloud-sql-common/detectors-cloud-sql-common.tf
+++ b/modules/integration_gcp-cloud-sql-common/detectors-cloud-sql-common.tf
@@ -5,8 +5,6 @@ resource "signalfx_detector" "heartbeat" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
-  max_delay = 900
-
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('database/cpu/usage_time', filter=${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
@@ -24,6 +22,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.heartbeat_max_delay
 }
 
 resource "signalfx_detector" "cpu_utilization" {
@@ -62,6 +62,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.cpu_utilization_max_delay
 }
 
 resource "signalfx_detector" "disk_utilization" {
@@ -100,6 +102,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.disk_utilization_max_delay
 }
 
 resource "signalfx_detector" "disk_utilization_forecast" {
@@ -126,6 +130,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.disk_utilization_forecast_max_delay
 }
 
 resource "signalfx_detector" "memory_utilization" {
@@ -164,6 +170,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.memory_utilization_max_delay
 }
 
 resource "signalfx_detector" "memory_utilization_forecast" {
@@ -190,5 +198,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.memory_utilization_forecast_max_delay
 }
 

--- a/modules/integration_gcp-cloud-sql-common/variables.tf
+++ b/modules/integration_gcp-cloud-sql-common/variables.tf
@@ -7,6 +7,12 @@ variable "gcp_project_id" {
 
 # Heartbeat detector
 
+variable "heartbeat_max_delay" {
+  description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = 900
+}
+
 variable "heartbeat_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -44,6 +50,12 @@ variable "heartbeat_aggregation_function" {
 }
 
 # CPU_utilization detector
+
+variable "cpu_utilization_max_delay" {
+  description = "Enforce max delay for cpu_utilization detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "cpu_utilization_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -107,6 +119,12 @@ variable "cpu_utilization_threshold_major" {
 
 # Disk_utilization detector
 
+variable "disk_utilization_max_delay" {
+  description = "Enforce max delay for disk_utilization detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "disk_utilization_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -168,6 +186,12 @@ variable "disk_utilization_threshold_major" {
 }
 
 # Disk_utilization_forecast detector
+
+variable "disk_utilization_forecast_max_delay" {
+  description = "Enforce max delay for disk_utilization_forecast detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "disk_utilization_forecast_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -243,6 +267,12 @@ variable "disk_utilization_forecast_notifications" {
 
 # Memory_utilization detector
 
+variable "memory_utilization_max_delay" {
+  description = "Enforce max delay for memory_utilization detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "memory_utilization_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -304,6 +334,12 @@ variable "memory_utilization_threshold_major" {
 }
 
 # Memory_utilization_forecast detector
+
+variable "memory_utilization_forecast_max_delay" {
+  description = "Enforce max delay for memory_utilization_forecast detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "memory_utilization_forecast_tip" {
   description = "Suggested first course of action or any note useful for incident handling"

--- a/modules/integration_gcp-cloud-sql-failover/detectors-cloud-sql-failover.tf
+++ b/modules/integration_gcp-cloud-sql-failover/detectors-cloud-sql-failover.tf
@@ -21,5 +21,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.failover_unavailable_max_delay
 }
 

--- a/modules/integration_gcp-cloud-sql-failover/variables.tf
+++ b/modules/integration_gcp-cloud-sql-failover/variables.tf
@@ -7,6 +7,12 @@ variable "gcp_project_id" {
 
 # Failover_unavailable detectors
 
+variable "failover_unavailable_max_delay" {
+  description = "Enforce max delay for failover_unavailable detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "failover_unavailable_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string

--- a/modules/integration_gcp-cloud-sql-mysql/detectors-cloudsql-mysql.tf
+++ b/modules/integration_gcp-cloud-sql-mysql/detectors-cloudsql-mysql.tf
@@ -34,5 +34,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.replication_lag_max_delay
 }
 

--- a/modules/integration_gcp-cloud-sql-mysql/variables.tf
+++ b/modules/integration_gcp-cloud-sql-mysql/variables.tf
@@ -7,6 +7,12 @@ variable "gcp_project_id" {
 
 # Replication_lag detectors
 
+variable "replication_lag_max_delay" {
+  description = "Enforce max delay for replication_lag detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "replication_lag_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string

--- a/modules/integration_gcp-compute-engine/detectors-gce-instance.tf
+++ b/modules/integration_gcp-compute-engine/detectors-gce-instance.tf
@@ -5,8 +5,6 @@ resource "signalfx_detector" "heartbeat" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
-  max_delay = 900
-
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('instance/cpu/usage_time', filter=${local.not_running_vm_filters_gcp} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
@@ -24,6 +22,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.heartbeat_max_delay
 }
 
 resource "signalfx_detector" "cpu_utilization" {
@@ -62,6 +62,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.cpu_utilization_max_delay
 }
 
 resource "signalfx_detector" "disk_throttled_bps" {
@@ -104,6 +106,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.disk_throttled_bps_max_delay
 }
 
 resource "signalfx_detector" "disk_throttled_ops" {
@@ -146,5 +150,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.disk_throttled_ops_max_delay
 }
 

--- a/modules/integration_gcp-compute-engine/variables.tf
+++ b/modules/integration_gcp-compute-engine/variables.tf
@@ -2,6 +2,12 @@
 
 # Heartbeat detector
 
+variable "heartbeat_max_delay" {
+  description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = 900
+}
+
 variable "heartbeat_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -39,6 +45,12 @@ variable "heartbeat_aggregation_function" {
 }
 
 # CPU_utilization detector
+
+variable "cpu_utilization_max_delay" {
+  description = "Enforce max delay for cpu_utilization detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "cpu_utilization_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -102,6 +114,12 @@ variable "cpu_utilization_threshold_major" {
 
 # Disk_throttled_bps detector
 
+variable "disk_throttled_bps_max_delay" {
+  description = "Enforce max delay for disk_throttled_bps detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "disk_throttled_bps_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -163,6 +181,12 @@ variable "disk_throttled_bps_threshold_major" {
 }
 
 # Disk_throttled_ops detector
+
+variable "disk_throttled_ops_max_delay" {
+  description = "Enforce max delay for disk_throttled_ops detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "disk_throttled_ops_tip" {
   description = "Suggested first course of action or any note useful for incident handling"

--- a/modules/integration_gcp-pubsub-subscription/detectors-subscription.tf
+++ b/modules/integration_gcp-pubsub-subscription/detectors-subscription.tf
@@ -5,8 +5,6 @@ resource "signalfx_detector" "heartbeat" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
-  max_delay = 900
-
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('subscription/pull_request_count', filter=${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
@@ -24,6 +22,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.heartbeat_max_delay
 }
 
 resource "signalfx_detector" "oldest_unacked_message" {
@@ -62,6 +62,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.oldest_unacked_message_max_delay
 }
 
 resource "signalfx_detector" "push_latency" {
@@ -100,5 +102,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.push_latency_max_delay
 }
 

--- a/modules/integration_gcp-pubsub-subscription/variables.tf
+++ b/modules/integration_gcp-pubsub-subscription/variables.tf
@@ -7,6 +7,12 @@ variable "gcp_project_id" {
 
 # Heartbeat detector
 
+variable "heartbeat_max_delay" {
+  description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = 900
+}
+
 variable "heartbeat_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -44,6 +50,12 @@ variable "heartbeat_aggregation_function" {
 }
 
 # Oldest_unacked_message detector
+
+variable "oldest_unacked_message_max_delay" {
+  description = "Enforce max delay for oldest_unacked_message detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "oldest_unacked_message_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -106,6 +118,12 @@ variable "oldest_unacked_message_threshold_major" {
 }
 
 # Push_latency detector
+
+variable "push_latency_max_delay" {
+  description = "Enforce max delay for push_latency detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "push_latency_tip" {
   description = "Suggested first course of action or any note useful for incident handling"

--- a/modules/integration_gcp-pubsub-topic/detectors-topics.tf
+++ b/modules/integration_gcp-pubsub-topic/detectors-topics.tf
@@ -22,6 +22,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.sending_operations_max_delay
 }
 
 resource "signalfx_detector" "unavailable_sending_operations" {
@@ -61,6 +63,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.unavailable_sending_operations_max_delay
 }
 
 resource "signalfx_detector" "unavailable_sending_operations_ratio" {
@@ -102,5 +106,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.unavailable_sending_operations_ratio_max_delay
 }
 

--- a/modules/integration_gcp-pubsub-topic/variables.tf
+++ b/modules/integration_gcp-pubsub-topic/variables.tf
@@ -7,6 +7,12 @@ variable "gcp_project_id" {
 
 # sending_operations detector
 
+variable "sending_operations_max_delay" {
+  description = "Enforce max delay for sending_operations detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "sending_operations_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -50,6 +56,12 @@ variable "sending_operations_threshold_major" {
 }
 
 # Unavailable_sending_operations detector
+
+variable "unavailable_sending_operations_max_delay" {
+  description = "Enforce max delay for unavailable_sending_operations detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "unavailable_sending_operations_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -112,6 +124,12 @@ variable "unavailable_sending_operations_threshold_major" {
 }
 
 # Unavailable_sending_operations_ratio detector
+
+variable "unavailable_sending_operations_ratio_max_delay" {
+  description = "Enforce max delay for unavailable_sending_operations_ratio detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "unavailable_sending_operations_ratio_tip" {
   description = "Suggested first course of action or any note useful for incident handling"

--- a/modules/integration_newrelic-apm/detectors-new-relic.tf
+++ b/modules/integration_newrelic-apm/detectors-new-relic.tf
@@ -5,8 +5,6 @@ resource "signalfx_detector" "heartbeat" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
-  max_delay = 900
-
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('Apdex/score/*', ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
@@ -24,6 +22,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.heartbeat_max_delay
 }
 
 resource "signalfx_detector" "error_rate" {
@@ -63,6 +63,7 @@ EOF
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
 
+  max_delay = var.error_rate_max_delay
 }
 
 resource "signalfx_detector" "apdex" {
@@ -101,5 +102,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.apdex_max_delay
 }
 

--- a/modules/integration_newrelic-apm/variables.tf
+++ b/modules/integration_newrelic-apm/variables.tf
@@ -2,6 +2,12 @@
 
 # Heartbeat detector
 
+variable "heartbeat_max_delay" {
+  description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = 900
+}
+
 variable "heartbeat_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -39,6 +45,12 @@ variable "heartbeat_aggregation_function" {
 }
 
 # error_rate detector
+
+variable "error_rate_max_delay" {
+  description = "Enforce max delay for error_rate detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "error_rate_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -101,6 +113,12 @@ variable "error_rate_threshold_major" {
 }
 
 # apdex detector
+
+variable "apdex_max_delay" {
+  description = "Enforce max delay for apdex detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "apdex_tip" {
   description = "Suggested first course of action or any note useful for incident handling"

--- a/modules/organization_usage/detectors-usage.tf
+++ b/modules/organization_usage/detectors-usage.tf
@@ -22,6 +22,8 @@ EOF
     parameterized_subject = coalesce(var.message_subject, "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}} > {{inputs.limit.value}}) on {{{dimensions}}}")
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.hosts_limit_max_delay
 }
 
 resource "signalfx_detector" "containers_limit" {
@@ -48,6 +50,8 @@ EOF
     parameterized_subject = coalesce(var.message_subject, "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}} > {{inputs.limit.value}}) on {{{dimensions}}}")
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.containers_limit_max_delay
 }
 
 resource "signalfx_detector" "custom_metrics_limit" {
@@ -74,6 +78,8 @@ EOF
     parameterized_subject = coalesce(var.message_subject, "[{{ruleSeverity}}]{{{detectorName}}} {{{readableRule}}} ({{inputs.signal.value}} > {{inputs.limit.value}}) on {{{dimensions}}}")
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.custom_metrics_limit_max_delay
 }
 
 resource "signalfx_detector" "containers_ratio" {
@@ -101,6 +107,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.containers_ratio_max_delay
 }
 
 resource "signalfx_detector" "custom_metrics_ratio" {
@@ -128,5 +136,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.custom_metrics_ratio_max_delay
 }
 

--- a/modules/organization_usage/variables.tf
+++ b/modules/organization_usage/variables.tf
@@ -14,6 +14,12 @@ variable "multiplier" {
 
 # hosts_limit detector
 
+variable "hosts_limit_max_delay" {
+  description = "Enforce max delay for hosts_limit detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "hosts_limit_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -47,6 +53,12 @@ variable "hosts_limit_transformation_function" {
 }
 
 # containers_limit detector
+
+variable "containers_limit_max_delay" {
+  description = "Enforce max delay for containers_limit detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "containers_limit_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -82,6 +94,12 @@ variable "containers_limit_transformation_function" {
 
 # custom_metrics_limit detector
 
+variable "custom_metrics_limit_max_delay" {
+  description = "Enforce max delay for custom_metrics_limit detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "custom_metrics_limit_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -115,6 +133,12 @@ variable "custom_metrics_limit_transformation_function" {
 }
 
 # containers_ratio detector
+
+variable "containers_ratio_max_delay" {
+  description = "Enforce max delay for containers_ratio detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "containers_ratio_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -158,6 +182,12 @@ variable "containers_ratio_threshold_major" {
 }
 
 # custom_metrics_ratio detector
+
+variable "custom_metrics_ratio_max_delay" {
+  description = "Enforce max delay for custom_metrics_ratio detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "custom_metrics_ratio_tip" {
   description = "Suggested first course of action or any note useful for incident handling"

--- a/modules/prometheus-exporter_kong/detectors-kong.tf
+++ b/modules/prometheus-exporter_kong/detectors-kong.tf
@@ -5,8 +5,6 @@ resource "signalfx_detector" "heartbeat" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
-  max_delay = 900
-
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('kong_datastore_reachable', filter=${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
@@ -24,6 +22,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.heartbeat_max_delay
 }
 
 resource "signalfx_detector" "treatment_limit" {
@@ -64,5 +64,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.treatment_limit_max_delay
 }
 

--- a/modules/prometheus-exporter_kong/variables.tf
+++ b/modules/prometheus-exporter_kong/variables.tf
@@ -2,6 +2,12 @@
 
 # Heartbeat detector
 
+variable "heartbeat_max_delay" {
+  description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = 900
+}
+
 variable "heartbeat_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -39,6 +45,12 @@ variable "heartbeat_aggregation_function" {
 }
 
 # treatment_limit detector
+
+variable "treatment_limit_max_delay" {
+  description = "Enforce max delay for treatment_limit detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "treatment_limit_tip" {
   description = "Suggested first course of action or any note useful for incident handling"

--- a/modules/smart-agent_dns/detectors-dns.tf
+++ b/modules/smart-agent_dns/detectors-dns.tf
@@ -5,8 +5,6 @@ resource "signalfx_detector" "heartbeat" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
-  max_delay = 900
-
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('dns.result_code', filter=${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
@@ -24,6 +22,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.heartbeat_max_delay
 }
 
 resource "signalfx_detector" "dns_query_time" {
@@ -62,6 +62,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.dns_query_time_max_delay
 }
 
 resource "signalfx_detector" "dns_result_code" {
@@ -88,4 +90,5 @@ EOF
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
 
+  max_delay = var.dns_result_code_max_delay
 }

--- a/modules/smart-agent_dns/variables.tf
+++ b/modules/smart-agent_dns/variables.tf
@@ -2,6 +2,12 @@
 
 # Heartbeat detector
 
+variable "heartbeat_max_delay" {
+  description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = 900
+}
+
 variable "heartbeat_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -39,6 +45,12 @@ variable "heartbeat_aggregation_function" {
 }
 
 # Dns_query_time detector
+
+variable "dns_query_time_max_delay" {
+  description = "Enforce max delay for dns_query_time detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "dns_query_time_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -101,6 +113,12 @@ variable "dns_query_time_threshold_major" {
 }
 
 # Dns_result_code detector
+
+variable "dns_result_code_max_delay" {
+  description = "Enforce max delay for dns_result_code detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "dns_result_code_tip" {
   description = "Suggested first course of action or any note useful for incident handling"

--- a/modules/smart-agent_docker/detectors-docker.tf
+++ b/modules/smart-agent_docker/detectors-docker.tf
@@ -5,8 +5,6 @@ resource "signalfx_detector" "heartbeat" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
-  max_delay = 900
-
   program_text = <<-EOF
 		from signalfx.detectors.not_reporting import not_reporting
 		signal = data('cpu.usage.system', filter=filter('plugin', 'docker') and ${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
@@ -24,6 +22,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.heartbeat_max_delay
 }
 
 resource "signalfx_detector" "cpu" {
@@ -62,6 +62,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.cpu_max_delay
 }
 
 resource "signalfx_detector" "throttling" {
@@ -102,6 +104,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.throttling_max_delay
 }
 
 resource "signalfx_detector" "memory" {
@@ -142,5 +146,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.memory_max_delay
 }
 

--- a/modules/smart-agent_docker/variables.tf
+++ b/modules/smart-agent_docker/variables.tf
@@ -2,6 +2,12 @@
 
 # Heartbeat detector
 
+variable "heartbeat_max_delay" {
+  description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = 900
+}
+
 variable "heartbeat_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -39,6 +45,12 @@ variable "heartbeat_aggregation_function" {
 }
 
 # cpu detector
+
+variable "cpu_max_delay" {
+  description = "Enforce max delay for cpu detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "cpu_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -102,6 +114,12 @@ variable "cpu_threshold_major" {
 
 # throttling detector
 
+variable "throttling_max_delay" {
+  description = "Enforce max delay for throttling detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "throttling_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -163,6 +181,12 @@ variable "throttling_threshold_major" {
 }
 
 # Memory detector
+
+variable "memory_max_delay" {
+  description = "Enforce max delay for memory detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "memory_tip" {
   description = "Suggested first course of action or any note useful for incident handling"

--- a/modules/smart-agent_elasticsearch/detectors-elasticsearch.tf
+++ b/modules/smart-agent_elasticsearch/detectors-elasticsearch.tf
@@ -5,8 +5,6 @@ resource "signalfx_detector" "heartbeat" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
-  max_delay = 900
-
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('elasticsearch.cluster.number-of-nodes', filter=filter('plugin', 'elasticsearch') and ${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
@@ -24,6 +22,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.heartbeat_max_delay
 }
 
 resource "signalfx_detector" "cluster_status" {
@@ -62,6 +62,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.cluster_status_max_delay
 }
 
 resource "signalfx_detector" "cluster_initializing_shards" {
@@ -100,6 +102,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.cluster_initializing_shards_max_delay
 }
 
 resource "signalfx_detector" "cluster_relocating_shards" {
@@ -138,6 +142,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.cluster_relocating_shards_max_delay
 }
 
 resource "signalfx_detector" "cluster_unassigned_shards" {
@@ -176,6 +182,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.cluster_unassigned_shards_max_delay
 }
 
 resource "signalfx_detector" "pending_tasks" {
@@ -214,6 +222,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.pending_tasks_max_delay
 }
 
 resource "signalfx_detector" "cpu_usage" {
@@ -252,6 +262,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.cpu_usage_max_delay
 }
 
 resource "signalfx_detector" "file_descriptors" {
@@ -292,6 +304,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.file_descriptors_max_delay
 }
 
 resource "signalfx_detector" "jvm_heap_memory_usage" {
@@ -330,6 +344,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.jvm_heap_memory_usage_max_delay
 }
 
 resource "signalfx_detector" "jvm_memory_young_usage" {
@@ -370,6 +386,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.jvm_memory_young_usage_max_delay
 }
 
 resource "signalfx_detector" "jvm_memory_old_usage" {
@@ -410,6 +428,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.jvm_memory_old_usage_max_delay
 }
 
 resource "signalfx_detector" "jvm_gc_old_collection_latency" {
@@ -450,6 +470,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.jvm_gc_old_collection_latency_max_delay
 }
 
 resource "signalfx_detector" "jvm_gc_young_collection_latency" {
@@ -490,6 +512,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.jvm_gc_young_collection_latency_max_delay
 }
 
 resource "signalfx_detector" "indexing_latency" {
@@ -530,6 +554,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.indexing_latency_max_delay
 }
 
 resource "signalfx_detector" "flush_latency" {
@@ -570,6 +596,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.flush_latency_max_delay
 }
 
 resource "signalfx_detector" "search_latency" {
@@ -610,6 +638,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.search_latency_max_delay
 }
 
 resource "signalfx_detector" "fetch_latency" {
@@ -650,6 +680,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.fetch_latency_max_delay
 }
 
 resource "signalfx_detector" "field_data_evictions_change" {
@@ -688,6 +720,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.field_data_evictions_change_max_delay
 }
 
 resource "signalfx_detector" "task_time_in_queue_change" {
@@ -726,5 +760,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.task_time_in_queue_change_max_delay
 }
 

--- a/modules/smart-agent_elasticsearch/variables.tf
+++ b/modules/smart-agent_elasticsearch/variables.tf
@@ -2,6 +2,12 @@
 
 # Heartbeat detector
 
+variable "heartbeat_max_delay" {
+  description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = 900
+}
+
 variable "heartbeat_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -39,6 +45,12 @@ variable "heartbeat_aggregation_function" {
 }
 
 # Cluster_status detector
+
+variable "cluster_status_max_delay" {
+  description = "Enforce max delay for cluster_status detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "cluster_status_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -89,6 +101,12 @@ variable "cluster_status_transformation_function" {
 }
 
 # Cluster_initializing_shards detector
+
+variable "cluster_initializing_shards_max_delay" {
+  description = "Enforce max delay for cluster_initializing_shards detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "cluster_initializing_shards_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -152,6 +170,12 @@ variable "cluster_initializing_shards_threshold_major" {
 
 # Cluster_relocating_shards detector
 
+variable "cluster_relocating_shards_max_delay" {
+  description = "Enforce max delay for cluster_relocating_shards detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "cluster_relocating_shards_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -213,6 +237,12 @@ variable "cluster_relocating_shards_threshold_major" {
 }
 
 # Cluster_unassigned_shards detector
+
+variable "cluster_unassigned_shards_max_delay" {
+  description = "Enforce max delay for cluster_unassigned_shards detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "cluster_unassigned_shards_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -276,6 +306,12 @@ variable "cluster_unassigned_shards_threshold_major" {
 
 # pending_tasks detector
 
+variable "pending_tasks_max_delay" {
+  description = "Enforce max delay for pending_tasks detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "pending_tasks_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -337,6 +373,12 @@ variable "pending_tasks_threshold_major" {
 }
 
 # Jvm_heap_memory_usage detector
+
+variable "jvm_heap_memory_usage_max_delay" {
+  description = "Enforce max delay for jvm_heap_memory_usage detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "jvm_heap_memory_usage_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -400,6 +442,12 @@ variable "jvm_heap_memory_usage_threshold_major" {
 
 # cpu_usage detector
 
+variable "cpu_usage_max_delay" {
+  description = "Enforce max delay for cpu_usage detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "cpu_usage_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -461,6 +509,12 @@ variable "cpu_usage_threshold_major" {
 }
 
 # file_descriptors detector
+
+variable "file_descriptors_max_delay" {
+  description = "Enforce max delay for file_descriptors detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "file_descriptors_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -524,6 +578,12 @@ variable "file_descriptors_threshold_major" {
 
 # Jvm_memory_young_usage detector
 
+variable "jvm_memory_young_usage_max_delay" {
+  description = "Enforce max delay for jvm_memory_young_usage detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "jvm_memory_young_usage_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -585,6 +645,12 @@ variable "jvm_memory_young_usage_threshold_minor" {
 }
 
 # Jvm_memory_old_usage detector
+
+variable "jvm_memory_old_usage_max_delay" {
+  description = "Enforce max delay for jvm_memory_old_usage detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "jvm_memory_old_usage_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -648,6 +714,12 @@ variable "jvm_memory_old_usage_threshold_minor" {
 
 # Jvm_gc_old_collection_latency detector
 
+variable "jvm_gc_old_collection_latency_max_delay" {
+  description = "Enforce max delay for jvm_gc_old_collection_latency detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "jvm_gc_old_collection_latency_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -709,6 +781,12 @@ variable "jvm_gc_old_collection_latency_threshold_minor" {
 }
 
 # Jvm_gc_young_collection_latency detector
+
+variable "jvm_gc_young_collection_latency_max_delay" {
+  description = "Enforce max delay for jvm_gc_young_collection_latency detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "jvm_gc_young_collection_latency_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -772,6 +850,12 @@ variable "jvm_gc_young_collection_latency_threshold_minor" {
 
 # Indexing_latency detector
 
+variable "indexing_latency_max_delay" {
+  description = "Enforce max delay for indexing_latency detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "indexing_latency_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -833,6 +917,12 @@ variable "indexing_latency_threshold_minor" {
 }
 
 # Flush_latency detector
+
+variable "flush_latency_max_delay" {
+  description = "Enforce max delay for flush_latency detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "flush_latency_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -896,6 +986,12 @@ variable "flush_latency_threshold_minor" {
 
 # Search_latency detector
 
+variable "search_latency_max_delay" {
+  description = "Enforce max delay for search_latency detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "search_latency_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -957,6 +1053,12 @@ variable "search_latency_threshold_minor" {
 }
 
 # Fetch_latency detector
+
+variable "fetch_latency_max_delay" {
+  description = "Enforce max delay for fetch_latency detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "fetch_latency_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -1020,6 +1122,12 @@ variable "fetch_latency_threshold_minor" {
 
 # Field_data_evictions_change detector
 
+variable "field_data_evictions_change_max_delay" {
+  description = "Enforce max delay for field_data_evictions_change detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "field_data_evictions_change_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -1081,6 +1189,12 @@ variable "field_data_evictions_change_threshold_minor" {
 }
 
 # Task_time_in_queue_change detector
+
+variable "task_time_in_queue_change_max_delay" {
+  description = "Enforce max delay for task_time_in_queue_change detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "task_time_in_queue_change_tip" {
   description = "Suggested first course of action or any note useful for incident handling"

--- a/modules/smart-agent_genericjmx/detectors-genericjmx.tf
+++ b/modules/smart-agent_genericjmx/detectors-genericjmx.tf
@@ -35,6 +35,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.memory_heap_max_delay
 }
 
 resource "signalfx_detector" "jmx_old_gen" {
@@ -74,5 +76,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.gc_old_gen_max_delay
 }
 

--- a/modules/smart-agent_genericjmx/variables.tf
+++ b/modules/smart-agent_genericjmx/variables.tf
@@ -2,6 +2,12 @@
 
 # memory_heap detector
 
+variable "memory_heap_max_delay" {
+  description = "Enforce max delay for memory_heap detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "memory_heap_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -63,6 +69,12 @@ variable "memory_heap_threshold_critical" {
 }
 
 # gc_old_gen detector
+
+variable "gc_old_gen_max_delay" {
+  description = "Enforce max delay for gc_old_gen detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "gc_old_gen_tip" {
   description = "Suggested first course of action or any note useful for incident handling"

--- a/modules/smart-agent_haproxy/detectors-haproxy.tf
+++ b/modules/smart-agent_haproxy/detectors-haproxy.tf
@@ -5,8 +5,6 @@ resource "signalfx_detector" "heartbeat" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
-  max_delay = 900
-
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('haproxy_session_current', filter=${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
@@ -24,6 +22,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.heartbeat_max_delay
 }
 
 resource "signalfx_detector" "server_status" {
@@ -49,6 +49,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.server_status_max_delay
 }
 
 resource "signalfx_detector" "backend_status" {
@@ -74,6 +76,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.backend_status_max_delay
 }
 
 resource "signalfx_detector" "session_limit" {
@@ -114,6 +118,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.session_limit_max_delay
 }
 
 resource "signalfx_detector" "http_5xx_response" {
@@ -154,6 +160,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.http_5xx_response_max_delay
 }
 
 resource "signalfx_detector" "http_4xx_response" {
@@ -194,5 +202,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.http_4xx_response_max_delay
 }
 

--- a/modules/smart-agent_haproxy/variables.tf
+++ b/modules/smart-agent_haproxy/variables.tf
@@ -2,6 +2,12 @@
 
 # Heartbeat detector
 
+variable "heartbeat_max_delay" {
+  description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = 900
+}
+
 variable "heartbeat_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -39,6 +45,12 @@ variable "heartbeat_aggregation_function" {
 }
 
 # Server_status detector
+
+variable "server_status_max_delay" {
+  description = "Enforce max delay for server_status detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "server_status_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -84,6 +96,12 @@ variable "server_status_transformation_function" {
 
 # Backend_status detector
 
+variable "backend_status_max_delay" {
+  description = "Enforce max delay for backend_status detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "backend_status_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -127,6 +145,12 @@ variable "backend_status_transformation_function" {
 }
 
 # Session_limit detector
+
+variable "session_limit_max_delay" {
+  description = "Enforce max delay for session_limit detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "session_limit_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -190,6 +214,12 @@ variable "session_limit_threshold_critical" {
 
 # Http_5xx_response detector
 
+variable "http_5xx_response_max_delay" {
+  description = "Enforce max delay for http_5xx_response detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "http_5xx_response_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -251,6 +281,12 @@ variable "http_5xx_response_threshold_critical" {
 }
 
 # Http_4xx_response detector
+
+variable "http_4xx_response_max_delay" {
+  description = "Enforce max delay for http_4xx_response detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "http_4xx_response_tip" {
   description = "Suggested first course of action or any note useful for incident handling"

--- a/modules/smart-agent_kubernetes-apiserver/detectors-k8s-cluster.tf
+++ b/modules/smart-agent_kubernetes-apiserver/detectors-k8s-cluster.tf
@@ -5,8 +5,6 @@ resource "signalfx_detector" "heartbeat" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
-  max_delay = 900
-
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('apiserver_request_total', filter=${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
@@ -24,5 +22,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.heartbeat_max_delay
 }
 

--- a/modules/smart-agent_kubernetes-apiserver/variables.tf
+++ b/modules/smart-agent_kubernetes-apiserver/variables.tf
@@ -2,6 +2,12 @@
 
 # Heartbeat detector
 
+variable "heartbeat_max_delay" {
+  description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = 900
+}
+
 variable "heartbeat_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string

--- a/modules/smart-agent_kubernetes-velero/detectors-velero.tf
+++ b/modules/smart-agent_kubernetes-velero/detectors-velero.tf
@@ -21,6 +21,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.velero_scheduled_backup_missing_max_delay
 }
 
 resource "signalfx_detector" "velero_backup_failure" {
@@ -46,6 +48,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.velero_backup_failure_max_delay
 }
 
 resource "signalfx_detector" "velero_backup_partial_failure" {
@@ -71,6 +75,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.velero_backup_partial_failure_max_delay
 }
 
 resource "signalfx_detector" "velero_backup_deletion_failure" {
@@ -96,6 +102,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.velero_backup_deletion_failure_max_delay
 }
 
 resource "signalfx_detector" "velero_volume_snapshot_failure" {
@@ -121,5 +129,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.velero_volume_snapshot_failure_max_delay
 }
 

--- a/modules/smart-agent_kubernetes-velero/variables.tf
+++ b/modules/smart-agent_kubernetes-velero/variables.tf
@@ -2,6 +2,12 @@
 
 # Velero_scheduled_backup_missing detector
 
+variable "velero_scheduled_backup_missing_max_delay" {
+  description = "Enforce max delay for velero_scheduled_backup_missing detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "velero_scheduled_backup_missing_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -39,6 +45,12 @@ variable "velero_scheduled_backup_missing_transformation_function" {
 }
 
 # Velero_backup_failure detector
+
+variable "velero_backup_failure_max_delay" {
+  description = "Enforce max delay for velero_backup_failure detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "velero_backup_failure_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -78,6 +90,12 @@ variable "velero_backup_failure_transformation_function" {
 
 # Velero_backup_partial_failure detector
 
+variable "velero_backup_partial_failure_max_delay" {
+  description = "Enforce max delay for velero_backup_partial_failure detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "velero_backup_partial_failure_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -116,6 +134,12 @@ variable "velero_backup_partial_failure_transformation_function" {
 
 # Velero_backup_deletion_failure detector
 
+variable "velero_backup_deletion_failure_max_delay" {
+  description = "Enforce max delay for velero_backup_deletion_failure detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "velero_backup_deletion_failure_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -153,6 +177,12 @@ variable "velero_backup_deletion_failure_transformation_function" {
 }
 
 # Velero_volume_snapshot_failure detector
+
+variable "velero_volume_snapshot_failure_max_delay" {
+  description = "Enforce max delay for velero_volume_snapshot_failure detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "velero_volume_snapshot_failure_tip" {
   description = "Suggested first course of action or any note useful for incident handling"

--- a/modules/smart-agent_kubernetes-volumes/detectors-kubernetes-volumes.tf
+++ b/modules/smart-agent_kubernetes-volumes/detectors-kubernetes-volumes.tf
@@ -36,6 +36,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.volume_space_max_delay
 }
 
 resource "signalfx_detector" "volume_inodes" {
@@ -76,5 +78,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.volume_inodes_max_delay
 }
 

--- a/modules/smart-agent_kubernetes-volumes/variables.tf
+++ b/modules/smart-agent_kubernetes-volumes/variables.tf
@@ -2,6 +2,12 @@
 
 # Volume_space detector
 
+variable "volume_space_max_delay" {
+  description = "Enforce max delay for volume_space detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "volume_space_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -63,6 +69,12 @@ variable "volume_space_threshold_major" {
 }
 
 # Volume_inodes detector
+
+variable "volume_inodes_max_delay" {
+  description = "Enforce max delay for volume_inodes detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "volume_inodes_tip" {
   description = "Suggested first course of action or any note useful for incident handling"

--- a/modules/smart-agent_memcached/detectors-memcached.tf
+++ b/modules/smart-agent_memcached/detectors-memcached.tf
@@ -5,8 +5,6 @@ resource "signalfx_detector" "heartbeat" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
-  max_delay = 900
-
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('memcached_items.current', filter=${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
@@ -24,6 +22,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.heartbeat_max_delay
 }
 
 resource "signalfx_detector" "memcached_max_conn" {
@@ -62,6 +62,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.memcached_max_conn_max_delay
 }
 
 resource "signalfx_detector" "memcached_hit_ratio" {
@@ -102,4 +104,6 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.memcached_hit_ratio_max_delay
 }

--- a/modules/smart-agent_memcached/variables.tf
+++ b/modules/smart-agent_memcached/variables.tf
@@ -12,6 +12,12 @@ variable "heartbeat_aggregation_function" {
   default     = ""
 }
 
+variable "heartbeat_max_delay" {
+  description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = 900
+}
+
 variable "heartbeat_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -54,6 +60,12 @@ variable "memcached_max_conn_transformation_function" {
   description = "Transformation function for memcached_max_conn detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ".max(over='5m')"
+}
+
+variable "memcached_max_conn_max_delay" {
+  description = "Enforce max delay for memcached_max_conn detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "memcached_max_conn_tip" {
@@ -116,6 +128,12 @@ variable "memcached_hit_ratio_transformation_function" {
   description = "Transformation function for memcached_hit_ratio detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ""
+}
+
+variable "memcached_hit_ratio_max_delay" {
+  description = "Enforce max delay for memcached_hit_ratio detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "memcached_hit_ratio_tip" {

--- a/modules/smart-agent_mongodb/detectors-mongo.tf
+++ b/modules/smart-agent_mongodb/detectors-mongo.tf
@@ -5,8 +5,6 @@ resource "signalfx_detector" "heartbeat" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
-  max_delay = 900
-
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('gauge.connections.available', filter=${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
@@ -24,6 +22,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.heartbeat_max_delay
 }
 
 resource "signalfx_detector" "page_faults" {
@@ -49,6 +49,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.page_faults_max_delay
 }
 
 resource "signalfx_detector" "max_connections" {
@@ -89,6 +91,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.max_connections_max_delay
 }
 
 resource "signalfx_detector" "asserts" {
@@ -116,6 +120,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.asserts_max_delay
 }
 
 resource "signalfx_detector" "primary" {
@@ -141,6 +147,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.primary_max_delay
 }
 
 resource "signalfx_detector" "secondary" {
@@ -168,6 +176,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.secondary_max_delay
 }
 
 resource "signalfx_detector" "replication_lag" {
@@ -206,5 +216,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.replication_lag_max_delay
 }
 

--- a/modules/smart-agent_mongodb/variables.tf
+++ b/modules/smart-agent_mongodb/variables.tf
@@ -12,6 +12,12 @@ variable "heartbeat_aggregation_function" {
   default     = ".mean(by=['cluster'])"
 }
 
+variable "heartbeat_max_delay" {
+  description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = 900
+}
+
 variable "heartbeat_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -56,6 +62,12 @@ variable "page_faults_transformation_function" {
   default     = ".mean(over='5m')"
 }
 
+variable "page_faults_max_delay" {
+  description = "Enforce max delay for page_faults detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "page_faults_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -98,6 +110,12 @@ variable "max_connections_transformation_function" {
   description = "Transformation function for max_connections detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ".mean(over='5m')"
+}
+
+variable "max_connections_max_delay" {
+  description = "Enforce max delay for max_connections detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "max_connections_tip" {
@@ -162,6 +180,12 @@ variable "asserts_transformation_function" {
   default     = ".max(over='30m')"
 }
 
+variable "asserts_max_delay" {
+  description = "Enforce max delay for asserts detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "asserts_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -204,6 +228,12 @@ variable "primary_transformation_function" {
   description = "Transformation function for primary detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ".min(over='1m')"
+}
+
+variable "primary_max_delay" {
+  description = "Enforce max delay for primary detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "primary_tip" {
@@ -250,6 +280,12 @@ variable "secondary_transformation_function" {
   default     = ".min(over='5m')"
 }
 
+variable "secondary_max_delay" {
+  description = "Enforce max delay for secondary detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "secondary_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -292,6 +328,12 @@ variable "replication_lag_transformation_function" {
   description = "Transformation function for replication_lag detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ".mean(over='15m')"
+}
+
+variable "replication_lag_max_delay" {
+  description = "Enforce max delay for replication_lag detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "replication_lag_tip" {

--- a/modules/smart-agent_mysql/detectors-mysql.tf
+++ b/modules/smart-agent_mysql/detectors-mysql.tf
@@ -5,8 +5,6 @@ resource "signalfx_detector" "heartbeat" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
-  max_delay = 900
-
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('mysql_octets.rx', filter=filter('plugin', 'mysql') and ${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
@@ -24,6 +22,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.heartbeat_max_delay
 }
 
 resource "signalfx_detector" "mysql_connections" {
@@ -64,6 +64,8 @@ resource "signalfx_detector" "mysql_connections" {
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.connections_max_delay
 }
 
 resource "signalfx_detector" "mysql_slow" {
@@ -104,6 +106,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.slow_max_delay
 }
 
 resource "signalfx_detector" "mysql_pool_efficiency" {
@@ -144,6 +148,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.pool_efficiency_max_delay
 }
 
 resource "signalfx_detector" "mysql_pool_utilization" {
@@ -184,6 +190,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.pool_utilization_max_delay
 }
 
 resource "signalfx_detector" "mysql_threads_anomaly" {
@@ -210,6 +218,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.threads_anomaly_max_delay
 }
 
 resource "signalfx_detector" "mysql_questions_anomaly" {
@@ -236,6 +246,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.questions_anomaly_max_delay
 }
 
 resource "signalfx_detector" "mysql_replication_lag" {
@@ -274,6 +286,8 @@ resource "signalfx_detector" "mysql_replication_lag" {
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.replication_lag_max_delay
 }
 
 resource "signalfx_detector" "mysql_slave_sql_status" {
@@ -299,6 +313,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.slave_sql_status_max_delay
 }
 
 resource "signalfx_detector" "mysql_slave_io_status" {
@@ -324,5 +340,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.slave_io_status_max_delay
 }
 

--- a/modules/smart-agent_mysql/variables.tf
+++ b/modules/smart-agent_mysql/variables.tf
@@ -2,6 +2,12 @@
 
 # Heartbeat detector
 
+variable "heartbeat_max_delay" {
+  description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = 900
+}
+
 variable "heartbeat_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -39,6 +45,12 @@ variable "heartbeat_aggregation_function" {
 }
 
 # connection detector
+
+variable "connections_max_delay" {
+  description = "Enforce max delay for connections detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "connections_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -102,6 +114,12 @@ variable "connections_threshold_major" {
 
 # pool_efficiency detector
 
+variable "pool_efficiency_max_delay" {
+  description = "Enforce max delay for pool_efficiency detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "pool_efficiency_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -163,6 +181,12 @@ variable "pool_efficiency_threshold_warning" {
 }
 
 # pool_utilization detector
+
+variable "pool_utilization_max_delay" {
+  description = "Enforce max delay for pool_utilization detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "pool_utilization_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -226,6 +250,12 @@ variable "pool_utilization_threshold_warning" {
 
 # slow detector
 
+variable "slow_max_delay" {
+  description = "Enforce max delay for slow detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "slow_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -287,6 +317,12 @@ variable "slow_threshold_major" {
 }
 
 # threads_anomaly detector
+
+variable "threads_anomaly_max_delay" {
+  description = "Enforce max delay for threads_anomaly detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "threads_anomaly_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -362,6 +398,12 @@ variable "threads_anomaly_orientation" {
 
 # questions_anomaly detector
 
+variable "questions_anomaly_max_delay" {
+  description = "Enforce max delay for questions_anomaly detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "questions_anomaly_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -436,6 +478,12 @@ variable "questions_anomaly_orientation" {
 
 # replication_lag detector
 
+variable "replication_lag_max_delay" {
+  description = "Enforce max delay for replication_lag detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "replication_lag_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -498,6 +546,12 @@ variable "replication_lag_threshold_major" {
 
 # slave_sql_status detector
 
+variable "slave_sql_status_max_delay" {
+  description = "Enforce max delay for slave_sql_status detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "slave_sql_status_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -535,6 +589,12 @@ variable "slave_sql_status_transformation_function" {
 }
 
 # slave_io_status detector
+
+variable "slave_io_status_max_delay" {
+  description = "Enforce max delay for slave_io_status detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "slave_io_status_tip" {
   description = "Suggested first course of action or any note useful for incident handling"

--- a/modules/smart-agent_nginx/detectors-nginx.tf
+++ b/modules/smart-agent_nginx/detectors-nginx.tf
@@ -5,8 +5,6 @@ resource "signalfx_detector" "heartbeat" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
-  max_delay = 900
-
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('nginx_connections.reading', filter=${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
@@ -24,6 +22,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.heartbeat_max_delay
 }
 
 resource "signalfx_detector" "dropped_connections" {
@@ -62,5 +62,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.dropped_connections_max_delay
 }
 

--- a/modules/smart-agent_nginx/variables.tf
+++ b/modules/smart-agent_nginx/variables.tf
@@ -2,6 +2,12 @@
 
 # Heartbeat detector
 
+variable "heartbeat_max_delay" {
+  description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = 900
+}
+
 variable "heartbeat_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -39,6 +45,12 @@ variable "heartbeat_aggregation_function" {
 }
 
 # dropped_connections detector
+
+variable "dropped_connections_max_delay" {
+  description = "Enforce max delay for dropped_connections detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "dropped_connections_tip" {
   description = "Suggested first course of action or any note useful for incident handling"

--- a/modules/smart-agent_ntp/detectors-ntp.tf
+++ b/modules/smart-agent_ntp/detectors-ntp.tf
@@ -5,8 +5,6 @@ resource "signalfx_detector" "heartbeat" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
-  max_delay = 900
-
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('ntp.offset_seconds', filter=${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
@@ -24,6 +22,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.heartbeat_max_delay
 }
 
 resource "signalfx_detector" "ntp" {
@@ -49,5 +49,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.ntp_max_delay
 }
 

--- a/modules/smart-agent_ntp/variables.tf
+++ b/modules/smart-agent_ntp/variables.tf
@@ -2,6 +2,12 @@
 
 # Heartbeat detector
 
+variable "heartbeat_max_delay" {
+  description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = 900
+}
+
 variable "heartbeat_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -39,6 +45,12 @@ variable "heartbeat_aggregation_function" {
 }
 
 # ntp detector
+
+variable "ntp_max_delay" {
+  description = "Enforce max delay for ntp detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "ntp_tip" {
   description = "Suggested first course of action or any note useful for incident handling"

--- a/modules/smart-agent_php-fpm/detectors-fpm.tf
+++ b/modules/smart-agent_php-fpm/detectors-fpm.tf
@@ -5,8 +5,6 @@ resource "signalfx_detector" "heartbeat" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
-  max_delay = 900
-
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('phpfpm_requests.accepted', filter=${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
@@ -24,6 +22,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.heartbeat_max_delay
 }
 
 resource "signalfx_detector" "php_fpm_connect_idle" {
@@ -64,5 +64,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.php_fpm_connect_idle_max_delay
 }
 

--- a/modules/smart-agent_php-fpm/variables.tf
+++ b/modules/smart-agent_php-fpm/variables.tf
@@ -2,6 +2,12 @@
 
 # Heartbeat detector
 
+variable "heartbeat_max_delay" {
+  description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = 900
+}
+
 variable "heartbeat_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -39,6 +45,12 @@ variable "heartbeat_aggregation_function" {
 }
 
 # PHP_fpm_connect_idle detector
+
+variable "php_fpm_connect_idle_max_delay" {
+  description = "Enforce max delay for php_fpm_connect_idle detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "php_fpm_connect_idle_tip" {
   description = "Suggested first course of action or any note useful for incident handling"

--- a/modules/smart-agent_postgresql/detectors-postgresql.tf
+++ b/modules/smart-agent_postgresql/detectors-postgresql.tf
@@ -5,8 +5,6 @@ resource "signalfx_detector" "heartbeat" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
-  max_delay = 900
-
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('postgres_database_size', filter=${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
@@ -24,6 +22,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.heartbeat_max_delay
 }
 
 resource "signalfx_detector" "deadlocks" {
@@ -62,6 +62,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.deadlocks_max_delay
 }
 
 resource "signalfx_detector" "hit_ratio" {
@@ -100,6 +102,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.hit_ratio_max_delay
 }
 
 resource "signalfx_detector" "rollbacks" {
@@ -140,6 +144,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.rollbacks_max_delay
 }
 
 resource "signalfx_detector" "conflicts" {
@@ -178,6 +184,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.conflicts_max_delay
 }
 
 resource "signalfx_detector" "max_connections" {
@@ -216,6 +224,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.max_connections_max_delay
 }
 
 resource "signalfx_detector" "replication_lag" {
@@ -254,6 +264,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.replication_lag_max_delay
 }
 
 resource "signalfx_detector" "replication_state" {
@@ -279,5 +291,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.replication_state_max_delay
 }
 

--- a/modules/smart-agent_postgresql/variables.tf
+++ b/modules/smart-agent_postgresql/variables.tf
@@ -2,6 +2,12 @@
 
 # Heartbeat detector
 
+variable "heartbeat_max_delay" {
+  description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = 900
+}
+
 variable "heartbeat_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -39,6 +45,12 @@ variable "heartbeat_aggregation_function" {
 }
 
 # deadlocks detector
+
+variable "deadlocks_max_delay" {
+  description = "Enforce max delay for deadlocks detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "deadlocks_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -102,6 +114,12 @@ variable "deadlocks_threshold_major" {
 
 # hit_ratio detector
 
+variable "hit_ratio_max_delay" {
+  description = "Enforce max delay for hit_ratio detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "hit_ratio_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -163,6 +181,12 @@ variable "hit_ratio_threshold_minor" {
 }
 
 # rollbacks detector
+
+variable "rollbacks_max_delay" {
+  description = "Enforce max delay for rollbacks detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "rollbacks_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -226,6 +250,12 @@ variable "rollbacks_threshold_minor" {
 
 # conflicts detector
 
+variable "conflicts_max_delay" {
+  description = "Enforce max delay for conflicts detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "conflicts_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -287,6 +317,12 @@ variable "conflicts_threshold_major" {
 }
 
 # max_connections detector
+
+variable "max_connections_max_delay" {
+  description = "Enforce max delay for max_connections detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "max_connections_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -350,6 +386,12 @@ variable "max_connections_threshold_major" {
 
 # replication_lag detector
 
+variable "replication_lag_max_delay" {
+  description = "Enforce max delay for replication_lag detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "replication_lag_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -411,6 +453,12 @@ variable "replication_lag_threshold_major" {
 }
 
 # replication_state detector
+
+variable "replication_state_max_delay" {
+  description = "Enforce max delay for replication_state detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "replication_state_tip" {
   description = "Suggested first course of action or any note useful for incident handling"

--- a/modules/smart-agent_rabbitmq-node/detectors-rabbitmq-node.tf
+++ b/modules/smart-agent_rabbitmq-node/detectors-rabbitmq-node.tf
@@ -5,8 +5,6 @@ resource "signalfx_detector" "heartbeat" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
-  max_delay = 900
-
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('gauge.node.uptime', filter=${local.not_running_vm_filters} and filter('plugin', 'rabbitmq') and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
@@ -24,6 +22,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.heartbeat_max_delay
 }
 
 resource "signalfx_detector" "file_descriptors" {
@@ -64,6 +64,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.file_descriptors_max_delay
 }
 
 resource "signalfx_detector" "processes" {
@@ -104,6 +106,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.processes_max_delay
 }
 
 resource "signalfx_detector" "sockets" {
@@ -144,6 +148,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.sockets_max_delay
 }
 
 resource "signalfx_detector" "vm_memory" {
@@ -184,5 +190,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.vm_memory_max_delay
 }
 

--- a/modules/smart-agent_rabbitmq-node/variables.tf
+++ b/modules/smart-agent_rabbitmq-node/variables.tf
@@ -2,6 +2,12 @@
 
 # Heartbeat detector
 
+variable "heartbeat_max_delay" {
+  description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = 900
+}
+
 variable "heartbeat_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -39,6 +45,12 @@ variable "heartbeat_aggregation_function" {
 }
 
 # file_descriptors detector
+
+variable "file_descriptors_max_delay" {
+  description = "Enforce max delay for file_descriptors detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "file_descriptors_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -102,6 +114,12 @@ variable "file_descriptors_threshold_major" {
 
 # processes detector
 
+variable "processes_max_delay" {
+  description = "Enforce max delay for processes detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "processes_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -164,6 +182,12 @@ variable "processes_threshold_major" {
 
 # sockets detector
 
+variable "sockets_max_delay" {
+  description = "Enforce max delay for sockets detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "sockets_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -225,6 +249,12 @@ variable "sockets_threshold_major" {
 }
 
 # vm_memory detector
+
+variable "vm_memory_max_delay" {
+  description = "Enforce max delay for vm_memory detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "vm_memory_tip" {
   description = "Suggested first course of action or any note useful for incident handling"

--- a/modules/smart-agent_redis/detectors-redis.tf
+++ b/modules/smart-agent_redis/detectors-redis.tf
@@ -5,8 +5,6 @@ resource "signalfx_detector" "heartbeat" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
-  max_delay = 900
-
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('bytes.used_memory', filter=filter('plugin', 'redis_info') and ${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
@@ -24,6 +22,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.heartbeat_max_delay
 }
 
 resource "signalfx_detector" "evicted_keys" {
@@ -62,6 +62,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.evicted_keys_max_delay
 }
 
 resource "signalfx_detector" "expirations" {
@@ -100,6 +102,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.expirations_max_delay
 }
 
 resource "signalfx_detector" "blocked_clients" {
@@ -140,6 +144,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.blocked_clients_max_delay
 }
 
 resource "signalfx_detector" "keyspace_full" {
@@ -165,6 +171,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.keyspace_full_max_delay
 }
 
 resource "signalfx_detector" "memory_used_max" {
@@ -205,6 +213,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.memory_used_max_max_delay
 }
 
 resource "signalfx_detector" "memory_used_total" {
@@ -245,6 +255,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.memory_used_total_max_delay
 }
 
 resource "signalfx_detector" "memory_frag_high" {
@@ -285,6 +297,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.memory_frag_high_max_delay
 }
 
 resource "signalfx_detector" "memory_frag_low" {
@@ -325,6 +339,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.memory_frag_low_max_delay
 }
 
 resource "signalfx_detector" "rejected_connections" {
@@ -363,6 +379,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.rejected_connections_max_delay
 }
 
 resource "signalfx_detector" "hitrate" {
@@ -403,5 +421,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.hitrate_max_delay
 }
 

--- a/modules/smart-agent_redis/variables.tf
+++ b/modules/smart-agent_redis/variables.tf
@@ -2,6 +2,12 @@
 
 # Heartbeat detector
 
+variable "heartbeat_max_delay" {
+  description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = 900
+}
+
 variable "heartbeat_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -39,6 +45,12 @@ variable "heartbeat_aggregation_function" {
 }
 
 # Evicted_keys detector
+
+variable "evicted_keys_max_delay" {
+  description = "Enforce max delay for evicted_keys detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "evicted_keys_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -102,6 +114,12 @@ variable "evicted_keys_threshold_major" {
 
 # Expirations detector
 
+variable "expirations_max_delay" {
+  description = "Enforce max delay for expirations detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "expirations_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -163,6 +181,12 @@ variable "expirations_threshold_major" {
 }
 
 # Blocked_clients detector
+
+variable "blocked_clients_max_delay" {
+  description = "Enforce max delay for blocked_clients detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "blocked_clients_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -226,6 +250,12 @@ variable "blocked_clients_threshold_warning" {
 
 # Keyspace_full detector
 
+variable "keyspace_full_max_delay" {
+  description = "Enforce max delay for keyspace_full detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "keyspace_full_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -263,6 +293,12 @@ variable "keyspace_full_transformation_function" {
 }
 
 # Memory_used_max detector
+
+variable "memory_used_max_max_delay" {
+  description = "Enforce max delay for memory_used_max detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "memory_used_max_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -326,6 +362,12 @@ variable "memory_used_max_threshold_major" {
 
 # Memory_used_total detector
 
+variable "memory_used_total_max_delay" {
+  description = "Enforce max delay for memory_used_total detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "memory_used_total_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -387,6 +429,12 @@ variable "memory_used_total_threshold_major" {
 }
 
 # Memory_frag_high detector
+
+variable "memory_frag_high_max_delay" {
+  description = "Enforce max delay for memory_frag_high detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "memory_frag_high_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -450,6 +498,12 @@ variable "memory_frag_high_threshold_major" {
 
 # Memory_frag_low detector
 
+variable "memory_frag_low_max_delay" {
+  description = "Enforce max delay for memory_frag_low detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "memory_frag_low_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -512,6 +566,12 @@ variable "memory_frag_low_threshold_major" {
 
 # rejected_connections detector
 
+variable "rejected_connections_max_delay" {
+  description = "Enforce max delay for rejected_connections detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "rejected_connections_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -573,6 +633,12 @@ variable "rejected_connections_threshold_major" {
 }
 
 # Hitrate detector
+
+variable "hitrate_max_delay" {
+  description = "Enforce max delay for hitrate detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "hitrate_tip" {
   description = "Suggested first course of action or any note useful for incident handling"

--- a/modules/smart-agent_solr/detectors-solr.tf
+++ b/modules/smart-agent_solr/detectors-solr.tf
@@ -5,8 +5,6 @@ resource "signalfx_detector" "heartbeat" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
-  max_delay = 900
-
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('counter.solr.http_requests', filter=${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
@@ -24,6 +22,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.heartbeat_max_delay
 }
 
 resource "signalfx_detector" "errors" {
@@ -62,6 +62,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.errors_max_delay
 }
 
 resource "signalfx_detector" "searcher_warmup_time" {
@@ -100,5 +102,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.searcher_warmup_time_max_delay
 }
 

--- a/modules/smart-agent_solr/variables.tf
+++ b/modules/smart-agent_solr/variables.tf
@@ -2,6 +2,12 @@
 
 # Heartbeat detector
 
+variable "heartbeat_max_delay" {
+  description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = 900
+}
+
 variable "heartbeat_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -39,6 +45,12 @@ variable "heartbeat_aggregation_function" {
 }
 
 # errors detector
+
+variable "errors_max_delay" {
+  description = "Enforce max delay for errors detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "errors_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -101,6 +113,12 @@ variable "errors_threshold_major" {
 }
 
 # Searcher_warmup_time detector
+
+variable "searcher_warmup_time_max_delay" {
+  description = "Enforce max delay for searcher_warmup_time detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "searcher_warmup_time_tip" {
   description = "Suggested first course of action or any note useful for incident handling"

--- a/modules/smart-agent_supervisor/detectors-supervisor.tf
+++ b/modules/smart-agent_supervisor/detectors-supervisor.tf
@@ -5,8 +5,6 @@ resource "signalfx_detector" "heartbeat" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
-  max_delay = 900
-
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('supervisor.state', filter=${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
@@ -24,6 +22,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.heartbeat_max_delay
 }
 
 resource "signalfx_detector" "process_state" {
@@ -62,5 +62,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.process_state_max_delay
 }
 

--- a/modules/smart-agent_supervisor/variables.tf
+++ b/modules/smart-agent_supervisor/variables.tf
@@ -2,6 +2,12 @@
 
 # Heartbeat detector
 
+variable "heartbeat_max_delay" {
+  description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = 900
+}
+
 variable "heartbeat_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -39,6 +45,12 @@ variable "heartbeat_aggregation_function" {
 }
 
 # process_state detector
+
+variable "process_state_max_delay" {
+  description = "Enforce max delay for process_state detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "process_state_tip" {
   description = "Suggested first course of action or any note useful for incident handling"

--- a/modules/smart-agent_system-common/detectors-system.tf
+++ b/modules/smart-agent_system-common/detectors-system.tf
@@ -22,5 +22,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.disk_running_out_max_delay
 }
 

--- a/modules/smart-agent_system-common/variables.tf
+++ b/modules/smart-agent_system-common/variables.tf
@@ -8,6 +8,12 @@ variable "agent_per_cpu_enabled" {
 
 # disk_running_out detector
 
+variable "disk_running_out_max_delay" {
+  description = "Enforce max delay for disk_running_out detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "disk_running_out_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string

--- a/modules/smart-agent_tomcat/detectors-tomcat.tf
+++ b/modules/smart-agent_tomcat/detectors-tomcat.tf
@@ -5,8 +5,6 @@ resource "signalfx_detector" "heartbeat" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
-  max_delay = 900
-
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data(' gauge.tomcat.ThreadPool.maxThreads ', filter=${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
@@ -24,6 +22,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.heartbeat_max_delay
 }
 
 resource "signalfx_detector" "average_processing_time" {
@@ -64,6 +64,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.average_processing_time_max_delay
 }
 
 resource "signalfx_detector" "busy_threads_percentage" {
@@ -104,5 +106,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.busy_threads_percentage_max_delay
 }
 

--- a/modules/smart-agent_tomcat/variables.tf
+++ b/modules/smart-agent_tomcat/variables.tf
@@ -12,6 +12,12 @@ variable "heartbeat_aggregation_function" {
   default     = ""
 }
 
+variable "heartbeat_max_delay" {
+  description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = 900
+}
+
 variable "heartbeat_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -54,6 +60,12 @@ variable "average_processing_time_transformation_function" {
   description = "Transformation function for average_processing_time detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ".min(over='10m')"
+}
+
+variable "average_processing_time_max_delay" {
+  description = "Enforce max delay for average_processing_time detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "average_processing_time_tip" {
@@ -116,6 +128,12 @@ variable "busy_threads_percentage_transformation_function" {
   description = "Transformation function for busy_threads_percentage detector (i.e. \".mean(over='5m')\")"
   type        = string
   default     = ".min(over='5m')"
+}
+
+variable "busy_threads_percentage_max_delay" {
+  description = "Enforce max delay for busy_threads_percentage detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
 }
 
 variable "busy_threads_percentage_tip" {

--- a/modules/smart-agent_varnish/detectors-varnish.tf
+++ b/modules/smart-agent_varnish/detectors-varnish.tf
@@ -5,8 +5,6 @@ resource "signalfx_detector" "heartbeat" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
-  max_delay = 900
-
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('varnish.threads', filter=${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
@@ -24,6 +22,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.heartbeat_max_delay
 }
 
 resource "signalfx_detector" "backend_failed" {
@@ -49,6 +49,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.backend_failed_max_delay
 }
 
 resource "signalfx_detector" "threads_number" {
@@ -74,6 +76,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.threads_number_max_delay
 }
 
 resource "signalfx_detector" "session_dropped" {
@@ -99,6 +103,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.session_dropped_max_delay
 }
 
 resource "signalfx_detector" "cache_hit_rate" {
@@ -138,6 +144,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.cache_hit_rate_max_delay
 }
 
 # memory used
@@ -178,5 +186,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.memory_usage_max_delay
 }
 

--- a/modules/smart-agent_varnish/variables.tf
+++ b/modules/smart-agent_varnish/variables.tf
@@ -14,6 +14,12 @@ variable "heartbeat_aggregation_function" {
   default     = ""
 }
 
+variable "heartbeat_max_delay" {
+  description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = 900
+}
+
 variable "heartbeat_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -39,6 +45,12 @@ variable "heartbeat_timeframe" {
 }
 
 # backend_failed detector
+
+variable "backend_failed_max_delay" {
+  description = "Enforce max delay for backend_failed detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "backend_failed_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -84,6 +96,12 @@ variable "backend_failed_threshold_critical" {
 
 # threads_number detector
 
+variable "threads_number_max_delay" {
+  description = "Enforce max delay for threads_number detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "threads_number_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -128,6 +146,12 @@ variable "threads_threshold_critical" {
 
 # session_dropped detector
 
+variable "session_dropped_max_delay" {
+  description = "Enforce max delay for session_dropped detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
 variable "session_dropped_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -171,6 +195,12 @@ variable "session_dropped_threshold_critical" {
 }
 
 # cache_hit_rate detector
+
+variable "cache_hit_rate_max_delay" {
+  description = "Enforce max delay for cache_hit_rate detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "cache_hit_rate_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -233,6 +263,12 @@ variable "cache_hit_rate_threshold_major" {
 }
 
 # memory_usage detector
+
+variable "memory_usage_max_delay" {
+  description = "Enforce max delay for memory_usage detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "memory_usage_tip" {
   description = "Suggested first course of action or any note useful for incident handling"

--- a/modules/smart-agent_zookeeper/detectors-zookeeper.tf
+++ b/modules/smart-agent_zookeeper/detectors-zookeeper.tf
@@ -5,8 +5,6 @@ resource "signalfx_detector" "heartbeat" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
-  max_delay = 900
-
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     signal = data('gauge.zk_max_file_descriptor_count', filter=filter('plugin', 'zookeeper') and ${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
@@ -24,6 +22,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.heartbeat_max_delay
 }
 
 resource "signalfx_detector" "zookeeper_health" {
@@ -49,6 +49,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.zookeeper_health_max_delay
 }
 
 resource "signalfx_detector" "zookeeper_latency" {
@@ -87,6 +89,8 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.zookeeper_latency_max_delay
 }
 
 resource "signalfx_detector" "file_descriptors" {
@@ -127,5 +131,7 @@ EOF
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
+
+  max_delay = var.file_descriptors_max_delay
 }
 

--- a/modules/smart-agent_zookeeper/variables.tf
+++ b/modules/smart-agent_zookeeper/variables.tf
@@ -2,6 +2,12 @@
 
 # Heartbeat detector
 
+variable "heartbeat_max_delay" {
+  description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = 900
+}
+
 variable "heartbeat_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
@@ -39,6 +45,12 @@ variable "heartbeat_aggregation_function" {
 }
 
 # zookeeper_health detector
+
+variable "zookeeper_health_max_delay" {
+  description = "Enforce max delay for zookeeper_health detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "zookeeper_health_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -83,6 +95,12 @@ variable "zookeeper_health_transformation_function" {
 }
 
 # zookeeper_latency detector
+
+variable "zookeeper_latency_max_delay" {
+  description = "Enforce max delay for zookeeper_latency detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "zookeeper_latency_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
@@ -145,6 +163,12 @@ variable "zookeeper_latency_threshold_major" {
 }
 
 # file_descriptors detector
+
+variable "file_descriptors_max_delay" {
+  description = "Enforce max delay for file_descriptors detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
 
 variable "file_descriptors_tip" {
   description = "Suggested first course of action or any note useful for incident handling"


### PR DESCRIPTION
the last one and the most tedious as usual to resolve https://github.com/claranet/terraform-signalfx-detectors/issues/375.

It adds support for configurable `max_delay` to all handmade detectors.

I already updated the doc to add the new related variable: https://github.com/claranet/terraform-signalfx-detectors/wiki/Variables#max_delay
