### PR TITLE
Genericjmx: add Parallel Old GC and Concurrent Mark Sweep GC support

### DIFF
--- a/modules/smart-agent_genericjmx/conf/02-gc_old.yaml
+++ b/modules/smart-agent_genericjmx/conf/02-gc_old.yaml
@@ -3,8 +3,15 @@ name: GC old gen
 
 transformation: ".min(over='5m')"
 value_unit: "%"
-#                                for G1 GC                                               for Serial GC
-filtering: (filter('plugin_instance', 'memory_pool-G1 Old Gen') or filter('plugin_instance', 'memory_pool-Tenured Gen'))
+# G1 Old Gen  : for G1 GC (-XX:+UseG1GC)
+# Tenured Gen : for Serial GC (aka MarkSweepCompact) (-XX:+UseSerialGC)
+# PS Old Gen  : for Parallel Old GC (aka PS MarkSweep) (-XX:+UseParallelOldGC)
+# CMS Old Gen : for Concurrent Mark Sweep (CMS) GC (-XX:+UseConcMarkSweepGC)
+filtering: >-
+  (filter('plugin_instance', 'memory_pool-G1 Old Gen') or
+  filter('plugin_instance', 'memory_pool-Tenured Gen') or
+  filter('plugin_instance', 'memory_pool-PS Old Gen') or
+  filter('plugin_instance', 'memory_pool-CMS Old Gen'))
 signals:
   A:
     metric: jmx_memory.used

--- a/modules/smart-agent_genericjmx/detectors-gen.tf
+++ b/modules/smart-agent_genericjmx/detectors-gen.tf
@@ -87,7 +87,7 @@ resource "signalfx_detector" "gc_old_gen" {
   }
 
   program_text = <<-EOF
-    base_filtering = (filter('plugin_instance', 'memory_pool-G1 Old Gen') or filter('plugin_instance', 'memory_pool-Tenured Gen'))
+    base_filtering = (filter('plugin_instance', 'memory_pool-G1 Old Gen') or filter('plugin_instance', 'memory_pool-Tenured Gen') or filter('plugin_instance', 'memory_pool-PS Old Gen') or filter('plugin_instance', 'memory_pool-CMS Old Gen'))
     A = data('jmx_memory.used', filter=base_filtering and ${module.filtering.signalflow})${var.gc_old_gen_aggregation_function}${var.gc_old_gen_transformation_function}
     B = data('jmx_memory.max', filter=base_filtering and ${module.filtering.signalflow})${var.gc_old_gen_aggregation_function}${var.gc_old_gen_transformation_function}
     signal = (A/B).scale(100).publish('signal')


### PR DESCRIPTION
my client use multiple types of GC…

The only one I didn't try is CMS, but I found the memorypool name here: https://gist.github.com/huynhbaoan/1bb4cd87313f56bc63cc4e19ce5c3ec7