### PR TITLE
change timeframe for heartbeat detector

### DIFF
--- a/modules/integration_azure-virtual-machine/variables.tf
+++ b/modules/integration_azure-virtual-machine/variables.tf
@@ -33,9 +33,9 @@ variable "heartbeat_notifications" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"20m\")"
   type        = string
-  default     = "10m"
+  default     = "20m"
 }
 
 variable "heartbeat_aggregation_function" {


### PR DESCRIPTION
We realize that occasionally Azure metrics don't always arrive quickly. Since we double the monitoring with an agent installed directly on the machines, we can increase this timeframe. This will avoid false positives due to lack of Azure metrics. 