### PR TITLE
smart-agent_system-common: add swap in/out detector

### DIFF
--- a/docs/severity.md
+++ b/docs/severity.md
@@ -1193,6 +1193,7 @@
 |System disk space utilization|X|X|-|-|-|
 |System disk inodes utilization|X|X|-|-|-|
 |System memory utilization|X|X|-|-|-|
+|System swap in/out|X|X|-|-|-|
 |System disk space running out|-|X|-|-|-|
 
 

--- a/modules/smart-agent_system-common/README.md
+++ b/modules/smart-agent_system-common/README.md
@@ -82,6 +82,7 @@ This module creates the following SignalFx detectors which could contain one or 
 |System disk space utilization|X|X|-|-|-|
 |System disk inodes utilization|X|X|-|-|-|
 |System memory utilization|X|X|-|-|-|
+|System swap in/out|X|X|-|-|-|
 |System disk space running out|-|X|-|-|-|
 
 ## How to collect required metrics?
@@ -150,6 +151,8 @@ parameter to the corresponding monitor configuration:
         - '!load.midterm'
         - '!memory.utilization'
         - '!percent_inodes.used'
+        - '!vmpage_io.swap.in'
+        - '!vmpage_io.swap.out'
 
 ```
 
@@ -165,5 +168,6 @@ parameter to the corresponding monitor configuration:
 * [Smart Agent monitor load](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/load.md)
 * [Smart Agent monitor filesystems](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/filesystems.md)
 * [Smart Agent monitor memory](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/memory.md)
+* [Smart Agent monitor vmem](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/vmem.md)
 * [Splunk Observability integration cpu](https://docs.splunk.com/Observability/gdi/cpu/cpu.html)
 * [Splunk Observability integration load](https://docs.splunk.com/Observability/gdi/load/load.html)

--- a/modules/smart-agent_system-common/conf/06-swap.yaml
+++ b/modules/smart-agent_system-common/conf/06-swap.yaml
@@ -1,0 +1,29 @@
+module: system
+name: "swap in/out"
+tip: There not enough RAM on the host, either increase the RAM or decrease the memory pressure (by stopping or throttling some process)
+id: swap_io
+
+value_unit: "iops"
+disabled: true
+
+signals:
+  A:
+    metric: vmpage_io.swap.in
+    rollup: rate
+  B:
+    metric: vmpage_io.swap.out
+    rollup: rate
+  signal:
+    formula: (A+B)
+rules:
+  critical:
+    threshold: 400
+    comparator: ">"
+    lasting_duration: 10m
+    lasting_at_least: 0.5
+  major:
+    threshold: 200
+    comparator: ">"
+    dependency: critical
+    lasting_duration: 10m
+    lasting_at_least: 0.5

--- a/modules/smart-agent_system-common/conf/readme.yaml
+++ b/modules/smart-agent_system-common/conf/readme.yaml
@@ -9,6 +9,8 @@ documentations:
     url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/filesystems.md'
   - name: Smart Agent monitor memory
     url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/memory.md'
+  - name: Smart Agent monitor vmem
+    url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/vmem.md'
   - name: Splunk Observability integration cpu
     url: 'https://docs.splunk.com/Observability/gdi/cpu/cpu.html'
   - name: Splunk Observability integration load

--- a/modules/smart-agent_system-common/detectors-gen.tf
+++ b/modules/smart-agent_system-common/detectors-gen.tf
@@ -248,3 +248,50 @@ EOF
   max_delay = var.memory_max_delay
 }
 
+resource "signalfx_detector" "swap_io" {
+  name = format("%s %s", local.detector_name_prefix, "System swap in/out")
+
+  authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
+  tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
+
+  viz_options {
+    label        = "signal"
+    value_suffix = "iops"
+  }
+
+  program_text = <<-EOF
+    A = data('vmpage_io.swap.in', filter=${module.filtering.signalflow}, rollup='rate')${var.swap_io_aggregation_function}${var.swap_io_transformation_function}
+    B = data('vmpage_io.swap.out', filter=${module.filtering.signalflow}, rollup='rate')${var.swap_io_aggregation_function}${var.swap_io_transformation_function}
+    signal = (A+B).publish('signal')
+    detect(when(signal > ${var.swap_io_threshold_critical}, lasting=%{if var.swap_io_lasting_duration_critical == null}None%{else}'${var.swap_io_lasting_duration_critical}'%{endif}, at_least=${var.swap_io_at_least_percentage_critical})).publish('CRIT')
+    detect(when(signal > ${var.swap_io_threshold_major}, lasting=%{if var.swap_io_lasting_duration_major == null}None%{else}'${var.swap_io_lasting_duration_major}'%{endif}, at_least=${var.swap_io_at_least_percentage_major}) and (not when(signal > ${var.swap_io_threshold_critical}, lasting=%{if var.swap_io_lasting_duration_critical == null}None%{else}'${var.swap_io_lasting_duration_critical}'%{endif}, at_least=${var.swap_io_at_least_percentage_critical}))).publish('MAJOR')
+EOF
+
+  rule {
+    description           = "is too high > ${var.swap_io_threshold_critical}iops"
+    severity              = "Critical"
+    detect_label          = "CRIT"
+    disabled              = coalesce(var.swap_io_disabled_critical, var.swap_io_disabled, var.detectors_disabled)
+    notifications         = try(coalescelist(lookup(var.swap_io_notifications, "critical", []), var.notifications.critical), null)
+    runbook_url           = try(coalesce(var.swap_io_runbook_url, var.runbook_url), "")
+    tip                   = var.swap_io_tip
+    parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
+    parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
+  }
+
+  rule {
+    description           = "is too high > ${var.swap_io_threshold_major}iops"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.swap_io_disabled_major, var.swap_io_disabled, var.detectors_disabled)
+    notifications         = try(coalescelist(lookup(var.swap_io_notifications, "major", []), var.notifications.major), null)
+    runbook_url           = try(coalesce(var.swap_io_runbook_url, var.runbook_url), "")
+    tip                   = var.swap_io_tip
+    parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
+    parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
+  }
+
+  max_delay = var.swap_io_max_delay
+}
+

--- a/modules/smart-agent_system-common/outputs.tf
+++ b/modules/smart-agent_system-common/outputs.tf
@@ -33,3 +33,8 @@ output "memory" {
   value       = signalfx_detector.memory
 }
 
+output "swap_io" {
+  description = "Detector resource for swap_io"
+  value       = signalfx_detector.swap_io
+}
+

--- a/modules/smart-agent_system-common/variables-gen.tf
+++ b/modules/smart-agent_system-common/variables-gen.tf
@@ -492,3 +492,95 @@ variable "memory_at_least_percentage_major" {
   type        = number
   default     = 1
 }
+# swap_io detector
+
+variable "swap_io_notifications" {
+  description = "Notification recipients list per severity overridden for swap_io detector"
+  type        = map(list(string))
+  default     = {}
+}
+
+variable "swap_io_aggregation_function" {
+  description = "Aggregation function and group by for swap_io detector (i.e. \".mean(by=['host'])\")"
+  type        = string
+  default     = ""
+}
+
+variable "swap_io_transformation_function" {
+  description = "Transformation function for swap_io detector (i.e. \".mean(over='5m')\")"
+  type        = string
+  default     = ""
+}
+
+variable "swap_io_max_delay" {
+  description = "Enforce max delay for swap_io detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
+variable "swap_io_tip" {
+  description = "Suggested first course of action or any note useful for incident handling"
+  type        = string
+  default     = <<-EOF
+    There not enough RAM on the host, either increase the RAM or decrease the memory pressure (by stopping or throttling some process)
+EOF
+}
+
+variable "swap_io_runbook_url" {
+  description = "URL like SignalFx dashboard or wiki page which can help to troubleshoot the incident cause"
+  type        = string
+  default     = ""
+}
+
+variable "swap_io_disabled" {
+  description = "Disable all alerting rules for swap_io detector"
+  type        = bool
+  default     = true
+}
+
+variable "swap_io_disabled_critical" {
+  description = "Disable critical alerting rule for swap_io detector"
+  type        = bool
+  default     = null
+}
+
+variable "swap_io_disabled_major" {
+  description = "Disable major alerting rule for swap_io detector"
+  type        = bool
+  default     = null
+}
+
+variable "swap_io_threshold_critical" {
+  description = "Critical threshold for swap_io detector in iops"
+  type        = number
+  default     = 400
+}
+
+variable "swap_io_lasting_duration_critical" {
+  description = "Minimum duration that conditions must be true before raising alert"
+  type        = string
+  default     = "10m"
+}
+
+variable "swap_io_at_least_percentage_critical" {
+  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
+  type        = number
+  default     = 0.5
+}
+variable "swap_io_threshold_major" {
+  description = "Major threshold for swap_io detector in iops"
+  type        = number
+  default     = 200
+}
+
+variable "swap_io_lasting_duration_major" {
+  description = "Minimum duration that conditions must be true before raising alert"
+  type        = string
+  default     = "10m"
+}
+
+variable "swap_io_at_least_percentage_major" {
+  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
+  type        = number
+  default     = 0.5
+}


### PR DESCRIPTION
"memory" detector consider memory as a whole (RAM+swap) so it doesn't alert when there is a lot of memory pressure on hosts with a lot of swap compared to RAM (eg. 1G RAM , 0.5G swap).

This detector aim to fix this problem.

I set the default thresholds (10k and 50k) based on the values I am seeing on the incident I am working on ( ISS-427141 ) but I don't really know if they are good (maybe we will need some tweaking later).

I will try on my project ( PRJ-5PBQKN ).

note: the metric this new detector used need the [vmem](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/vmem.md) monitor (which wasn't used by any detector in this repo before)