### PR TITLE
fix reverted thresholds values for api gateway

### DIFF
--- a/modules/integration_aws-apigateway/conf/01-latency.yaml
+++ b/modules/integration_aws-apigateway/conf/01-latency.yaml
@@ -13,12 +13,12 @@ signals:
     rollup: average
 rules:
   critical:
-    threshold: 1000
+    threshold: 3000
     comparator: ">"
     lasting_duration: 10m
     lasting_at_least: 0.9
   major:
-    threshold: 3000
+    threshold: 1000
     comparator: ">"
     dependency: critical
     lasting_duration: 10m


### PR DESCRIPTION
same as https://github.com/claranet/terraform-signalfx-detectors/pull/394 for aws api gateway