### PR TITLE
Add Azure CDN detector

### DIFF
--- a/docs/severity.md
+++ b/docs/severity.md
@@ -32,6 +32,7 @@
 - [integration_azure-app-service](#integration_azure-app-service)
 - [integration_azure-application-gateway](#integration_azure-application-gateway)
 - [integration_azure-azure-search](#integration_azure-azure-search)
+- [integration_azure-cdn](#integration_azure-cdn)
 - [integration_azure-container-instance](#integration_azure-container-instance)
 - [integration_azure-cosmos-db](#integration_azure-cosmos-db)
 - [integration_azure-datafactory](#integration_azure-datafactory)
@@ -387,6 +388,13 @@
 |---|---|---|---|---|---|
 |Azure Search latency|X|X|-|-|-|
 |Azure Search throttled queries rate|X|X|-|-|-|
+
+
+## integration_azure-cdn
+
+|Detector|Critical|Major|Minor|Warning|Info|
+|---|---|---|---|---|---|
+|Azure CDN latency|X|X|-|-|-|
 
 
 ## integration_azure-container-instance

--- a/modules/integration_azure-cdn/README.md
+++ b/modules/integration_azure-cdn/README.md
@@ -1,0 +1,105 @@
+# AZURE-CDN SignalFx detectors
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+:link: **Contents**
+
+- [How to use this module?](#how-to-use-this-module)
+- [What are the available detectors in this module?](#what-are-the-available-detectors-in-this-module)
+- [How to collect required metrics?](#how-to-collect-required-metrics)
+  - [Metrics](#metrics)
+- [Related documentation](#related-documentation)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## How to use this module?
+
+This directory defines a [Terraform](https://www.terraform.io/)
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
+existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
+`module` configuration and setting its `source` parameter to URL of this folder:
+
+```hcl
+module "signalfx-detectors-integration-azure-cdn" {
+  source = "github.com/claranet/terraform-signalfx-detectors.git//modules/integration_azure-cdn?ref={revision}"
+
+  environment   = var.environment
+  notifications = local.notifications
+}
+```
+
+Note the following parameters:
+
+* `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
+  Terraform uses it to specify subfolders within a Git repo (see [module
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
+  this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
+  like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
+  [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
+  instead of `git` which is more flexible but less future-proof.
+
+* `environment`: Use this parameter to specify the
+  [environment](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#environment) used by this
+  instance of the module.
+  Its value will be added to the `prefixes` list at the start of the [detector
+  name](https://github.com/claranet/terraform-signalfx-detectors/wiki/Templating#example).
+  In general, it will also be used in the `filtering` internal sub-module to [apply
+  filters](https://github.com/claranet/terraform-signalfx-detectors/wiki/Guidance#filtering) based on our default
+  [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
+
+* `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
+  and its value is a list of recipients. Every recipients must respect the [detector notification
+  format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
+  Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
+  documentation to understand the recommended role of each severity.
+
+These 3 parameters alongs with all variables defined in [common-variables.tf](common-variables.tf) are common to all
+[modules](../) in this repository. Other variables, specific to this module, are available in
+[variables-gen.tf](variables-gen.tf).
+In general, the default configuration "works" but all of these Terraform
+[variables](https://www.terraform.io/language/values/variables) make it possible to
+customize the detectors behavior to better fit your needs.
+
+Most of them represent usual tips and rules detailled in the
+[guidance](https://github.com/claranet/terraform-signalfx-detectors/wiki/Guidance) documentation and listed in the
+common [variables](https://github.com/claranet/terraform-signalfx-detectors/wiki/Variables) dedicated documentation.
+
+Feel free to explore the [wiki](https://github.com/claranet/terraform-signalfx-detectors/wiki) for more information about
+general usage of this repository.
+
+## What are the available detectors in this module?
+
+This module creates the following SignalFx detectors which could contain one or multiple alerting rules:
+
+|Detector|Critical|Major|Minor|Warning|Info|
+|---|---|---|---|---|---|
+|Azure CDN latency|X|X|-|-|-|
+
+## How to collect required metrics?
+
+This module deploys detectors using metrics reported by the
+[Azure integration](https://docs.splunk.com/Observability/gdi/get-data-in/connect/azure/azure.html) configurable
+with [this Terraform module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/azure).
+
+
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
+
+
+
+### Metrics
+
+
+Here is the list of required metrics for detectors in this module.
+
+* `TotalLatency`
+
+
+
+
+## Related documentation
+
+* [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
+* [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)

--- a/modules/integration_azure-cdn/common-filters.tf
+++ b/modules/integration_azure-cdn/common-filters.tf
@@ -1,0 +1,1 @@
+../../common/module/filters-integration-azure.tf

--- a/modules/integration_azure-cdn/common-locals.tf
+++ b/modules/integration_azure-cdn/common-locals.tf
@@ -1,0 +1,1 @@
+../../common/module/locals.tf

--- a/modules/integration_azure-cdn/common-modules.tf
+++ b/modules/integration_azure-cdn/common-modules.tf
@@ -1,0 +1,1 @@
+../../common/module/modules.tf

--- a/modules/integration_azure-cdn/common-variables.tf
+++ b/modules/integration_azure-cdn/common-variables.tf
@@ -1,0 +1,1 @@
+../../common/module/variables.tf

--- a/modules/integration_azure-cdn/common-versions.tf
+++ b/modules/integration_azure-cdn/common-versions.tf
@@ -1,0 +1,1 @@
+../../common/module/versions.tf

--- a/modules/integration_azure-cdn/conf/00-latency.yaml
+++ b/modules/integration_azure-cdn/conf/00-latency.yaml
@@ -1,0 +1,17 @@
+module: Azure CDN
+name: latency
+filtering: "filter('resource_type', 'microsoft.cdn/profiles') and filter('primary_aggregation_type', 'true')"
+
+transformation: ".min(over='15m')"
+
+signals:
+  signal:
+    metric: "TotalLatency"
+rules:
+  critical:
+    threshold: 2000
+    comparator: ">"
+  major:
+    threshold: 4000
+    comparator: ">"
+    dependency: critical

--- a/modules/integration_azure-cdn/conf/00-latency.yaml
+++ b/modules/integration_azure-cdn/conf/00-latency.yaml
@@ -2,6 +2,7 @@ module: Azure CDN
 name: latency
 filtering: "filter('resource_type', 'microsoft.cdn/profiles') and filter('primary_aggregation_type', 'true')"
 id: cdn_total_latency
+value_unit: ms
 
 transformation: true
 aggregation: true
@@ -9,16 +10,15 @@ aggregation: true
 signals:
   signal:
     metric: "TotalLatency"
-    rollup: max
 
 rules:
   critical:
-    threshold: 1500
+    threshold: 3000
     comparator: ">"
     lasting_duration: 15m
 
   major:
-    threshold: 3000
+    threshold: 1500
     comparator: ">"
     dependency: critical
     lasting_duration: 15m

--- a/modules/integration_azure-cdn/conf/00-latency.yaml
+++ b/modules/integration_azure-cdn/conf/00-latency.yaml
@@ -2,16 +2,16 @@ module: Azure CDN
 name: latency
 filtering: "filter('resource_type', 'microsoft.cdn/profiles') and filter('primary_aggregation_type', 'true')"
 
-transformation: ".min(over='15m')"
+transformation: ".max(over='15m')"
 
 signals:
   signal:
     metric: "TotalLatency"
 rules:
   critical:
-    threshold: 2000
+    threshold: 1500
     comparator: ">"
   major:
-    threshold: 4000
+    threshold: 3000
     comparator: ">"
     dependency: critical

--- a/modules/integration_azure-cdn/conf/00-latency.yaml
+++ b/modules/integration_azure-cdn/conf/00-latency.yaml
@@ -1,17 +1,24 @@
 module: Azure CDN
 name: latency
 filtering: "filter('resource_type', 'microsoft.cdn/profiles') and filter('primary_aggregation_type', 'true')"
+id: cdn_total_latency
 
-transformation: ".max(over='15m')"
+transformation: true
+aggregation: true
 
 signals:
   signal:
     metric: "TotalLatency"
+    rollup: max
+
 rules:
   critical:
     threshold: 1500
     comparator: ">"
+    lasting_duration: 15m
+
   major:
     threshold: 3000
     comparator: ">"
     dependency: critical
+    lasting_duration: 15m

--- a/modules/integration_azure-cdn/conf/readme.yaml
+++ b/modules/integration_azure-cdn/conf/readme.yaml
@@ -1,0 +1,3 @@
+documentations:
+
+source_doc:

--- a/modules/integration_azure-cdn/detectors-gen.tf
+++ b/modules/integration_azure-cdn/detectors-gen.tf
@@ -1,0 +1,41 @@
+resource "signalfx_detector" "latency" {
+  name = format("%s %s", local.detector_name_prefix, "Azure CDN latency")
+
+  authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
+  tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
+
+  program_text = <<-EOF
+    base_filtering = filter('resource_type', 'microsoft.cdn/profiles') and filter('primary_aggregation_type', 'true')
+    signal = data('TotalLatency', filter=base_filtering and ${module.filtering.signalflow})${var.latency_aggregation_function}${var.latency_transformation_function}.publish('signal')
+    detect(when(signal > ${var.latency_threshold_critical}, lasting=%{if var.latency_lasting_duration_critical == null}None%{else}'${var.latency_lasting_duration_critical}'%{endif}, at_least=${var.latency_at_least_percentage_critical})).publish('CRIT')
+    detect(when(signal > ${var.latency_threshold_major}, lasting=%{if var.latency_lasting_duration_major == null}None%{else}'${var.latency_lasting_duration_major}'%{endif}, at_least=${var.latency_at_least_percentage_major}) and (not when(signal > ${var.latency_threshold_critical}, lasting=%{if var.latency_lasting_duration_critical == null}None%{else}'${var.latency_lasting_duration_critical}'%{endif}, at_least=${var.latency_at_least_percentage_critical}))).publish('MAJOR')
+EOF
+
+  rule {
+    description           = "is too high > ${var.latency_threshold_critical}"
+    severity              = "Critical"
+    detect_label          = "CRIT"
+    disabled              = coalesce(var.latency_disabled_critical, var.latency_disabled, var.detectors_disabled)
+    notifications         = try(coalescelist(lookup(var.latency_notifications, "critical", []), var.notifications.critical), null)
+    runbook_url           = try(coalesce(var.latency_runbook_url, var.runbook_url), "")
+    tip                   = var.latency_tip
+    parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
+    parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
+  }
+
+  rule {
+    description           = "is too high > ${var.latency_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.latency_disabled_major, var.latency_disabled, var.detectors_disabled)
+    notifications         = try(coalescelist(lookup(var.latency_notifications, "major", []), var.notifications.major), null)
+    runbook_url           = try(coalesce(var.latency_runbook_url, var.runbook_url), "")
+    tip                   = var.latency_tip
+    parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
+    parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
+  }
+
+  max_delay = var.latency_max_delay
+}
+

--- a/modules/integration_azure-cdn/detectors-gen.tf
+++ b/modules/integration_azure-cdn/detectors-gen.tf
@@ -1,4 +1,4 @@
-resource "signalfx_detector" "latency" {
+resource "signalfx_detector" "cdn_total_latency" {
   name = format("%s %s", local.detector_name_prefix, "Azure CDN latency")
 
   authorized_writer_teams = var.authorized_writer_teams
@@ -7,35 +7,35 @@ resource "signalfx_detector" "latency" {
 
   program_text = <<-EOF
     base_filtering = filter('resource_type', 'microsoft.cdn/profiles') and filter('primary_aggregation_type', 'true')
-    signal = data('TotalLatency', filter=base_filtering and ${module.filtering.signalflow})${var.latency_aggregation_function}${var.latency_transformation_function}.publish('signal')
-    detect(when(signal > ${var.latency_threshold_critical}, lasting=%{if var.latency_lasting_duration_critical == null}None%{else}'${var.latency_lasting_duration_critical}'%{endif}, at_least=${var.latency_at_least_percentage_critical})).publish('CRIT')
-    detect(when(signal > ${var.latency_threshold_major}, lasting=%{if var.latency_lasting_duration_major == null}None%{else}'${var.latency_lasting_duration_major}'%{endif}, at_least=${var.latency_at_least_percentage_major}) and (not when(signal > ${var.latency_threshold_critical}, lasting=%{if var.latency_lasting_duration_critical == null}None%{else}'${var.latency_lasting_duration_critical}'%{endif}, at_least=${var.latency_at_least_percentage_critical}))).publish('MAJOR')
+    signal = data('TotalLatency', filter=base_filtering and ${module.filtering.signalflow}, rollup='max')${var.cdn_total_latency_aggregation_function}${var.cdn_total_latency_transformation_function}.publish('signal')
+    detect(when(signal > ${var.cdn_total_latency_threshold_critical}, lasting=%{if var.cdn_total_latency_lasting_duration_critical == null}None%{else}'${var.cdn_total_latency_lasting_duration_critical}'%{endif}, at_least=${var.cdn_total_latency_at_least_percentage_critical})).publish('CRIT')
+    detect(when(signal > ${var.cdn_total_latency_threshold_major}, lasting=%{if var.cdn_total_latency_lasting_duration_major == null}None%{else}'${var.cdn_total_latency_lasting_duration_major}'%{endif}, at_least=${var.cdn_total_latency_at_least_percentage_major}) and (not when(signal > ${var.cdn_total_latency_threshold_critical}, lasting=%{if var.cdn_total_latency_lasting_duration_critical == null}None%{else}'${var.cdn_total_latency_lasting_duration_critical}'%{endif}, at_least=${var.cdn_total_latency_at_least_percentage_critical}))).publish('MAJOR')
 EOF
 
   rule {
-    description           = "is too high > ${var.latency_threshold_critical}"
+    description           = "is too high > ${var.cdn_total_latency_threshold_critical}"
     severity              = "Critical"
     detect_label          = "CRIT"
-    disabled              = coalesce(var.latency_disabled_critical, var.latency_disabled, var.detectors_disabled)
-    notifications         = try(coalescelist(lookup(var.latency_notifications, "critical", []), var.notifications.critical), null)
-    runbook_url           = try(coalesce(var.latency_runbook_url, var.runbook_url), "")
-    tip                   = var.latency_tip
+    disabled              = coalesce(var.cdn_total_latency_disabled_critical, var.cdn_total_latency_disabled, var.detectors_disabled)
+    notifications         = try(coalescelist(lookup(var.cdn_total_latency_notifications, "critical", []), var.notifications.critical), null)
+    runbook_url           = try(coalesce(var.cdn_total_latency_runbook_url, var.runbook_url), "")
+    tip                   = var.cdn_total_latency_tip
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
 
   rule {
-    description           = "is too high > ${var.latency_threshold_major}"
+    description           = "is too high > ${var.cdn_total_latency_threshold_major}"
     severity              = "Major"
     detect_label          = "MAJOR"
-    disabled              = coalesce(var.latency_disabled_major, var.latency_disabled, var.detectors_disabled)
-    notifications         = try(coalescelist(lookup(var.latency_notifications, "major", []), var.notifications.major), null)
-    runbook_url           = try(coalesce(var.latency_runbook_url, var.runbook_url), "")
-    tip                   = var.latency_tip
+    disabled              = coalesce(var.cdn_total_latency_disabled_major, var.cdn_total_latency_disabled, var.detectors_disabled)
+    notifications         = try(coalescelist(lookup(var.cdn_total_latency_notifications, "major", []), var.notifications.major), null)
+    runbook_url           = try(coalesce(var.cdn_total_latency_runbook_url, var.runbook_url), "")
+    tip                   = var.cdn_total_latency_tip
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
     parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
   }
 
-  max_delay = var.latency_max_delay
+  max_delay = var.cdn_total_latency_max_delay
 }
 

--- a/modules/integration_azure-cdn/detectors-gen.tf
+++ b/modules/integration_azure-cdn/detectors-gen.tf
@@ -5,15 +5,20 @@ resource "signalfx_detector" "cdn_total_latency" {
   teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
+  viz_options {
+    label        = "signal"
+    value_suffix = "ms"
+  }
+
   program_text = <<-EOF
     base_filtering = filter('resource_type', 'microsoft.cdn/profiles') and filter('primary_aggregation_type', 'true')
-    signal = data('TotalLatency', filter=base_filtering and ${module.filtering.signalflow}, rollup='max')${var.cdn_total_latency_aggregation_function}${var.cdn_total_latency_transformation_function}.publish('signal')
+    signal = data('TotalLatency', filter=base_filtering and ${module.filtering.signalflow})${var.cdn_total_latency_aggregation_function}${var.cdn_total_latency_transformation_function}.publish('signal')
     detect(when(signal > ${var.cdn_total_latency_threshold_critical}, lasting=%{if var.cdn_total_latency_lasting_duration_critical == null}None%{else}'${var.cdn_total_latency_lasting_duration_critical}'%{endif}, at_least=${var.cdn_total_latency_at_least_percentage_critical})).publish('CRIT')
     detect(when(signal > ${var.cdn_total_latency_threshold_major}, lasting=%{if var.cdn_total_latency_lasting_duration_major == null}None%{else}'${var.cdn_total_latency_lasting_duration_major}'%{endif}, at_least=${var.cdn_total_latency_at_least_percentage_major}) and (not when(signal > ${var.cdn_total_latency_threshold_critical}, lasting=%{if var.cdn_total_latency_lasting_duration_critical == null}None%{else}'${var.cdn_total_latency_lasting_duration_critical}'%{endif}, at_least=${var.cdn_total_latency_at_least_percentage_critical}))).publish('MAJOR')
 EOF
 
   rule {
-    description           = "is too high > ${var.cdn_total_latency_threshold_critical}"
+    description           = "is too high > ${var.cdn_total_latency_threshold_critical}ms"
     severity              = "Critical"
     detect_label          = "CRIT"
     disabled              = coalesce(var.cdn_total_latency_disabled_critical, var.cdn_total_latency_disabled, var.detectors_disabled)
@@ -25,7 +30,7 @@ EOF
   }
 
   rule {
-    description           = "is too high > ${var.cdn_total_latency_threshold_major}"
+    description           = "is too high > ${var.cdn_total_latency_threshold_major}ms"
     severity              = "Major"
     detect_label          = "MAJOR"
     disabled              = coalesce(var.cdn_total_latency_disabled_major, var.cdn_total_latency_disabled, var.detectors_disabled)

--- a/modules/integration_azure-cdn/outputs.tf
+++ b/modules/integration_azure-cdn/outputs.tf
@@ -1,5 +1,5 @@
-output "latency" {
-  description = "Detector resource for latency"
-  value       = signalfx_detector.latency
+output "cdn_total_latency" {
+  description = "Detector resource for cdn_total_latency"
+  value       = signalfx_detector.cdn_total_latency
 }
 

--- a/modules/integration_azure-cdn/outputs.tf
+++ b/modules/integration_azure-cdn/outputs.tf
@@ -1,0 +1,5 @@
+output "latency" {
+  description = "Detector resource for latency"
+  value       = signalfx_detector.latency
+}
+

--- a/modules/integration_azure-cdn/tags.tf
+++ b/modules/integration_azure-cdn/tags.tf
@@ -1,0 +1,4 @@
+locals {
+  tags = ["integration", "azure-cdn"]
+}
+

--- a/modules/integration_azure-cdn/variables-gen.tf
+++ b/modules/integration_azure-cdn/variables-gen.tf
@@ -1,0 +1,90 @@
+# latency detector
+
+variable "latency_notifications" {
+  description = "Notification recipients list per severity overridden for latency detector"
+  type        = map(list(string))
+  default     = {}
+}
+
+variable "latency_aggregation_function" {
+  description = "Aggregation function and group by for latency detector (i.e. \".mean(by=['host'])\")"
+  type        = string
+  default     = ""
+}
+
+variable "latency_transformation_function" {
+  description = "Transformation function for latency detector (i.e. \".mean(over='5m')\")"
+  type        = string
+  default     = ".min(over='15m')"
+}
+
+variable "latency_max_delay" {
+  description = "Enforce max delay for latency detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
+variable "latency_tip" {
+  description = "Suggested first course of action or any note useful for incident handling"
+  type        = string
+  default     = ""
+}
+
+variable "latency_runbook_url" {
+  description = "URL like SignalFx dashboard or wiki page which can help to troubleshoot the incident cause"
+  type        = string
+  default     = ""
+}
+
+variable "latency_disabled" {
+  description = "Disable all alerting rules for latency detector"
+  type        = bool
+  default     = null
+}
+
+variable "latency_disabled_critical" {
+  description = "Disable critical alerting rule for latency detector"
+  type        = bool
+  default     = null
+}
+
+variable "latency_disabled_major" {
+  description = "Disable major alerting rule for latency detector"
+  type        = bool
+  default     = null
+}
+
+variable "latency_threshold_critical" {
+  description = "Critical threshold for latency detector"
+  type        = number
+  default     = 2000
+}
+
+variable "latency_lasting_duration_critical" {
+  description = "Minimum duration that conditions must be true before raising alert"
+  type        = string
+  default     = null
+}
+
+variable "latency_at_least_percentage_critical" {
+  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
+  type        = number
+  default     = 1
+}
+variable "latency_threshold_major" {
+  description = "Major threshold for latency detector"
+  type        = number
+  default     = 4000
+}
+
+variable "latency_lasting_duration_major" {
+  description = "Minimum duration that conditions must be true before raising alert"
+  type        = string
+  default     = null
+}
+
+variable "latency_at_least_percentage_major" {
+  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
+  type        = number
+  default     = 1
+}

--- a/modules/integration_azure-cdn/variables-gen.tf
+++ b/modules/integration_azure-cdn/variables-gen.tf
@@ -1,89 +1,89 @@
-# latency detector
+# cdn_total_latency detector
 
-variable "latency_notifications" {
-  description = "Notification recipients list per severity overridden for latency detector"
+variable "cdn_total_latency_notifications" {
+  description = "Notification recipients list per severity overridden for cdn_total_latency detector"
   type        = map(list(string))
   default     = {}
 }
 
-variable "latency_aggregation_function" {
-  description = "Aggregation function and group by for latency detector (i.e. \".mean(by=['host'])\")"
+variable "cdn_total_latency_aggregation_function" {
+  description = "Aggregation function and group by for cdn_total_latency detector (i.e. \".mean(by=['host'])\")"
   type        = string
   default     = ""
 }
 
-variable "latency_transformation_function" {
-  description = "Transformation function for latency detector (i.e. \".mean(over='5m')\")"
+variable "cdn_total_latency_transformation_function" {
+  description = "Transformation function for cdn_total_latency detector (i.e. \".mean(over='5m')\")"
   type        = string
-  default     = ".max(over='15m')"
+  default     = ""
 }
 
-variable "latency_max_delay" {
-  description = "Enforce max delay for latency detector (use \"0\" or \"null\" for \"Auto\")"
+variable "cdn_total_latency_max_delay" {
+  description = "Enforce max delay for cdn_total_latency detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
   default     = null
 }
 
-variable "latency_tip" {
+variable "cdn_total_latency_tip" {
   description = "Suggested first course of action or any note useful for incident handling"
   type        = string
   default     = ""
 }
 
-variable "latency_runbook_url" {
+variable "cdn_total_latency_runbook_url" {
   description = "URL like SignalFx dashboard or wiki page which can help to troubleshoot the incident cause"
   type        = string
   default     = ""
 }
 
-variable "latency_disabled" {
-  description = "Disable all alerting rules for latency detector"
+variable "cdn_total_latency_disabled" {
+  description = "Disable all alerting rules for cdn_total_latency detector"
   type        = bool
   default     = null
 }
 
-variable "latency_disabled_critical" {
-  description = "Disable critical alerting rule for latency detector"
+variable "cdn_total_latency_disabled_critical" {
+  description = "Disable critical alerting rule for cdn_total_latency detector"
   type        = bool
   default     = null
 }
 
-variable "latency_disabled_major" {
-  description = "Disable major alerting rule for latency detector"
+variable "cdn_total_latency_disabled_major" {
+  description = "Disable major alerting rule for cdn_total_latency detector"
   type        = bool
   default     = null
 }
 
-variable "latency_threshold_critical" {
-  description = "Critical threshold for latency detector"
+variable "cdn_total_latency_threshold_critical" {
+  description = "Critical threshold for cdn_total_latency detector"
   type        = number
   default     = 1500
 }
 
-variable "latency_lasting_duration_critical" {
+variable "cdn_total_latency_lasting_duration_critical" {
   description = "Minimum duration that conditions must be true before raising alert"
   type        = string
-  default     = null
+  default     = "15m"
 }
 
-variable "latency_at_least_percentage_critical" {
+variable "cdn_total_latency_at_least_percentage_critical" {
   description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
   type        = number
   default     = 1
 }
-variable "latency_threshold_major" {
-  description = "Major threshold for latency detector"
+variable "cdn_total_latency_threshold_major" {
+  description = "Major threshold for cdn_total_latency detector"
   type        = number
   default     = 3000
 }
 
-variable "latency_lasting_duration_major" {
+variable "cdn_total_latency_lasting_duration_major" {
   description = "Minimum duration that conditions must be true before raising alert"
   type        = string
-  default     = null
+  default     = "15m"
 }
 
-variable "latency_at_least_percentage_major" {
+variable "cdn_total_latency_at_least_percentage_major" {
   description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
   type        = number
   default     = 1

--- a/modules/integration_azure-cdn/variables-gen.tf
+++ b/modules/integration_azure-cdn/variables-gen.tf
@@ -55,9 +55,9 @@ variable "cdn_total_latency_disabled_major" {
 }
 
 variable "cdn_total_latency_threshold_critical" {
-  description = "Critical threshold for cdn_total_latency detector"
+  description = "Critical threshold for cdn_total_latency detector in ms"
   type        = number
-  default     = 1500
+  default     = 3000
 }
 
 variable "cdn_total_latency_lasting_duration_critical" {
@@ -72,9 +72,9 @@ variable "cdn_total_latency_at_least_percentage_critical" {
   default     = 1
 }
 variable "cdn_total_latency_threshold_major" {
-  description = "Major threshold for cdn_total_latency detector"
+  description = "Major threshold for cdn_total_latency detector in ms"
   type        = number
-  default     = 3000
+  default     = 1500
 }
 
 variable "cdn_total_latency_lasting_duration_major" {

--- a/modules/integration_azure-cdn/variables-gen.tf
+++ b/modules/integration_azure-cdn/variables-gen.tf
@@ -15,7 +15,7 @@ variable "latency_aggregation_function" {
 variable "latency_transformation_function" {
   description = "Transformation function for latency detector (i.e. \".mean(over='5m')\")"
   type        = string
-  default     = ".min(over='15m')"
+  default     = ".max(over='15m')"
 }
 
 variable "latency_max_delay" {
@@ -57,7 +57,7 @@ variable "latency_disabled_major" {
 variable "latency_threshold_critical" {
   description = "Critical threshold for latency detector"
   type        = number
-  default     = 2000
+  default     = 1500
 }
 
 variable "latency_lasting_duration_critical" {
@@ -74,7 +74,7 @@ variable "latency_at_least_percentage_critical" {
 variable "latency_threshold_major" {
   description = "Major threshold for latency detector"
   type        = number
-  default     = 4000
+  default     = 3000
 }
 
 variable "latency_lasting_duration_major" {

--- a/modules/integration_azure-datafactory/README.md
+++ b/modules/integration_azure-datafactory/README.md
@@ -105,8 +105,8 @@ Here is the list of required metrics for detectors in this module.
 * `IntegrationRuntimeCpuPercentage`
 * `PipelineFailedRuns`
 * `PipelineSucceededRuns`
-* `triggerFailedRuns`
-* `triggerSucceededRuns`
+* `TriggerFailedRuns`
+* `TriggerSucceededRuns`
 
 
 ## Notes

--- a/modules/integration_azure-sql-database/README.md
+++ b/modules/integration_azure-sql-database/README.md
@@ -97,10 +97,10 @@ Check the [Related documentation](#related-documentation) section for more detai
 
 Here is the list of required metrics for detectors in this module.
 
-* `connection_successful`
 * `cpu_percent`
 * `deadlock`
 * `dtu_consumption_percent`
+* `sessions_count`
 * `storage_percent`
 
 


### PR DESCRIPTION
Add the Azure CDN classic integration module.
This module aims to supervise the CDN resource of Azure (microsoft.cdn/profiles). For the moment only the latency is supervised. 