### PR TITLE
fix: Reduce hitrate detector severity

### DIFF
--- a/docs/severity.md
+++ b/docs/severity.md
@@ -1099,7 +1099,7 @@
 |Redis high memory fragmentation ratio|X|X|-|-|-|
 |Redis low memory fragmentation ratio|X|X|-|-|-|
 |Redis rejected connections|X|X|-|-|-|
-|Redis hitrate|X|X|-|-|-|
+|Redis hitrate|-|X|X|-|-|
 
 
 ## smart-agent_solr

--- a/docs/severity.md
+++ b/docs/severity.md
@@ -1099,7 +1099,7 @@
 |Redis high memory fragmentation ratio|X|X|-|-|-|
 |Redis low memory fragmentation ratio|X|X|-|-|-|
 |Redis rejected connections|X|X|-|-|-|
-|Redis hitrate|-|X|X|-|-|
+|Redis hitrate|X|X|X|-|-|
 
 
 ## smart-agent_solr

--- a/modules/smart-agent_redis/README.md
+++ b/modules/smart-agent_redis/README.md
@@ -87,7 +87,7 @@ This module creates the following SignalFx detectors which could contain one or 
 |Redis high memory fragmentation ratio|X|X|-|-|-|
 |Redis low memory fragmentation ratio|X|X|-|-|-|
 |Redis rejected connections|X|X|-|-|-|
-|Redis hitrate|-|X|X|-|-|
+|Redis hitrate|X|X|X|-|-|
 
 ## How to collect required metrics?
 

--- a/modules/smart-agent_redis/README.md
+++ b/modules/smart-agent_redis/README.md
@@ -87,7 +87,7 @@ This module creates the following SignalFx detectors which could contain one or 
 |Redis high memory fragmentation ratio|X|X|-|-|-|
 |Redis low memory fragmentation ratio|X|X|-|-|-|
 |Redis rejected connections|X|X|-|-|-|
-|Redis hitrate|X|X|-|-|-|
+|Redis hitrate|-|X|X|-|-|
 
 ## How to collect required metrics?
 

--- a/modules/smart-agent_redis/conf/10-hitrate.yaml
+++ b/modules/smart-agent_redis/conf/10-hitrate.yaml
@@ -14,12 +14,12 @@ signals:
     formula: (A/(A+B)).scale(100)
 
 rules:
-  critical:
+  major:
     threshold: 10
     comparator: '<'
     lasting_duration: 5m
-  major:
+  minor:
     threshold: 30
     comparator: '<'
     lasting_duration: 5m
-    dependency: critical
+    dependency: major

--- a/modules/smart-agent_redis/conf/10-hitrate.yaml
+++ b/modules/smart-agent_redis/conf/10-hitrate.yaml
@@ -14,10 +14,16 @@ signals:
     formula: (A/(A+B)).scale(100)
 
 rules:
+  critical:
+    threshold: 0
+    comparator: '<'
+    lasting_duration: 5m
+    disabled: true
   major:
     threshold: 10
     comparator: '<'
     lasting_duration: 5m
+    dependency: critical
   minor:
     threshold: 30
     comparator: '<'

