### PR TITLE
Change permitted.scale(1024) -> permitted.scale(60), need to be in se…

### DIFF
--- a/modules/integration_aws-efs/conf/05-permitted-throughput.yaml
+++ b/modules/integration_aws-efs/conf/05-permitted-throughput.yaml
@@ -12,8 +12,7 @@ signals:
     metric: "PermittedThroughput"
     filter: "filter('stat', 'sum')"
   signal:
-    formula:
-      (metered/permitted.scale(1024)).scale(100)
+    formula: (metered/permitted.scale(60)).scale(100)
 rules:
   major:
     comparator: ">"

--- a/modules/integration_aws-efs/detectors-gen.tf
+++ b/modules/integration_aws-efs/detectors-gen.tf
@@ -203,7 +203,7 @@ resource "signalfx_detector" "percent_of_permitted_throughput" {
     base_filtering = filter('namespace', 'AWS/EFS')
     metered = data('MeteredIOBytes', filter=base_filtering and filter('stat', 'sum') and ${module.filtering.signalflow})${var.percent_of_permitted_throughput_aggregation_function}${var.percent_of_permitted_throughput_transformation_function}
     permitted = data('PermittedThroughput', filter=base_filtering and filter('stat', 'sum') and ${module.filtering.signalflow})${var.percent_of_permitted_throughput_aggregation_function}${var.percent_of_permitted_throughput_transformation_function}
-    signal = (metered/permitted.scale(1024)).scale(100).publish('signal')
+    signal = (metered/permitted.scale(60)).scale(100).publish('signal')
     detect(when(signal > ${var.percent_of_permitted_throughput_threshold_major}, lasting=%{if var.percent_of_permitted_throughput_lasting_duration_major == null}None%{else}'${var.percent_of_permitted_throughput_lasting_duration_major}'%{endif}, at_least=${var.percent_of_permitted_throughput_at_least_percentage_major})).publish('MAJOR')
     detect(when(signal > ${var.percent_of_permitted_throughput_threshold_minor}, lasting=%{if var.percent_of_permitted_throughput_lasting_duration_minor == null}None%{else}'${var.percent_of_permitted_throughput_lasting_duration_minor}'%{endif}, at_least=${var.percent_of_permitted_throughput_at_least_percentage_minor}) and (not when(signal > ${var.percent_of_permitted_throughput_threshold_major}, lasting=%{if var.percent_of_permitted_throughput_lasting_duration_major == null}None%{else}'${var.percent_of_permitted_throughput_lasting_duration_major}'%{endif}, at_least=${var.percent_of_permitted_throughput_at_least_percentage_major}))).publish('MINOR')
 EOF


### PR DESCRIPTION
Formula 
`    signal = (metered/permitted.scale(60)).scale(100).publish('signal')
`
is incorrect.
PermittedThroughput need to be converted in second

https://docs.aws.amazon.com/efs/latest/ug/monitoring-metric-math.html#metric-math-throughput-utilization