### PR TITLE
Fix dependency rules

### DIFF
--- a/modules/integration_aws-rds-common/conf/05-dbload.yaml
+++ b/modules/integration_aws-rds-common/conf/05-dbload.yaml
@@ -11,12 +11,12 @@ signals:
   signal:
     metric: "DBLoad"
 rules:
-  major:
-    threshold: 80
-    comparator: ">"
-    lasting_duration: '5m'
   critical:
     threshold: 90
     comparator: ">"
     lasting_duration: '5m'
-    dependency: major
+  major:
+    threshold: 80
+    comparator: ">"
+    lasting_duration: '5m'
+    dependency: critical

--- a/modules/integration_aws-rds-common/detectors-gen.tf
+++ b/modules/integration_aws-rds-common/detectors-gen.tf
@@ -13,21 +13,9 @@ resource "signalfx_detector" "dbload" {
   program_text = <<-EOF
     base_filtering = filter('namespace', 'AWS/RDS')
     signal = data('DBLoad', filter=base_filtering and ${module.filtering.signalflow})${var.dbload_aggregation_function}${var.dbload_transformation_function}.publish('signal')
-    detect(when(signal > ${var.dbload_threshold_major}, lasting=%{if var.dbload_lasting_duration_major == null}None%{else}'${var.dbload_lasting_duration_major}'%{endif}, at_least=${var.dbload_at_least_percentage_major})).publish('MAJOR')
-    detect(when(signal > ${var.dbload_threshold_critical}, lasting=%{if var.dbload_lasting_duration_critical == null}None%{else}'${var.dbload_lasting_duration_critical}'%{endif}, at_least=${var.dbload_at_least_percentage_critical}) and (not when(signal > ${var.dbload_threshold_major}, lasting=%{if var.dbload_lasting_duration_major == null}None%{else}'${var.dbload_lasting_duration_major}'%{endif}, at_least=${var.dbload_at_least_percentage_major}))).publish('CRIT')
+    detect(when(signal > ${var.dbload_threshold_critical}, lasting=%{if var.dbload_lasting_duration_critical == null}None%{else}'${var.dbload_lasting_duration_critical}'%{endif}, at_least=${var.dbload_at_least_percentage_critical})).publish('CRIT')
+    detect(when(signal > ${var.dbload_threshold_major}, lasting=%{if var.dbload_lasting_duration_major == null}None%{else}'${var.dbload_lasting_duration_major}'%{endif}, at_least=${var.dbload_at_least_percentage_major}) and (not when(signal > ${var.dbload_threshold_critical}, lasting=%{if var.dbload_lasting_duration_critical == null}None%{else}'${var.dbload_lasting_duration_critical}'%{endif}, at_least=${var.dbload_at_least_percentage_critical}))).publish('MAJOR')
 EOF
-
-  rule {
-    description           = "is too high > ${var.dbload_threshold_major}%"
-    severity              = "Major"
-    detect_label          = "MAJOR"
-    disabled              = coalesce(var.dbload_disabled_major, var.dbload_disabled, var.detectors_disabled)
-    notifications         = try(coalescelist(lookup(var.dbload_notifications, "major", []), var.notifications.major), null)
-    runbook_url           = try(coalesce(var.dbload_runbook_url, var.runbook_url), "")
-    tip                   = var.dbload_tip
-    parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
-    parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
-  }
 
   rule {
     description           = "is too high > ${var.dbload_threshold_critical}%"
@@ -35,6 +23,18 @@ EOF
     detect_label          = "CRIT"
     disabled              = coalesce(var.dbload_disabled_critical, var.dbload_disabled, var.detectors_disabled)
     notifications         = try(coalescelist(lookup(var.dbload_notifications, "critical", []), var.notifications.critical), null)
+    runbook_url           = try(coalesce(var.dbload_runbook_url, var.runbook_url), "")
+    tip                   = var.dbload_tip
+    parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
+    parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
+  }
+
+  rule {
+    description           = "is too high > ${var.dbload_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.dbload_disabled_major, var.dbload_disabled, var.detectors_disabled)
+    notifications         = try(coalescelist(lookup(var.dbload_notifications, "major", []), var.notifications.major), null)
     runbook_url           = try(coalesce(var.dbload_runbook_url, var.runbook_url), "")
     tip                   = var.dbload_tip
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject

--- a/modules/integration_aws-rds-common/variables-gen.tf
+++ b/modules/integration_aws-rds-common/variables-gen.tf
@@ -42,35 +42,18 @@ variable "dbload_disabled" {
   default     = null
 }
 
-variable "dbload_disabled_major" {
-  description = "Disable major alerting rule for dbload detector"
-  type        = bool
-  default     = null
-}
-
 variable "dbload_disabled_critical" {
   description = "Disable critical alerting rule for dbload detector"
   type        = bool
   default     = null
 }
 
-variable "dbload_threshold_major" {
-  description = "Major threshold for dbload detector in %"
-  type        = number
-  default     = 80
+variable "dbload_disabled_major" {
+  description = "Disable major alerting rule for dbload detector"
+  type        = bool
+  default     = null
 }
 
-variable "dbload_lasting_duration_major" {
-  description = "Minimum duration that conditions must be true before raising alert"
-  type        = string
-  default     = "5m"
-}
-
-variable "dbload_at_least_percentage_major" {
-  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
-  type        = number
-  default     = 1
-}
 variable "dbload_threshold_critical" {
   description = "Critical threshold for dbload detector in %"
   type        = number
@@ -84,6 +67,23 @@ variable "dbload_lasting_duration_critical" {
 }
 
 variable "dbload_at_least_percentage_critical" {
+  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
+  type        = number
+  default     = 1
+}
+variable "dbload_threshold_major" {
+  description = "Major threshold for dbload detector in %"
+  type        = number
+  default     = 80
+}
+
+variable "dbload_lasting_duration_major" {
+  description = "Minimum duration that conditions must be true before raising alert"
+  type        = string
+  default     = "5m"
+}
+
+variable "dbload_at_least_percentage_major" {
   description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
   type        = number
   default     = 1

--- a/modules/integration_aws-redshift/conf/01-cpu.yaml
+++ b/modules/integration_aws-redshift/conf/01-cpu.yaml
@@ -13,12 +13,12 @@ signals:
     filter: "filter('stat', 'mean') and filter('ClusterIdentifier', '*') and filter('NodeID', '*')"
 
 rules:
-  major:
-    threshold: 80
-    comparator: ">"
-    lasting_duration: "15m"
   critical:
     threshold: 90
     comparator: ">"
     lasting_duration: "15m"
-    dependency: major
+  major:
+    threshold: 80
+    comparator: ">"
+    lasting_duration: "15m"
+    dependency: critical

--- a/modules/integration_aws-redshift/variables-gen.tf
+++ b/modules/integration_aws-redshift/variables-gen.tf
@@ -86,35 +86,18 @@ variable "cpu_usage_disabled" {
   default     = null
 }
 
-variable "cpu_usage_disabled_major" {
-  description = "Disable major alerting rule for cpu_usage detector"
-  type        = bool
-  default     = null
-}
-
 variable "cpu_usage_disabled_critical" {
   description = "Disable critical alerting rule for cpu_usage detector"
   type        = bool
   default     = null
 }
 
-variable "cpu_usage_threshold_major" {
-  description = "Major threshold for cpu_usage detector in %"
-  type        = number
-  default     = 80
+variable "cpu_usage_disabled_major" {
+  description = "Disable major alerting rule for cpu_usage detector"
+  type        = bool
+  default     = null
 }
 
-variable "cpu_usage_lasting_duration_major" {
-  description = "Minimum duration that conditions must be true before raising alert"
-  type        = string
-  default     = "15m"
-}
-
-variable "cpu_usage_at_least_percentage_major" {
-  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
-  type        = number
-  default     = 1
-}
 variable "cpu_usage_threshold_critical" {
   description = "Critical threshold for cpu_usage detector in %"
   type        = number
@@ -128,6 +111,23 @@ variable "cpu_usage_lasting_duration_critical" {
 }
 
 variable "cpu_usage_at_least_percentage_critical" {
+  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
+  type        = number
+  default     = 1
+}
+variable "cpu_usage_threshold_major" {
+  description = "Major threshold for cpu_usage detector in %"
+  type        = number
+  default     = 80
+}
+
+variable "cpu_usage_lasting_duration_major" {
+  description = "Minimum duration that conditions must be true before raising alert"
+  type        = string
+  default     = "15m"
+}
+
+variable "cpu_usage_at_least_percentage_major" {
   description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
   type        = number
   default     = 1

--- a/modules/integration_azure-flexible-mysql/conf/01-cpu.yaml
+++ b/modules/integration_azure-flexible-mysql/conf/01-cpu.yaml
@@ -13,13 +13,13 @@ signals:
   signal:
     metric: "cpu_percent"
 rules:
-  major:
-    threshold: 80
-    comparator: ">"
-    lasting_duration: '15m'
   critical:
     threshold: 90
     comparator: ">"
     lasting_duration: '15m'
-    dependency: major
+  major:
+    threshold: 80
+    comparator: ">"
+    lasting_duration: '15m'
+    dependency: critical
 ...

--- a/modules/integration_azure-flexible-mysql/conf/02-free-storage.yaml
+++ b/modules/integration_azure-flexible-mysql/conf/02-free-storage.yaml
@@ -13,13 +13,13 @@ signals:
   signal:
     metric: "storage_percent"
 rules:
-  major:
-    threshold: 80
-    comparator: ">"
-    lasting_duration: '15m'
   critical:
     threshold: 90
     comparator: ">"
     lasting_duration: '15m'
-    dependency: major
+  major:
+    threshold: 80
+    comparator: ">"
+    lasting_duration: '15m'
+    dependency: critical
 ...

--- a/modules/integration_azure-flexible-mysql/conf/03-io-conso.yaml
+++ b/modules/integration_azure-flexible-mysql/conf/03-io-conso.yaml
@@ -13,13 +13,13 @@ signals:
   signal:
     metric: "io_consumption_percent"
 rules:
-  major:
-    threshold: 80
-    comparator: ">"
-    lasting_duration: '15m'
   critical:
     threshold: 90
     comparator: ">"
     lasting_duration: '15m'
-    dependency: major
+  major:
+    threshold: 80
+    comparator: ">"
+    lasting_duration: '15m'
+    dependency: critical
 ...

--- a/modules/integration_azure-flexible-mysql/conf/05-replication-lag.yaml
+++ b/modules/integration_azure-flexible-mysql/conf/05-replication-lag.yaml
@@ -12,13 +12,13 @@ signals:
   signal:
     metric: "seconds_behind_master"
 rules:
-  major:
-    threshold: 100
-    comparator: ">"
-    lasting_duration: '15m'
   critical:
     threshold: 200
     comparator: ">"
     lasting_duration: '15m'
-    dependency: major
+  major:
+    threshold: 100
+    comparator: ">"
+    lasting_duration: '15m'
+    dependency: critical
 ...

--- a/modules/integration_azure-flexible-mysql/detectors-gen.tf
+++ b/modules/integration_azure-flexible-mysql/detectors-gen.tf
@@ -42,21 +42,9 @@ resource "signalfx_detector" "cpu" {
   program_text = <<-EOF
     base_filtering = filter('resource_type', 'Microsoft.DBforMySQL/flexibleServers') and filter('primary_aggregation_type', 'true')
     signal = data('cpu_percent', filter=base_filtering and ${module.filtering.signalflow})${var.cpu_aggregation_function}${var.cpu_transformation_function}.publish('signal')
-    detect(when(signal > ${var.cpu_threshold_major}, lasting=%{if var.cpu_lasting_duration_major == null}None%{else}'${var.cpu_lasting_duration_major}'%{endif}, at_least=${var.cpu_at_least_percentage_major})).publish('MAJOR')
-    detect(when(signal > ${var.cpu_threshold_critical}, lasting=%{if var.cpu_lasting_duration_critical == null}None%{else}'${var.cpu_lasting_duration_critical}'%{endif}, at_least=${var.cpu_at_least_percentage_critical}) and (not when(signal > ${var.cpu_threshold_major}, lasting=%{if var.cpu_lasting_duration_major == null}None%{else}'${var.cpu_lasting_duration_major}'%{endif}, at_least=${var.cpu_at_least_percentage_major}))).publish('CRIT')
+    detect(when(signal > ${var.cpu_threshold_critical}, lasting=%{if var.cpu_lasting_duration_critical == null}None%{else}'${var.cpu_lasting_duration_critical}'%{endif}, at_least=${var.cpu_at_least_percentage_critical})).publish('CRIT')
+    detect(when(signal > ${var.cpu_threshold_major}, lasting=%{if var.cpu_lasting_duration_major == null}None%{else}'${var.cpu_lasting_duration_major}'%{endif}, at_least=${var.cpu_at_least_percentage_major}) and (not when(signal > ${var.cpu_threshold_critical}, lasting=%{if var.cpu_lasting_duration_critical == null}None%{else}'${var.cpu_lasting_duration_critical}'%{endif}, at_least=${var.cpu_at_least_percentage_critical}))).publish('MAJOR')
 EOF
-
-  rule {
-    description           = "is too high > ${var.cpu_threshold_major}%"
-    severity              = "Major"
-    detect_label          = "MAJOR"
-    disabled              = coalesce(var.cpu_disabled_major, var.cpu_disabled, var.detectors_disabled)
-    notifications         = try(coalescelist(lookup(var.cpu_notifications, "major", []), var.notifications.major), null)
-    runbook_url           = try(coalesce(var.cpu_runbook_url, var.runbook_url), "")
-    tip                   = var.cpu_tip
-    parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
-    parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
-  }
 
   rule {
     description           = "is too high > ${var.cpu_threshold_critical}%"
@@ -64,6 +52,18 @@ EOF
     detect_label          = "CRIT"
     disabled              = coalesce(var.cpu_disabled_critical, var.cpu_disabled, var.detectors_disabled)
     notifications         = try(coalescelist(lookup(var.cpu_notifications, "critical", []), var.notifications.critical), null)
+    runbook_url           = try(coalesce(var.cpu_runbook_url, var.runbook_url), "")
+    tip                   = var.cpu_tip
+    parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
+    parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
+  }
+
+  rule {
+    description           = "is too high > ${var.cpu_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.cpu_disabled_major, var.cpu_disabled, var.detectors_disabled)
+    notifications         = try(coalescelist(lookup(var.cpu_notifications, "major", []), var.notifications.major), null)
     runbook_url           = try(coalesce(var.cpu_runbook_url, var.runbook_url), "")
     tip                   = var.cpu_tip
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
@@ -88,21 +88,9 @@ resource "signalfx_detector" "storage" {
   program_text = <<-EOF
     base_filtering = filter('resource_type', 'Microsoft.DBforMySQL/flexibleServers') and filter('primary_aggregation_type', 'true')
     signal = data('storage_percent', filter=base_filtering and ${module.filtering.signalflow})${var.storage_aggregation_function}${var.storage_transformation_function}.publish('signal')
-    detect(when(signal > ${var.storage_threshold_major}, lasting=%{if var.storage_lasting_duration_major == null}None%{else}'${var.storage_lasting_duration_major}'%{endif}, at_least=${var.storage_at_least_percentage_major})).publish('MAJOR')
-    detect(when(signal > ${var.storage_threshold_critical}, lasting=%{if var.storage_lasting_duration_critical == null}None%{else}'${var.storage_lasting_duration_critical}'%{endif}, at_least=${var.storage_at_least_percentage_critical}) and (not when(signal > ${var.storage_threshold_major}, lasting=%{if var.storage_lasting_duration_major == null}None%{else}'${var.storage_lasting_duration_major}'%{endif}, at_least=${var.storage_at_least_percentage_major}))).publish('CRIT')
+    detect(when(signal > ${var.storage_threshold_critical}, lasting=%{if var.storage_lasting_duration_critical == null}None%{else}'${var.storage_lasting_duration_critical}'%{endif}, at_least=${var.storage_at_least_percentage_critical})).publish('CRIT')
+    detect(when(signal > ${var.storage_threshold_major}, lasting=%{if var.storage_lasting_duration_major == null}None%{else}'${var.storage_lasting_duration_major}'%{endif}, at_least=${var.storage_at_least_percentage_major}) and (not when(signal > ${var.storage_threshold_critical}, lasting=%{if var.storage_lasting_duration_critical == null}None%{else}'${var.storage_lasting_duration_critical}'%{endif}, at_least=${var.storage_at_least_percentage_critical}))).publish('MAJOR')
 EOF
-
-  rule {
-    description           = "is too high > ${var.storage_threshold_major}%"
-    severity              = "Major"
-    detect_label          = "MAJOR"
-    disabled              = coalesce(var.storage_disabled_major, var.storage_disabled, var.detectors_disabled)
-    notifications         = try(coalescelist(lookup(var.storage_notifications, "major", []), var.notifications.major), null)
-    runbook_url           = try(coalesce(var.storage_runbook_url, var.runbook_url), "")
-    tip                   = var.storage_tip
-    parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
-    parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
-  }
 
   rule {
     description           = "is too high > ${var.storage_threshold_critical}%"
@@ -110,6 +98,18 @@ EOF
     detect_label          = "CRIT"
     disabled              = coalesce(var.storage_disabled_critical, var.storage_disabled, var.detectors_disabled)
     notifications         = try(coalescelist(lookup(var.storage_notifications, "critical", []), var.notifications.critical), null)
+    runbook_url           = try(coalesce(var.storage_runbook_url, var.runbook_url), "")
+    tip                   = var.storage_tip
+    parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
+    parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
+  }
+
+  rule {
+    description           = "is too high > ${var.storage_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.storage_disabled_major, var.storage_disabled, var.detectors_disabled)
+    notifications         = try(coalescelist(lookup(var.storage_notifications, "major", []), var.notifications.major), null)
     runbook_url           = try(coalesce(var.storage_runbook_url, var.runbook_url), "")
     tip                   = var.storage_tip
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
@@ -134,21 +134,9 @@ resource "signalfx_detector" "io" {
   program_text = <<-EOF
     base_filtering = filter('resource_type', 'Microsoft.DBforMySQL/flexibleServers') and filter('primary_aggregation_type', 'true')
     signal = data('io_consumption_percent', filter=base_filtering and ${module.filtering.signalflow})${var.io_aggregation_function}${var.io_transformation_function}.publish('signal')
-    detect(when(signal > ${var.io_threshold_major}, lasting=%{if var.io_lasting_duration_major == null}None%{else}'${var.io_lasting_duration_major}'%{endif}, at_least=${var.io_at_least_percentage_major})).publish('MAJOR')
-    detect(when(signal > ${var.io_threshold_critical}, lasting=%{if var.io_lasting_duration_critical == null}None%{else}'${var.io_lasting_duration_critical}'%{endif}, at_least=${var.io_at_least_percentage_critical}) and (not when(signal > ${var.io_threshold_major}, lasting=%{if var.io_lasting_duration_major == null}None%{else}'${var.io_lasting_duration_major}'%{endif}, at_least=${var.io_at_least_percentage_major}))).publish('CRIT')
+    detect(when(signal > ${var.io_threshold_critical}, lasting=%{if var.io_lasting_duration_critical == null}None%{else}'${var.io_lasting_duration_critical}'%{endif}, at_least=${var.io_at_least_percentage_critical})).publish('CRIT')
+    detect(when(signal > ${var.io_threshold_major}, lasting=%{if var.io_lasting_duration_major == null}None%{else}'${var.io_lasting_duration_major}'%{endif}, at_least=${var.io_at_least_percentage_major}) and (not when(signal > ${var.io_threshold_critical}, lasting=%{if var.io_lasting_duration_critical == null}None%{else}'${var.io_lasting_duration_critical}'%{endif}, at_least=${var.io_at_least_percentage_critical}))).publish('MAJOR')
 EOF
-
-  rule {
-    description           = "is too high > ${var.io_threshold_major}%"
-    severity              = "Major"
-    detect_label          = "MAJOR"
-    disabled              = coalesce(var.io_disabled_major, var.io_disabled, var.detectors_disabled)
-    notifications         = try(coalescelist(lookup(var.io_notifications, "major", []), var.notifications.major), null)
-    runbook_url           = try(coalesce(var.io_runbook_url, var.runbook_url), "")
-    tip                   = var.io_tip
-    parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
-    parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
-  }
 
   rule {
     description           = "is too high > ${var.io_threshold_critical}%"
@@ -156,6 +144,18 @@ EOF
     detect_label          = "CRIT"
     disabled              = coalesce(var.io_disabled_critical, var.io_disabled, var.detectors_disabled)
     notifications         = try(coalescelist(lookup(var.io_notifications, "critical", []), var.notifications.critical), null)
+    runbook_url           = try(coalesce(var.io_runbook_url, var.runbook_url), "")
+    tip                   = var.io_tip
+    parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
+    parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
+  }
+
+  rule {
+    description           = "is too high > ${var.io_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.io_disabled_major, var.io_disabled, var.detectors_disabled)
+    notifications         = try(coalescelist(lookup(var.io_notifications, "major", []), var.notifications.major), null)
     runbook_url           = try(coalesce(var.io_runbook_url, var.runbook_url), "")
     tip                   = var.io_tip
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
@@ -226,21 +226,9 @@ resource "signalfx_detector" "replication_lag" {
   program_text = <<-EOF
     base_filtering = filter('resource_type', 'Microsoft.DBforMySQL/flexibleServers') and filter('primary_aggregation_type', 'true')
     signal = data('seconds_behind_master', filter=base_filtering and ${module.filtering.signalflow})${var.replication_lag_aggregation_function}${var.replication_lag_transformation_function}.publish('signal')
-    detect(when(signal > ${var.replication_lag_threshold_major}, lasting=%{if var.replication_lag_lasting_duration_major == null}None%{else}'${var.replication_lag_lasting_duration_major}'%{endif}, at_least=${var.replication_lag_at_least_percentage_major})).publish('MAJOR')
-    detect(when(signal > ${var.replication_lag_threshold_critical}, lasting=%{if var.replication_lag_lasting_duration_critical == null}None%{else}'${var.replication_lag_lasting_duration_critical}'%{endif}, at_least=${var.replication_lag_at_least_percentage_critical}) and (not when(signal > ${var.replication_lag_threshold_major}, lasting=%{if var.replication_lag_lasting_duration_major == null}None%{else}'${var.replication_lag_lasting_duration_major}'%{endif}, at_least=${var.replication_lag_at_least_percentage_major}))).publish('CRIT')
+    detect(when(signal > ${var.replication_lag_threshold_critical}, lasting=%{if var.replication_lag_lasting_duration_critical == null}None%{else}'${var.replication_lag_lasting_duration_critical}'%{endif}, at_least=${var.replication_lag_at_least_percentage_critical})).publish('CRIT')
+    detect(when(signal > ${var.replication_lag_threshold_major}, lasting=%{if var.replication_lag_lasting_duration_major == null}None%{else}'${var.replication_lag_lasting_duration_major}'%{endif}, at_least=${var.replication_lag_at_least_percentage_major}) and (not when(signal > ${var.replication_lag_threshold_critical}, lasting=%{if var.replication_lag_lasting_duration_critical == null}None%{else}'${var.replication_lag_lasting_duration_critical}'%{endif}, at_least=${var.replication_lag_at_least_percentage_critical}))).publish('MAJOR')
 EOF
-
-  rule {
-    description           = "is too high > ${var.replication_lag_threshold_major}Second"
-    severity              = "Major"
-    detect_label          = "MAJOR"
-    disabled              = coalesce(var.replication_lag_disabled_major, var.replication_lag_disabled, var.detectors_disabled)
-    notifications         = try(coalescelist(lookup(var.replication_lag_notifications, "major", []), var.notifications.major), null)
-    runbook_url           = try(coalesce(var.replication_lag_runbook_url, var.runbook_url), "")
-    tip                   = var.replication_lag_tip
-    parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
-    parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
-  }
 
   rule {
     description           = "is too high > ${var.replication_lag_threshold_critical}Second"
@@ -248,6 +236,18 @@ EOF
     detect_label          = "CRIT"
     disabled              = coalesce(var.replication_lag_disabled_critical, var.replication_lag_disabled, var.detectors_disabled)
     notifications         = try(coalescelist(lookup(var.replication_lag_notifications, "critical", []), var.notifications.critical), null)
+    runbook_url           = try(coalesce(var.replication_lag_runbook_url, var.runbook_url), "")
+    tip                   = var.replication_lag_tip
+    parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
+    parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
+  }
+
+  rule {
+    description           = "is too high > ${var.replication_lag_threshold_major}Second"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.replication_lag_disabled_major, var.replication_lag_disabled, var.detectors_disabled)
+    notifications         = try(coalescelist(lookup(var.replication_lag_notifications, "major", []), var.notifications.major), null)
     runbook_url           = try(coalesce(var.replication_lag_runbook_url, var.runbook_url), "")
     tip                   = var.replication_lag_tip
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject

--- a/modules/integration_azure-flexible-mysql/variables-gen.tf
+++ b/modules/integration_azure-flexible-mysql/variables-gen.tf
@@ -92,35 +92,18 @@ variable "cpu_disabled" {
   default     = null
 }
 
-variable "cpu_disabled_major" {
-  description = "Disable major alerting rule for cpu detector"
-  type        = bool
-  default     = null
-}
-
 variable "cpu_disabled_critical" {
   description = "Disable critical alerting rule for cpu detector"
   type        = bool
   default     = null
 }
 
-variable "cpu_threshold_major" {
-  description = "Major threshold for cpu detector in %"
-  type        = number
-  default     = 80
+variable "cpu_disabled_major" {
+  description = "Disable major alerting rule for cpu detector"
+  type        = bool
+  default     = null
 }
 
-variable "cpu_lasting_duration_major" {
-  description = "Minimum duration that conditions must be true before raising alert"
-  type        = string
-  default     = "15m"
-}
-
-variable "cpu_at_least_percentage_major" {
-  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
-  type        = number
-  default     = 1
-}
 variable "cpu_threshold_critical" {
   description = "Critical threshold for cpu detector in %"
   type        = number
@@ -134,6 +117,23 @@ variable "cpu_lasting_duration_critical" {
 }
 
 variable "cpu_at_least_percentage_critical" {
+  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
+  type        = number
+  default     = 1
+}
+variable "cpu_threshold_major" {
+  description = "Major threshold for cpu detector in %"
+  type        = number
+  default     = 80
+}
+
+variable "cpu_lasting_duration_major" {
+  description = "Minimum duration that conditions must be true before raising alert"
+  type        = string
+  default     = "15m"
+}
+
+variable "cpu_at_least_percentage_major" {
   description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
   type        = number
   default     = 1
@@ -182,35 +182,18 @@ variable "storage_disabled" {
   default     = null
 }
 
-variable "storage_disabled_major" {
-  description = "Disable major alerting rule for storage detector"
-  type        = bool
-  default     = null
-}
-
 variable "storage_disabled_critical" {
   description = "Disable critical alerting rule for storage detector"
   type        = bool
   default     = null
 }
 
-variable "storage_threshold_major" {
-  description = "Major threshold for storage detector in %"
-  type        = number
-  default     = 80
+variable "storage_disabled_major" {
+  description = "Disable major alerting rule for storage detector"
+  type        = bool
+  default     = null
 }
 
-variable "storage_lasting_duration_major" {
-  description = "Minimum duration that conditions must be true before raising alert"
-  type        = string
-  default     = "15m"
-}
-
-variable "storage_at_least_percentage_major" {
-  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
-  type        = number
-  default     = 1
-}
 variable "storage_threshold_critical" {
   description = "Critical threshold for storage detector in %"
   type        = number
@@ -224,6 +207,23 @@ variable "storage_lasting_duration_critical" {
 }
 
 variable "storage_at_least_percentage_critical" {
+  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
+  type        = number
+  default     = 1
+}
+variable "storage_threshold_major" {
+  description = "Major threshold for storage detector in %"
+  type        = number
+  default     = 80
+}
+
+variable "storage_lasting_duration_major" {
+  description = "Minimum duration that conditions must be true before raising alert"
+  type        = string
+  default     = "15m"
+}
+
+variable "storage_at_least_percentage_major" {
   description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
   type        = number
   default     = 1
@@ -272,35 +272,18 @@ variable "io_disabled" {
   default     = null
 }
 
-variable "io_disabled_major" {
-  description = "Disable major alerting rule for io detector"
-  type        = bool
-  default     = null
-}
-
 variable "io_disabled_critical" {
   description = "Disable critical alerting rule for io detector"
   type        = bool
   default     = null
 }
 
-variable "io_threshold_major" {
-  description = "Major threshold for io detector in %"
-  type        = number
-  default     = 80
+variable "io_disabled_major" {
+  description = "Disable major alerting rule for io detector"
+  type        = bool
+  default     = null
 }
 
-variable "io_lasting_duration_major" {
-  description = "Minimum duration that conditions must be true before raising alert"
-  type        = string
-  default     = "15m"
-}
-
-variable "io_at_least_percentage_major" {
-  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
-  type        = number
-  default     = 1
-}
 variable "io_threshold_critical" {
   description = "Critical threshold for io detector in %"
   type        = number
@@ -314,6 +297,23 @@ variable "io_lasting_duration_critical" {
 }
 
 variable "io_at_least_percentage_critical" {
+  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
+  type        = number
+  default     = 1
+}
+variable "io_threshold_major" {
+  description = "Major threshold for io detector in %"
+  type        = number
+  default     = 80
+}
+
+variable "io_lasting_duration_major" {
+  description = "Minimum duration that conditions must be true before raising alert"
+  type        = string
+  default     = "15m"
+}
+
+variable "io_at_least_percentage_major" {
   description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
   type        = number
   default     = 1
@@ -452,35 +452,18 @@ variable "replication_lag_disabled" {
   default     = null
 }
 
-variable "replication_lag_disabled_major" {
-  description = "Disable major alerting rule for replication_lag detector"
-  type        = bool
-  default     = null
-}
-
 variable "replication_lag_disabled_critical" {
   description = "Disable critical alerting rule for replication_lag detector"
   type        = bool
   default     = null
 }
 
-variable "replication_lag_threshold_major" {
-  description = "Major threshold for replication_lag detector in Second"
-  type        = number
-  default     = 100
+variable "replication_lag_disabled_major" {
+  description = "Disable major alerting rule for replication_lag detector"
+  type        = bool
+  default     = null
 }
 
-variable "replication_lag_lasting_duration_major" {
-  description = "Minimum duration that conditions must be true before raising alert"
-  type        = string
-  default     = "15m"
-}
-
-variable "replication_lag_at_least_percentage_major" {
-  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
-  type        = number
-  default     = 1
-}
 variable "replication_lag_threshold_critical" {
   description = "Critical threshold for replication_lag detector in Second"
   type        = number
@@ -494,6 +477,23 @@ variable "replication_lag_lasting_duration_critical" {
 }
 
 variable "replication_lag_at_least_percentage_critical" {
+  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
+  type        = number
+  default     = 1
+}
+variable "replication_lag_threshold_major" {
+  description = "Major threshold for replication_lag detector in Second"
+  type        = number
+  default     = 100
+}
+
+variable "replication_lag_lasting_duration_major" {
+  description = "Minimum duration that conditions must be true before raising alert"
+  type        = string
+  default     = "15m"
+}
+
+variable "replication_lag_at_least_percentage_major" {
   description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
   type        = number
   default     = 1

--- a/modules/integration_azure-mariadb/conf/02-free-storage.yaml
+++ b/modules/integration_azure-mariadb/conf/02-free-storage.yaml
@@ -12,12 +12,12 @@ signals:
   signal:
     metric: "storage_percent"
 rules:
-  major:
-    threshold: 80
-    comparator: ">"
-    lasting_duration: '15m'
   critical:
     threshold: 90
     comparator: ">"
     lasting_duration: '15m'
-    dependency: major
+  major:
+    threshold: 80
+    comparator: ">"
+    lasting_duration: '15m'
+    dependency: critical

--- a/modules/integration_azure-mariadb/conf/04-memory.yaml
+++ b/modules/integration_azure-mariadb/conf/04-memory.yaml
@@ -12,12 +12,12 @@ signals:
   signal:
     metric: "memory_percent"
 rules:
-  major:
-    threshold: 80
-    comparator: ">"
-    lasting_duration: '15m'
   critical:
     threshold: 90
     comparator: ">"
     lasting_duration: '15m'
-    dependency: major
+  major:
+    threshold: 80
+    comparator: ">"
+    lasting_duration: '15m'
+    dependency: critical

--- a/modules/integration_azure-mariadb/detectors-gen.tf
+++ b/modules/integration_azure-mariadb/detectors-gen.tf
@@ -88,21 +88,9 @@ resource "signalfx_detector" "storage" {
   program_text = <<-EOF
     base_filtering = filter('resource_type', 'Microsoft.DB*orMariaDB/servers') and filter('primary_aggregation_type', 'true')
     signal = data('storage_percent', filter=base_filtering and ${module.filtering.signalflow})${var.storage_aggregation_function}${var.storage_transformation_function}.publish('signal')
-    detect(when(signal > ${var.storage_threshold_major}, lasting=%{if var.storage_lasting_duration_major == null}None%{else}'${var.storage_lasting_duration_major}'%{endif}, at_least=${var.storage_at_least_percentage_major})).publish('MAJOR')
-    detect(when(signal > ${var.storage_threshold_critical}, lasting=%{if var.storage_lasting_duration_critical == null}None%{else}'${var.storage_lasting_duration_critical}'%{endif}, at_least=${var.storage_at_least_percentage_critical}) and (not when(signal > ${var.storage_threshold_major}, lasting=%{if var.storage_lasting_duration_major == null}None%{else}'${var.storage_lasting_duration_major}'%{endif}, at_least=${var.storage_at_least_percentage_major}))).publish('CRIT')
+    detect(when(signal > ${var.storage_threshold_critical}, lasting=%{if var.storage_lasting_duration_critical == null}None%{else}'${var.storage_lasting_duration_critical}'%{endif}, at_least=${var.storage_at_least_percentage_critical})).publish('CRIT')
+    detect(when(signal > ${var.storage_threshold_major}, lasting=%{if var.storage_lasting_duration_major == null}None%{else}'${var.storage_lasting_duration_major}'%{endif}, at_least=${var.storage_at_least_percentage_major}) and (not when(signal > ${var.storage_threshold_critical}, lasting=%{if var.storage_lasting_duration_critical == null}None%{else}'${var.storage_lasting_duration_critical}'%{endif}, at_least=${var.storage_at_least_percentage_critical}))).publish('MAJOR')
 EOF
-
-  rule {
-    description           = "is too high > ${var.storage_threshold_major}%"
-    severity              = "Major"
-    detect_label          = "MAJOR"
-    disabled              = coalesce(var.storage_disabled_major, var.storage_disabled, var.detectors_disabled)
-    notifications         = try(coalescelist(lookup(var.storage_notifications, "major", []), var.notifications.major), null)
-    runbook_url           = try(coalesce(var.storage_runbook_url, var.runbook_url), "")
-    tip                   = var.storage_tip
-    parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
-    parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
-  }
 
   rule {
     description           = "is too high > ${var.storage_threshold_critical}%"
@@ -110,6 +98,18 @@ EOF
     detect_label          = "CRIT"
     disabled              = coalesce(var.storage_disabled_critical, var.storage_disabled, var.detectors_disabled)
     notifications         = try(coalescelist(lookup(var.storage_notifications, "critical", []), var.notifications.critical), null)
+    runbook_url           = try(coalesce(var.storage_runbook_url, var.runbook_url), "")
+    tip                   = var.storage_tip
+    parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
+    parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
+  }
+
+  rule {
+    description           = "is too high > ${var.storage_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.storage_disabled_major, var.storage_disabled, var.detectors_disabled)
+    notifications         = try(coalescelist(lookup(var.storage_notifications, "major", []), var.notifications.major), null)
     runbook_url           = try(coalesce(var.storage_runbook_url, var.runbook_url), "")
     tip                   = var.storage_tip
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
@@ -180,21 +180,9 @@ resource "signalfx_detector" "memory" {
   program_text = <<-EOF
     base_filtering = filter('resource_type', 'Microsoft.DB*orMariaDB/servers') and filter('primary_aggregation_type', 'true')
     signal = data('memory_percent', filter=base_filtering and ${module.filtering.signalflow})${var.memory_aggregation_function}${var.memory_transformation_function}.publish('signal')
-    detect(when(signal > ${var.memory_threshold_major}, lasting=%{if var.memory_lasting_duration_major == null}None%{else}'${var.memory_lasting_duration_major}'%{endif}, at_least=${var.memory_at_least_percentage_major})).publish('MAJOR')
-    detect(when(signal > ${var.memory_threshold_critical}, lasting=%{if var.memory_lasting_duration_critical == null}None%{else}'${var.memory_lasting_duration_critical}'%{endif}, at_least=${var.memory_at_least_percentage_critical}) and (not when(signal > ${var.memory_threshold_major}, lasting=%{if var.memory_lasting_duration_major == null}None%{else}'${var.memory_lasting_duration_major}'%{endif}, at_least=${var.memory_at_least_percentage_major}))).publish('CRIT')
+    detect(when(signal > ${var.memory_threshold_critical}, lasting=%{if var.memory_lasting_duration_critical == null}None%{else}'${var.memory_lasting_duration_critical}'%{endif}, at_least=${var.memory_at_least_percentage_critical})).publish('CRIT')
+    detect(when(signal > ${var.memory_threshold_major}, lasting=%{if var.memory_lasting_duration_major == null}None%{else}'${var.memory_lasting_duration_major}'%{endif}, at_least=${var.memory_at_least_percentage_major}) and (not when(signal > ${var.memory_threshold_critical}, lasting=%{if var.memory_lasting_duration_critical == null}None%{else}'${var.memory_lasting_duration_critical}'%{endif}, at_least=${var.memory_at_least_percentage_critical}))).publish('MAJOR')
 EOF
-
-  rule {
-    description           = "is too high > ${var.memory_threshold_major}%"
-    severity              = "Major"
-    detect_label          = "MAJOR"
-    disabled              = coalesce(var.memory_disabled_major, var.memory_disabled, var.detectors_disabled)
-    notifications         = try(coalescelist(lookup(var.memory_notifications, "major", []), var.notifications.major), null)
-    runbook_url           = try(coalesce(var.memory_runbook_url, var.runbook_url), "")
-    tip                   = var.memory_tip
-    parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
-    parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
-  }
 
   rule {
     description           = "is too high > ${var.memory_threshold_critical}%"
@@ -202,6 +190,18 @@ EOF
     detect_label          = "CRIT"
     disabled              = coalesce(var.memory_disabled_critical, var.memory_disabled, var.detectors_disabled)
     notifications         = try(coalescelist(lookup(var.memory_notifications, "critical", []), var.notifications.critical), null)
+    runbook_url           = try(coalesce(var.memory_runbook_url, var.runbook_url), "")
+    tip                   = var.memory_tip
+    parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
+    parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
+  }
+
+  rule {
+    description           = "is too high > ${var.memory_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.memory_disabled_major, var.memory_disabled, var.detectors_disabled)
+    notifications         = try(coalescelist(lookup(var.memory_notifications, "major", []), var.notifications.major), null)
     runbook_url           = try(coalesce(var.memory_runbook_url, var.runbook_url), "")
     tip                   = var.memory_tip
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject

--- a/modules/integration_azure-mariadb/variables-gen.tf
+++ b/modules/integration_azure-mariadb/variables-gen.tf
@@ -182,35 +182,18 @@ variable "storage_disabled" {
   default     = null
 }
 
-variable "storage_disabled_major" {
-  description = "Disable major alerting rule for storage detector"
-  type        = bool
-  default     = null
-}
-
 variable "storage_disabled_critical" {
   description = "Disable critical alerting rule for storage detector"
   type        = bool
   default     = null
 }
 
-variable "storage_threshold_major" {
-  description = "Major threshold for storage detector in %"
-  type        = number
-  default     = 80
+variable "storage_disabled_major" {
+  description = "Disable major alerting rule for storage detector"
+  type        = bool
+  default     = null
 }
 
-variable "storage_lasting_duration_major" {
-  description = "Minimum duration that conditions must be true before raising alert"
-  type        = string
-  default     = "15m"
-}
-
-variable "storage_at_least_percentage_major" {
-  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
-  type        = number
-  default     = 1
-}
 variable "storage_threshold_critical" {
   description = "Critical threshold for storage detector in %"
   type        = number
@@ -224,6 +207,23 @@ variable "storage_lasting_duration_critical" {
 }
 
 variable "storage_at_least_percentage_critical" {
+  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
+  type        = number
+  default     = 1
+}
+variable "storage_threshold_major" {
+  description = "Major threshold for storage detector in %"
+  type        = number
+  default     = 80
+}
+
+variable "storage_lasting_duration_major" {
+  description = "Minimum duration that conditions must be true before raising alert"
+  type        = string
+  default     = "15m"
+}
+
+variable "storage_at_least_percentage_major" {
   description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
   type        = number
   default     = 1
@@ -362,35 +362,18 @@ variable "memory_disabled" {
   default     = null
 }
 
-variable "memory_disabled_major" {
-  description = "Disable major alerting rule for memory detector"
-  type        = bool
-  default     = null
-}
-
 variable "memory_disabled_critical" {
   description = "Disable critical alerting rule for memory detector"
   type        = bool
   default     = null
 }
 
-variable "memory_threshold_major" {
-  description = "Major threshold for memory detector in %"
-  type        = number
-  default     = 80
+variable "memory_disabled_major" {
+  description = "Disable major alerting rule for memory detector"
+  type        = bool
+  default     = null
 }
 
-variable "memory_lasting_duration_major" {
-  description = "Minimum duration that conditions must be true before raising alert"
-  type        = string
-  default     = "15m"
-}
-
-variable "memory_at_least_percentage_major" {
-  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
-  type        = number
-  default     = 1
-}
 variable "memory_threshold_critical" {
   description = "Critical threshold for memory detector in %"
   type        = number
@@ -404,6 +387,23 @@ variable "memory_lasting_duration_critical" {
 }
 
 variable "memory_at_least_percentage_critical" {
+  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
+  type        = number
+  default     = 1
+}
+variable "memory_threshold_major" {
+  description = "Major threshold for memory detector in %"
+  type        = number
+  default     = 80
+}
+
+variable "memory_lasting_duration_major" {
+  description = "Minimum duration that conditions must be true before raising alert"
+  type        = string
+  default     = "15m"
+}
+
+variable "memory_at_least_percentage_major" {
   description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
   type        = number
   default     = 1

--- a/modules/integration_azure-mysql/conf/01-cpu.yaml
+++ b/modules/integration_azure-mysql/conf/01-cpu.yaml
@@ -12,12 +12,12 @@ signals:
   signal:
     metric: "cpu_percent"
 rules:
-  major:
-    threshold: 80
-    comparator: ">"
-    lasting_duration: '15m'
   critical:
     threshold: 90
     comparator: ">"
     lasting_duration: '15m'
-    dependency: major
+  major:
+    threshold: 80
+    comparator: ">"
+    lasting_duration: '15m'
+    dependency: critical

--- a/modules/integration_azure-mysql/conf/03-io-conso.yaml
+++ b/modules/integration_azure-mysql/conf/03-io-conso.yaml
@@ -12,12 +12,12 @@ signals:
   signal:
     metric: "io_consumption_percent"
 rules:
-  major:
-    threshold: 80
-    comparator: ">"
-    lasting_duration: '15m'
   critical:
     threshold: 90
     comparator: ">"
     lasting_duration: '15m'
-    dependency: major
+  major:
+    threshold: 80
+    comparator: ">"
+    lasting_duration: '15m'
+    dependency: critical

--- a/modules/integration_azure-mysql/conf/05-replication-lag.yaml
+++ b/modules/integration_azure-mysql/conf/05-replication-lag.yaml
@@ -11,12 +11,12 @@ signals:
   signal:
     metric: "seconds_behind_master"
 rules:
-  major:
-    threshold: 100
-    comparator: ">"
-    lasting_duration: '15m'
   critical:
     threshold: 200
     comparator: ">"
     lasting_duration: '15m'
-    dependency: major
+  major:
+    threshold: 100
+    comparator: ">"
+    lasting_duration: '15m'
+    dependency: critical

--- a/modules/integration_azure-mysql/detectors-gen.tf
+++ b/modules/integration_azure-mysql/detectors-gen.tf
@@ -42,21 +42,9 @@ resource "signalfx_detector" "cpu" {
   program_text = <<-EOF
     base_filtering = filter('resource_type', 'Microsoft.DBforMySQL/servers') and filter('primary_aggregation_type', 'true')
     signal = data('cpu_percent', filter=base_filtering and ${module.filtering.signalflow})${var.cpu_aggregation_function}${var.cpu_transformation_function}.publish('signal')
-    detect(when(signal > ${var.cpu_threshold_major}, lasting=%{if var.cpu_lasting_duration_major == null}None%{else}'${var.cpu_lasting_duration_major}'%{endif}, at_least=${var.cpu_at_least_percentage_major})).publish('MAJOR')
-    detect(when(signal > ${var.cpu_threshold_critical}, lasting=%{if var.cpu_lasting_duration_critical == null}None%{else}'${var.cpu_lasting_duration_critical}'%{endif}, at_least=${var.cpu_at_least_percentage_critical}) and (not when(signal > ${var.cpu_threshold_major}, lasting=%{if var.cpu_lasting_duration_major == null}None%{else}'${var.cpu_lasting_duration_major}'%{endif}, at_least=${var.cpu_at_least_percentage_major}))).publish('CRIT')
+    detect(when(signal > ${var.cpu_threshold_critical}, lasting=%{if var.cpu_lasting_duration_critical == null}None%{else}'${var.cpu_lasting_duration_critical}'%{endif}, at_least=${var.cpu_at_least_percentage_critical})).publish('CRIT')
+    detect(when(signal > ${var.cpu_threshold_major}, lasting=%{if var.cpu_lasting_duration_major == null}None%{else}'${var.cpu_lasting_duration_major}'%{endif}, at_least=${var.cpu_at_least_percentage_major}) and (not when(signal > ${var.cpu_threshold_critical}, lasting=%{if var.cpu_lasting_duration_critical == null}None%{else}'${var.cpu_lasting_duration_critical}'%{endif}, at_least=${var.cpu_at_least_percentage_critical}))).publish('MAJOR')
 EOF
-
-  rule {
-    description           = "is too high > ${var.cpu_threshold_major}%"
-    severity              = "Major"
-    detect_label          = "MAJOR"
-    disabled              = coalesce(var.cpu_disabled_major, var.cpu_disabled, var.detectors_disabled)
-    notifications         = try(coalescelist(lookup(var.cpu_notifications, "major", []), var.notifications.major), null)
-    runbook_url           = try(coalesce(var.cpu_runbook_url, var.runbook_url), "")
-    tip                   = var.cpu_tip
-    parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
-    parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
-  }
 
   rule {
     description           = "is too high > ${var.cpu_threshold_critical}%"
@@ -64,6 +52,18 @@ EOF
     detect_label          = "CRIT"
     disabled              = coalesce(var.cpu_disabled_critical, var.cpu_disabled, var.detectors_disabled)
     notifications         = try(coalescelist(lookup(var.cpu_notifications, "critical", []), var.notifications.critical), null)
+    runbook_url           = try(coalesce(var.cpu_runbook_url, var.runbook_url), "")
+    tip                   = var.cpu_tip
+    parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
+    parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
+  }
+
+  rule {
+    description           = "is too high > ${var.cpu_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.cpu_disabled_major, var.cpu_disabled, var.detectors_disabled)
+    notifications         = try(coalescelist(lookup(var.cpu_notifications, "major", []), var.notifications.major), null)
     runbook_url           = try(coalesce(var.cpu_runbook_url, var.runbook_url), "")
     tip                   = var.cpu_tip
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
@@ -134,21 +134,9 @@ resource "signalfx_detector" "io" {
   program_text = <<-EOF
     base_filtering = filter('resource_type', 'Microsoft.DBforMySQL/servers') and filter('primary_aggregation_type', 'true')
     signal = data('io_consumption_percent', filter=base_filtering and ${module.filtering.signalflow})${var.io_aggregation_function}${var.io_transformation_function}.publish('signal')
-    detect(when(signal > ${var.io_threshold_major}, lasting=%{if var.io_lasting_duration_major == null}None%{else}'${var.io_lasting_duration_major}'%{endif}, at_least=${var.io_at_least_percentage_major})).publish('MAJOR')
-    detect(when(signal > ${var.io_threshold_critical}, lasting=%{if var.io_lasting_duration_critical == null}None%{else}'${var.io_lasting_duration_critical}'%{endif}, at_least=${var.io_at_least_percentage_critical}) and (not when(signal > ${var.io_threshold_major}, lasting=%{if var.io_lasting_duration_major == null}None%{else}'${var.io_lasting_duration_major}'%{endif}, at_least=${var.io_at_least_percentage_major}))).publish('CRIT')
+    detect(when(signal > ${var.io_threshold_critical}, lasting=%{if var.io_lasting_duration_critical == null}None%{else}'${var.io_lasting_duration_critical}'%{endif}, at_least=${var.io_at_least_percentage_critical})).publish('CRIT')
+    detect(when(signal > ${var.io_threshold_major}, lasting=%{if var.io_lasting_duration_major == null}None%{else}'${var.io_lasting_duration_major}'%{endif}, at_least=${var.io_at_least_percentage_major}) and (not when(signal > ${var.io_threshold_critical}, lasting=%{if var.io_lasting_duration_critical == null}None%{else}'${var.io_lasting_duration_critical}'%{endif}, at_least=${var.io_at_least_percentage_critical}))).publish('MAJOR')
 EOF
-
-  rule {
-    description           = "is too high > ${var.io_threshold_major}%"
-    severity              = "Major"
-    detect_label          = "MAJOR"
-    disabled              = coalesce(var.io_disabled_major, var.io_disabled, var.detectors_disabled)
-    notifications         = try(coalescelist(lookup(var.io_notifications, "major", []), var.notifications.major), null)
-    runbook_url           = try(coalesce(var.io_runbook_url, var.runbook_url), "")
-    tip                   = var.io_tip
-    parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
-    parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
-  }
 
   rule {
     description           = "is too high > ${var.io_threshold_critical}%"
@@ -156,6 +144,18 @@ EOF
     detect_label          = "CRIT"
     disabled              = coalesce(var.io_disabled_critical, var.io_disabled, var.detectors_disabled)
     notifications         = try(coalescelist(lookup(var.io_notifications, "critical", []), var.notifications.critical), null)
+    runbook_url           = try(coalesce(var.io_runbook_url, var.runbook_url), "")
+    tip                   = var.io_tip
+    parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
+    parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
+  }
+
+  rule {
+    description           = "is too high > ${var.io_threshold_major}%"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.io_disabled_major, var.io_disabled, var.detectors_disabled)
+    notifications         = try(coalescelist(lookup(var.io_notifications, "major", []), var.notifications.major), null)
     runbook_url           = try(coalesce(var.io_runbook_url, var.runbook_url), "")
     tip                   = var.io_tip
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
@@ -226,21 +226,9 @@ resource "signalfx_detector" "replication_lag" {
   program_text = <<-EOF
     base_filtering = filter('resource_type', 'Microsoft.DBforMySQL/servers') and filter('primary_aggregation_type', 'true')
     signal = data('seconds_behind_master', filter=base_filtering and ${module.filtering.signalflow})${var.replication_lag_aggregation_function}${var.replication_lag_transformation_function}.publish('signal')
-    detect(when(signal > ${var.replication_lag_threshold_major}, lasting=%{if var.replication_lag_lasting_duration_major == null}None%{else}'${var.replication_lag_lasting_duration_major}'%{endif}, at_least=${var.replication_lag_at_least_percentage_major})).publish('MAJOR')
-    detect(when(signal > ${var.replication_lag_threshold_critical}, lasting=%{if var.replication_lag_lasting_duration_critical == null}None%{else}'${var.replication_lag_lasting_duration_critical}'%{endif}, at_least=${var.replication_lag_at_least_percentage_critical}) and (not when(signal > ${var.replication_lag_threshold_major}, lasting=%{if var.replication_lag_lasting_duration_major == null}None%{else}'${var.replication_lag_lasting_duration_major}'%{endif}, at_least=${var.replication_lag_at_least_percentage_major}))).publish('CRIT')
+    detect(when(signal > ${var.replication_lag_threshold_critical}, lasting=%{if var.replication_lag_lasting_duration_critical == null}None%{else}'${var.replication_lag_lasting_duration_critical}'%{endif}, at_least=${var.replication_lag_at_least_percentage_critical})).publish('CRIT')
+    detect(when(signal > ${var.replication_lag_threshold_major}, lasting=%{if var.replication_lag_lasting_duration_major == null}None%{else}'${var.replication_lag_lasting_duration_major}'%{endif}, at_least=${var.replication_lag_at_least_percentage_major}) and (not when(signal > ${var.replication_lag_threshold_critical}, lasting=%{if var.replication_lag_lasting_duration_critical == null}None%{else}'${var.replication_lag_lasting_duration_critical}'%{endif}, at_least=${var.replication_lag_at_least_percentage_critical}))).publish('MAJOR')
 EOF
-
-  rule {
-    description           = "is too high > ${var.replication_lag_threshold_major}Second"
-    severity              = "Major"
-    detect_label          = "MAJOR"
-    disabled              = coalesce(var.replication_lag_disabled_major, var.replication_lag_disabled, var.detectors_disabled)
-    notifications         = try(coalescelist(lookup(var.replication_lag_notifications, "major", []), var.notifications.major), null)
-    runbook_url           = try(coalesce(var.replication_lag_runbook_url, var.runbook_url), "")
-    tip                   = var.replication_lag_tip
-    parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
-    parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
-  }
 
   rule {
     description           = "is too high > ${var.replication_lag_threshold_critical}Second"
@@ -248,6 +236,18 @@ EOF
     detect_label          = "CRIT"
     disabled              = coalesce(var.replication_lag_disabled_critical, var.replication_lag_disabled, var.detectors_disabled)
     notifications         = try(coalescelist(lookup(var.replication_lag_notifications, "critical", []), var.notifications.critical), null)
+    runbook_url           = try(coalesce(var.replication_lag_runbook_url, var.runbook_url), "")
+    tip                   = var.replication_lag_tip
+    parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
+    parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
+  }
+
+  rule {
+    description           = "is too high > ${var.replication_lag_threshold_major}Second"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.replication_lag_disabled_major, var.replication_lag_disabled, var.detectors_disabled)
+    notifications         = try(coalescelist(lookup(var.replication_lag_notifications, "major", []), var.notifications.major), null)
     runbook_url           = try(coalesce(var.replication_lag_runbook_url, var.runbook_url), "")
     tip                   = var.replication_lag_tip
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject

--- a/modules/integration_azure-mysql/variables-gen.tf
+++ b/modules/integration_azure-mysql/variables-gen.tf
@@ -92,35 +92,18 @@ variable "cpu_disabled" {
   default     = null
 }
 
-variable "cpu_disabled_major" {
-  description = "Disable major alerting rule for cpu detector"
-  type        = bool
-  default     = null
-}
-
 variable "cpu_disabled_critical" {
   description = "Disable critical alerting rule for cpu detector"
   type        = bool
   default     = null
 }
 
-variable "cpu_threshold_major" {
-  description = "Major threshold for cpu detector in %"
-  type        = number
-  default     = 80
+variable "cpu_disabled_major" {
+  description = "Disable major alerting rule for cpu detector"
+  type        = bool
+  default     = null
 }
 
-variable "cpu_lasting_duration_major" {
-  description = "Minimum duration that conditions must be true before raising alert"
-  type        = string
-  default     = "15m"
-}
-
-variable "cpu_at_least_percentage_major" {
-  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
-  type        = number
-  default     = 1
-}
 variable "cpu_threshold_critical" {
   description = "Critical threshold for cpu detector in %"
   type        = number
@@ -134,6 +117,23 @@ variable "cpu_lasting_duration_critical" {
 }
 
 variable "cpu_at_least_percentage_critical" {
+  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
+  type        = number
+  default     = 1
+}
+variable "cpu_threshold_major" {
+  description = "Major threshold for cpu detector in %"
+  type        = number
+  default     = 80
+}
+
+variable "cpu_lasting_duration_major" {
+  description = "Minimum duration that conditions must be true before raising alert"
+  type        = string
+  default     = "15m"
+}
+
+variable "cpu_at_least_percentage_major" {
   description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
   type        = number
   default     = 1
@@ -272,35 +272,18 @@ variable "io_disabled" {
   default     = null
 }
 
-variable "io_disabled_major" {
-  description = "Disable major alerting rule for io detector"
-  type        = bool
-  default     = null
-}
-
 variable "io_disabled_critical" {
   description = "Disable critical alerting rule for io detector"
   type        = bool
   default     = null
 }
 
-variable "io_threshold_major" {
-  description = "Major threshold for io detector in %"
-  type        = number
-  default     = 80
+variable "io_disabled_major" {
+  description = "Disable major alerting rule for io detector"
+  type        = bool
+  default     = null
 }
 
-variable "io_lasting_duration_major" {
-  description = "Minimum duration that conditions must be true before raising alert"
-  type        = string
-  default     = "15m"
-}
-
-variable "io_at_least_percentage_major" {
-  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
-  type        = number
-  default     = 1
-}
 variable "io_threshold_critical" {
   description = "Critical threshold for io detector in %"
   type        = number
@@ -314,6 +297,23 @@ variable "io_lasting_duration_critical" {
 }
 
 variable "io_at_least_percentage_critical" {
+  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
+  type        = number
+  default     = 1
+}
+variable "io_threshold_major" {
+  description = "Major threshold for io detector in %"
+  type        = number
+  default     = 80
+}
+
+variable "io_lasting_duration_major" {
+  description = "Minimum duration that conditions must be true before raising alert"
+  type        = string
+  default     = "15m"
+}
+
+variable "io_at_least_percentage_major" {
   description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
   type        = number
   default     = 1
@@ -452,35 +452,18 @@ variable "replication_lag_disabled" {
   default     = null
 }
 
-variable "replication_lag_disabled_major" {
-  description = "Disable major alerting rule for replication_lag detector"
-  type        = bool
-  default     = null
-}
-
 variable "replication_lag_disabled_critical" {
   description = "Disable critical alerting rule for replication_lag detector"
   type        = bool
   default     = null
 }
 
-variable "replication_lag_threshold_major" {
-  description = "Major threshold for replication_lag detector in Second"
-  type        = number
-  default     = 100
+variable "replication_lag_disabled_major" {
+  description = "Disable major alerting rule for replication_lag detector"
+  type        = bool
+  default     = null
 }
 
-variable "replication_lag_lasting_duration_major" {
-  description = "Minimum duration that conditions must be true before raising alert"
-  type        = string
-  default     = "15m"
-}
-
-variable "replication_lag_at_least_percentage_major" {
-  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
-  type        = number
-  default     = 1
-}
 variable "replication_lag_threshold_critical" {
   description = "Critical threshold for replication_lag detector in Second"
   type        = number
@@ -494,6 +477,23 @@ variable "replication_lag_lasting_duration_critical" {
 }
 
 variable "replication_lag_at_least_percentage_critical" {
+  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
+  type        = number
+  default     = 1
+}
+variable "replication_lag_threshold_major" {
+  description = "Major threshold for replication_lag detector in Second"
+  type        = number
+  default     = 100
+}
+
+variable "replication_lag_lasting_duration_major" {
+  description = "Minimum duration that conditions must be true before raising alert"
+  type        = string
+  default     = "15m"
+}
+
+variable "replication_lag_at_least_percentage_major" {
   description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
   type        = number
   default     = 1

--- a/modules/smart-agent_http/conf/03-response-time.yaml
+++ b/modules/smart-agent_http/conf/03-response-time.yaml
@@ -19,3 +19,4 @@ rules:
     threshold: 1
     comparator: ">"
     lasting_duration: 15m
+    dependency: critical

--- a/modules/smart-agent_http/detectors-gen.tf
+++ b/modules/smart-agent_http/detectors-gen.tf
@@ -90,7 +90,7 @@ resource "signalfx_detector" "http_response_time" {
   program_text = <<-EOF
     signal = data('http.response_time', filter=${module.filtering.signalflow}, rollup='max')${var.http_response_time_aggregation_function}${var.http_response_time_transformation_function}.publish('signal')
     detect(when(signal > ${var.http_response_time_threshold_critical}, lasting=%{if var.http_response_time_lasting_duration_critical == null}None%{else}'${var.http_response_time_lasting_duration_critical}'%{endif}, at_least=${var.http_response_time_at_least_percentage_critical})).publish('CRIT')
-    detect(when(signal > ${var.http_response_time_threshold_major}, lasting=%{if var.http_response_time_lasting_duration_major == null}None%{else}'${var.http_response_time_lasting_duration_major}'%{endif}, at_least=${var.http_response_time_at_least_percentage_major})).publish('MAJOR')
+    detect(when(signal > ${var.http_response_time_threshold_major}, lasting=%{if var.http_response_time_lasting_duration_major == null}None%{else}'${var.http_response_time_lasting_duration_major}'%{endif}, at_least=${var.http_response_time_at_least_percentage_major}) and (not when(signal > ${var.http_response_time_threshold_critical}, lasting=%{if var.http_response_time_lasting_duration_critical == null}None%{else}'${var.http_response_time_lasting_duration_critical}'%{endif}, at_least=${var.http_response_time_at_least_percentage_critical}))).publish('MAJOR')
 EOF
 
   rule {


### PR DESCRIPTION
- Some detectors have a wrong dependency rule (the dependency is applied on critical rule instead of major rule), so the critical rule is never triggered
- Add a dependency for the major rule of the response time detector in the smart-agent_http module