--- a/modules/smart-agent_redis/detectors-gen.tf
+++ b/modules/smart-agent_redis/detectors-gen.tf
@@ -423,21 +423,9 @@ resource "signalfx_detector" "hitrate" {
     A = data('${var.use_otel_receiver ? "redis.keyspace.hits" : "counter.keyspace_hits"}', filter=${module.filtering.signalflow}, rollup='delta')${var.hitrate_aggregation_function}${var.hitrate_transformation_function}
     B = data('${var.use_otel_receiver ? "redis.keyspace.hits" : "counter.keyspace_hits"}', filter=${module.filtering.signalflow}, rollup='delta')${var.hitrate_aggregation_function}${var.hitrate_transformation_function}
     signal = (A/(A+B)).scale(100).publish('signal')
-    detect(when(signal < ${var.hitrate_threshold_critical}, lasting=%{if var.hitrate_lasting_duration_critical == null}None%{else}'${var.hitrate_lasting_duration_critical}'%{endif}, at_least=${var.hitrate_at_least_percentage_critical})).publish('CRIT')
-    detect(when(signal < ${var.hitrate_threshold_major}, lasting=%{if var.hitrate_lasting_duration_major == null}None%{else}'${var.hitrate_lasting_duration_major}'%{endif}, at_least=${var.hitrate_at_least_percentage_major}) and (not when(signal < ${var.hitrate_threshold_critical}, lasting=%{if var.hitrate_lasting_duration_critical == null}None%{else}'${var.hitrate_lasting_duration_critical}'%{endif}, at_least=${var.hitrate_at_least_percentage_critical}))).publish('MAJOR')
+    detect(when(signal < ${var.hitrate_threshold_major}, lasting=%{if var.hitrate_lasting_duration_major == null}None%{else}'${var.hitrate_lasting_duration_major}'%{endif}, at_least=${var.hitrate_at_least_percentage_major})).publish('MAJOR')
+    detect(when(signal < ${var.hitrate_threshold_minor}, lasting=%{if var.hitrate_lasting_duration_minor == null}None%{else}'${var.hitrate_lasting_duration_minor}'%{endif}, at_least=${var.hitrate_at_least_percentage_minor}) and (not when(signal < ${var.hitrate_threshold_major}, lasting=%{if var.hitrate_lasting_duration_major == null}None%{else}'${var.hitrate_lasting_duration_major}'%{endif}, at_least=${var.hitrate_at_least_percentage_major}))).publish('MINOR')
 EOF
-
-  rule {
-    description           = "is too low < ${var.hitrate_threshold_critical}%"
-    severity              = "Critical"
-    detect_label          = "CRIT"
-    disabled              = coalesce(var.hitrate_disabled_critical, var.hitrate_disabled, var.detectors_disabled)
-    notifications         = try(coalescelist(lookup(var.hitrate_notifications, "critical", []), var.notifications.critical), null)
-    runbook_url           = try(coalesce(var.hitrate_runbook_url, var.runbook_url), "")
-    tip                   = var.hitrate_tip
-    parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
-    parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
-  }
 
   rule {
     description           = "is too low < ${var.hitrate_threshold_major}%"
@@ -445,6 +433,18 @@ EOF
     detect_label          = "MAJOR"
     disabled              = coalesce(var.hitrate_disabled_major, var.hitrate_disabled, var.detectors_disabled)
     notifications         = try(coalescelist(lookup(var.hitrate_notifications, "major", []), var.notifications.major), null)
+    runbook_url           = try(coalesce(var.hitrate_runbook_url, var.runbook_url), "")
+    tip                   = var.hitrate_tip
+    parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
+    parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
+  }
+
+  rule {
+    description           = "is too low < ${var.hitrate_threshold_minor}%"
+    severity              = "Minor"
+    detect_label          = "MINOR"
+    disabled              = coalesce(var.hitrate_disabled_minor, var.hitrate_disabled, var.detectors_disabled)
+    notifications         = try(coalescelist(lookup(var.hitrate_notifications, "minor", []), var.notifications.minor), null)
     runbook_url           = try(coalesce(var.hitrate_runbook_url, var.runbook_url), "")
     tip                   = var.hitrate_tip
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject

--- a/modules/smart-agent_redis/variables-gen.tf
+++ b/modules/smart-agent_redis/variables-gen.tf
@@ -877,6 +877,12 @@ variable "hitrate_disabled" {
   default     = null
 }
 
+variable "hitrate_disabled_critical" {
+  description = "Disable critical alerting rule for hitrate detector"
+  type        = bool
+  default     = true
+}
+
 variable "hitrate_disabled_major" {
   description = "Disable major alerting rule for hitrate detector"
   type        = bool
@@ -889,6 +895,23 @@ variable "hitrate_disabled_minor" {
   default     = null
 }
 
+variable "hitrate_threshold_critical" {
+  description = "Critical threshold for hitrate detector in %"
+  type        = number
+  default     = 0
+}
+
+variable "hitrate_lasting_duration_critical" {
+  description = "Minimum duration that conditions must be true before raising alert"
+  type        = string
+  default     = "5m"
+}
+
+variable "hitrate_at_least_percentage_critical" {
+  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
+  type        = number
+  default     = 1
+}
 variable "hitrate_threshold_major" {
   description = "Major threshold for hitrate detector in %"
   type        = number

--- a/modules/smart-agent_redis/variables-gen.tf
+++ b/modules/smart-agent_redis/variables-gen.tf
@@ -877,39 +877,22 @@ variable "hitrate_disabled" {
   default     = null
 }
 
-variable "hitrate_disabled_critical" {
-  description = "Disable critical alerting rule for hitrate detector"
-  type        = bool
-  default     = null
-}
-
 variable "hitrate_disabled_major" {
   description = "Disable major alerting rule for hitrate detector"
   type        = bool
   default     = null
 }
 
-variable "hitrate_threshold_critical" {
-  description = "Critical threshold for hitrate detector in %"
-  type        = number
-  default     = 10
+variable "hitrate_disabled_minor" {
+  description = "Disable minor alerting rule for hitrate detector"
+  type        = bool
+  default     = null
 }
 
-variable "hitrate_lasting_duration_critical" {
-  description = "Minimum duration that conditions must be true before raising alert"
-  type        = string
-  default     = "5m"
-}
-
-variable "hitrate_at_least_percentage_critical" {
-  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
-  type        = number
-  default     = 1
-}
 variable "hitrate_threshold_major" {
   description = "Major threshold for hitrate detector in %"
   type        = number
-  default     = 30
+  default     = 10
 }
 
 variable "hitrate_lasting_duration_major" {
@@ -919,6 +902,23 @@ variable "hitrate_lasting_duration_major" {
 }
 
 variable "hitrate_at_least_percentage_major" {
+  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
+  type        = number
+  default     = 1
+}
+variable "hitrate_threshold_minor" {
+  description = "Minor threshold for hitrate detector in %"
+  type        = number
+  default     = 30
+}
+
+variable "hitrate_lasting_duration_minor" {
+  description = "Minimum duration that conditions must be true before raising alert"
+  type        = string
+  default     = "5m"
+}
+
+variable "hitrate_at_least_percentage_minor" {
   description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
   type        = number
   default     = 1


### PR DESCRIPTION
Other hitrate/hitratio detectors doesn't use critical level:

* https://github.com/claranet/terraform-signalfx-detectors/tree/master/modules/smart-agent_memcached#what-are-the-available-detectors-in-this-module
* https://github.com/claranet/terraform-signalfx-detectors/tree/master/modules/smart-agent_postgresql#what-are-the-available-detectors-in-this-module
* https://github.com/claranet/terraform-signalfx-detectors/tree/master/modules/smart-agent_varnish#what-are-the-available-detectors-in-this-module