### PR TITLE
fix reverted thresholds values for elb

### DIFF
--- a/modules/integration_aws-elb/conf/01-latency.yaml
+++ b/modules/integration_aws-elb/conf/01-latency.yaml
@@ -14,12 +14,12 @@ signals:
     rollup: average
 rules:
   critical:
-    threshold: 1
+    threshold: 3
     comparator: ">"
     lasting_duration: 10m
     lasting_at_least: 0.9
   major:
-    threshold: 3
+    threshold: 1
     comparator: ">"
     dependency: critical
     lasting_duration: 10m

--- a/modules/integration_aws-elb/variables-gen.tf
+++ b/modules/integration_aws-elb/variables-gen.tf
@@ -101,7 +101,7 @@ variable "backend_latency_disabled_major" {
 variable "backend_latency_threshold_critical" {
   description = "Critical threshold for backend_latency detector in Second"
   type        = number
-  default     = 1
+  default     = 3
 }
 
 variable "backend_latency_lasting_duration_critical" {
@@ -118,7 +118,7 @@ variable "backend_latency_at_least_percentage_critical" {
 variable "backend_latency_threshold_major" {
   description = "Major threshold for backend_latency detector in Second"
   type        = number
-  default     = 3
+  default     = 1
 }
 
 variable "backend_latency_lasting_duration_major" {


### PR DESCRIPTION
same as https://github.com/claranet/terraform-signalfx-detectors/pull/394 for aws elb