### PR TITLE
feat(elasticache): Add NetworkConntrackAllowanceExceeded detector

### DIFF
--- a/docs/severity.md
+++ b/docs/severity.md
@@ -226,6 +226,7 @@
 |AWS ElastiCache redis cpu|X|X|-|-|-|
 |AWS ElastiCache redis replication lag|X|X|-|-|-|
 |AWS ElastiCache redis commands|-|X|-|-|-|
+|AWS ElastiCache redis network conntrack allowance exceeded|X|-|-|-|-|
 
 
 ## integration_aws-elasticsearch

--- a/modules/integration_aws-elasticache-redis/README.md
+++ b/modules/integration_aws-elasticache-redis/README.md
@@ -79,6 +79,7 @@ This module creates the following SignalFx detectors which could contain one or 
 |AWS ElastiCache redis cpu|X|X|-|-|-|
 |AWS ElastiCache redis replication lag|X|X|-|-|-|
 |AWS ElastiCache redis commands|-|X|-|-|-|
+|AWS ElastiCache redis network conntrack allowance exceeded|X|-|-|-|-|
 
 ## How to collect required metrics?
 
@@ -100,6 +101,7 @@ Here is the list of required metrics for detectors in this module.
 * `CacheMisses`
 * `EngineCPUUtilization`
 * `GetTypeCmds`
+* `NetworkConntrackAllowanceExceeded`
 * `ReplicationLag`
 * `SetTypeCmds`
 

--- a/modules/integration_aws-elasticache-redis/conf/05-network-conntrack-allowance.yaml
+++ b/modules/integration_aws-elasticache-redis/conf/05-network-conntrack-allowance.yaml
@@ -1,0 +1,15 @@
+module: AWS ElastiCache redis
+name: Network conntrack allowance exceeded
+
+transformation: true
+aggregation: true
+filtering: "filter('namespace', 'AWS/ElastiCache') and filter('stat', 'upper') and filter('CacheNodeId', '*')"
+
+signals:
+  signal:
+    metric: NetworkConntrackAllowanceExceeded
+
+rules:
+  critical:
+    threshold: 0
+    comparator: ">"

--- a/modules/integration_aws-elasticache-redis/outputs.tf
+++ b/modules/integration_aws-elasticache-redis/outputs.tf
@@ -13,6 +13,11 @@ output "cpu_high" {
   value       = signalfx_detector.cpu_high
 }
 
+output "network_conntrack_allowance_exceeded" {
+  description = "Detector resource for network_conntrack_allowance_exceeded"
+  value       = signalfx_detector.network_conntrack_allowance_exceeded
+}
+
 output "replication_lag" {
   description = "Detector resource for replication_lag"
   value       = signalfx_detector.replication_lag

--- a/modules/integration_aws-elasticache-redis/variables-gen.tf
+++ b/modules/integration_aws-elasticache-redis/variables-gen.tf
@@ -329,3 +329,64 @@ variable "commands_at_least_percentage_major" {
   type        = number
   default     = 1
 }
+# network_conntrack_allowance_exceeded detector
+
+variable "network_conntrack_allowance_exceeded_notifications" {
+  description = "Notification recipients list per severity overridden for network_conntrack_allowance_exceeded detector"
+  type        = map(list(string))
+  default     = {}
+}
+
+variable "network_conntrack_allowance_exceeded_aggregation_function" {
+  description = "Aggregation function and group by for network_conntrack_allowance_exceeded detector (i.e. \".mean(by=['host'])\")"
+  type        = string
+  default     = ""
+}
+
+variable "network_conntrack_allowance_exceeded_transformation_function" {
+  description = "Transformation function for network_conntrack_allowance_exceeded detector (i.e. \".mean(over='5m')\")"
+  type        = string
+  default     = ""
+}
+
+variable "network_conntrack_allowance_exceeded_max_delay" {
+  description = "Enforce max delay for network_conntrack_allowance_exceeded detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
+variable "network_conntrack_allowance_exceeded_tip" {
+  description = "Suggested first course of action or any note useful for incident handling"
+  type        = string
+  default     = ""
+}
+
+variable "network_conntrack_allowance_exceeded_runbook_url" {
+  description = "URL like SignalFx dashboard or wiki page which can help to troubleshoot the incident cause"
+  type        = string
+  default     = ""
+}
+
+variable "network_conntrack_allowance_exceeded_disabled" {
+  description = "Disable all alerting rules for network_conntrack_allowance_exceeded detector"
+  type        = bool
+  default     = null
+}
+
+variable "network_conntrack_allowance_exceeded_threshold_critical" {
+  description = "Critical threshold for network_conntrack_allowance_exceeded detector"
+  type        = number
+  default     = 0
+}
+
+variable "network_conntrack_allowance_exceeded_lasting_duration_critical" {
+  description = "Minimum duration that conditions must be true before raising alert"
+  type        = string
+  default     = null
+}
+
+variable "network_conntrack_allowance_exceeded_at_least_percentage_critical" {
+  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
+  type        = number
+  default     = 1
+}


### PR DESCRIPTION
Hello,

Detector created during an incident this week-end, relevant AWS documentation: https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/TroubleshootingConnections.html#Network-limits