### PR TITLE
Galera cluster

### DIFF
--- a/modules/smart-agent_galera/README.md
+++ b/modules/smart-agent_galera/README.md
@@ -1,0 +1,176 @@
+# GALERA SignalFx detectors
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## How to use this module?
+
+This directory defines a [Terraform](https://www.terraform.io/)
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
+existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
+`module` configuration and setting its `source` parameter to URL of this folder:
+
+```hcl
+module "signalfx-detectors-smart-agent-galera" {
+  source = "github.com/claranet/terraform-signalfx-detectors.git//modules/smart-agent_galera?ref={revision}"
+
+  environment   = var.environment
+  notifications = local.notifications
+}
+```
+
+Note the following parameters:
+
+* `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
+  Terraform uses it to specify subfolders within a Git repo (see [module
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
+  this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
+  like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
+  [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
+  instead of `git` which is more flexible but less future-proof.
+
+* `environment`: Use this parameter to specify the
+  [environment](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#environment) used by this
+  instance of the module.
+  Its value will be added to the `prefixes` list at the start of the [detector
+  name](https://github.com/claranet/terraform-signalfx-detectors/wiki/Templating#example).
+  In general, it will also be used in the `filtering` internal sub-module to [apply
+  filters](https://github.com/claranet/terraform-signalfx-detectors/wiki/Guidance#filtering) based on our default
+  [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
+
+* `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
+  and its value is a list of recipients. Every recipients must respect the [detector notification
+  format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
+  Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
+  documentation to understand the recommended role of each severity.
+
+These 3 parameters alongs with all variables defined in [common-variables.tf](common-variables.tf) are common to all
+[modules](../) in this repository. Other variables, specific to this module, are available in
+[variables-gen.tf](variables-gen.tf).
+In general, the default configuration "works" but all of these Terraform
+[variables](https://www.terraform.io/language/values/variables) make it possible to
+customize the detectors behavior to better fit your needs.
+
+Most of them represent usual tips and rules detailled in the
+[guidance](https://github.com/claranet/terraform-signalfx-detectors/wiki/Guidance) documentation and listed in the
+common [variables](https://github.com/claranet/terraform-signalfx-detectors/wiki/Variables) dedicated documentation.
+
+Feel free to explore the [wiki](https://github.com/claranet/terraform-signalfx-detectors/wiki) for more information about
+general usage of this repository.
+
+## What are the available detectors in this module?
+
+This module creates the following SignalFx detectors which could contain one or multiple alerting rules:
+
+|Detector|Critical|Major|Minor|Warning|Info|
+|---|---|---|---|---|---|
+|Galera node|X|-|-|-|-|
+|Galera node state|X|-|-|-|-|
+|Galera replication paused ratio|-|X|X|-|-|
+|Galera recv queue length|-|X|X|-|-|
+
+## How to collect required metrics?
+
+This module deploys detectors using metrics reported by the
+[SignalFx Smart Agent Monitors](https://github.com/signalfx/signalfx-agent#monitors).
+
+Even if the [Smart Agent is deprecated](https://github.com/signalfx/signalfx-agent/blob/main/docs/smartagent-deprecation-notice.md)
+it remains an efficient, lightweight and simple monitoring agent which still works fine.
+See the [official documentation](https://docs.splunk.com/Observability/gdi/smart-agent/smart-agent-resources.html) for more information
+about this agent.
+You might find the related following documentations useful:
+- the global level [agent configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/config-schema.md)
+- the [monitor level configuration](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitor-config.md)
+- the internal [agent configuration tips](https://github.com/claranet/terraform-signalfx-detectors/wiki/Guidance#agent-configuration).
+- the full list of [monitors available](https://github.com/signalfx/signalfx-agent/tree/main/docs/monitors) with their own specific documentation.
+
+In addition, all of these monitors are still available in the [Splunk Otel Collector](https://github.com/signalfx/splunk-otel-collector),
+the Splunk [distro of OpenTelemetry Collector](https://opentelemetry.io/docs/concepts/distributions/) which replaces SignalFx Smart Agent,
+thanks to the internal [Smart Agent Receiver](https://github.com/signalfx/splunk-otel-collector/tree/main/internal/receiver/smartagentreceiver).
+
+As a result:
+- any SignalFx Smart Agent monitor are compatible with the new agent OpenTelemetry Collector and related modules in this repository keep `smart-agent` as source name.
+- any OpenTelemetry receiver not based on an existing Smart Agent monitor is not available from old agent so related modules in this repository use `otel-collector` as source name.
+
+
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
+
+This module is only based on the [sql](https://docs.signalfx.com/en/latest/integrations/agent/monitors/sql.html) monitor.
+
+Here is a full configuration example working with these detectors:
+
+```yaml
+  - type: sql
+    dbDriver: mysql
+    host: &mysqlHost localhost
+    port: &mysqlPort 3306
+    extraDimensions:
+      mysql_port: *mysqlPort
+    params:
+      host: *mysqlHost
+      port: *mysqlPort
+      dbname: mysql
+      username: {"#from": "vault:secret/my-database[username]"}
+      password: {"#from": "vault:secret/my-database[password]"}
+    connectionString: '{{.username}}:{{.password}}@tcp({{.host}}:{{.port}})/{{.dbname}}'
+    queries:
+      - query: 'SHOW STATUS LIKE "wsrep_ready";'
+        datapointExpressions:
+          - 'GAUGE("mysql_wsrep_ready", {}, Value== "ON" ? 1: 0)'
+
+      - query: 'SHOW STATUS LIKE "wsrep_local_state";'
+        metrics:
+          - metricName: "mysql_wsrep_local_state"
+            valueColumn: "Value"
+ 
+      - query: 'SHOW STATUS LIKE "wsrep_flow_control_paused";'
+        metrics:
+          - metricName: "mysql_wsrep_flow_control_paused"
+            valueColumn: "Value"
+
+      - query: 'SHOW STATUS LIKE "wsrep_local_recv_queue_avg";'
+        metrics:
+          - metricName: "mysql_wsrep_local_recv_queue_avg"
+            valueColumn: "Value"
+```
+
+If you already use the MySQL module, you can just merge the `queries` attribute with the one already present in your configuration.
+
+
+### Metrics
+
+
+To filter only required metrics for the detectors of this module, add the
+[datapointsToExclude](https://docs.splunk.com/observability/gdi/smart-agent/smart-agent-resources.html#filtering-data-using-the-smart-agent)
+parameter to the corresponding monitor configuration:
+
+```yaml
+    datapointsToExclude:
+      - metricNames:
+        - '*'
+        - '!mysql_wsrep_flow_control_paused'
+        - '!mysql_wsrep_local_recv_queue_avg'
+        - '!mysql_wsrep_local_state'
+        - '!mysql_wsrep_ready'
+
+```
+
+## Notes
+
+To prepare the Mysql server allowing monitoring you can use [this terraform module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/database/mysql).
+
+This module is usually used in addition with the [MySQL](../database/mysql) module.
+
+
+## Related documentation
+
+* [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
+* [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [Official SQL documentation](https://docs.signalfx.com/en/latest/integrations/integrations-reference/integrations.mysql.html)
+* [Galera Status variables](https://galeracluster.com/library/documentation/galera-status-variables.html)
+* [Galera monitoring](https://galeracluster.com/library/documentation/monitoring-cluster.html)

--- a/modules/smart-agent_galera/README.md
+++ b/modules/smart-agent_galera/README.md
@@ -161,9 +161,9 @@ parameter to the corresponding monitor configuration:
 
 ## Notes
 
-To prepare the Mysql server allowing monitoring you can use [this terraform module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/database/mysql).
+To prepare the Mysql server you can use [this terraform module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/database/mysql).
 
-This module is usually used in addition with the [MySQL](../database/mysql) module.
+This module is usually used in addition with the [MySQL](../smart-agent_mysql) module.
 
 
 ## Related documentation
@@ -174,3 +174,4 @@ This module is usually used in addition with the [MySQL](../database/mysql) modu
 * [Official SQL documentation](https://docs.signalfx.com/en/latest/integrations/integrations-reference/integrations.mysql.html)
 * [Galera Status variables](https://galeracluster.com/library/documentation/galera-status-variables.html)
 * [Galera monitoring](https://galeracluster.com/library/documentation/monitoring-cluster.html)
+* [Galera node state](https://galeracluster.com/library/documentation/node-states.html#node-state-changes)

--- a/modules/smart-agent_galera/common-filters.tf
+++ b/modules/smart-agent_galera/common-filters.tf
@@ -1,0 +1,1 @@
+../../common/module/filters-smart-agent.tf

--- a/modules/smart-agent_galera/common-locals.tf
+++ b/modules/smart-agent_galera/common-locals.tf
@@ -1,0 +1,1 @@
+../../common/module/locals.tf

--- a/modules/smart-agent_galera/common-modules.tf
+++ b/modules/smart-agent_galera/common-modules.tf
@@ -1,0 +1,1 @@
+../../common/module/modules.tf

--- a/modules/smart-agent_galera/common-variables.tf
+++ b/modules/smart-agent_galera/common-variables.tf
@@ -1,0 +1,1 @@
+../../common/module/variables.tf

--- a/modules/smart-agent_galera/common-versions.tf
+++ b/modules/smart-agent_galera/common-versions.tf
@@ -1,0 +1,1 @@
+../../common/module/versions.tf

--- a/modules/smart-agent_galera/conf/01-node.yaml
+++ b/modules/smart-agent_galera/conf/01-node.yaml
@@ -1,0 +1,13 @@
+module: galera
+name: "node"
+transformation: true
+aggregation: true
+signals:
+  signal:
+    metric: "mysql_wsrep_ready"
+rules:
+  critical:
+    lasting_duration: 10m
+    description: "is not ready"
+    threshold: 1
+    comparator: "<"

--- a/modules/smart-agent_galera/conf/02-state.yaml
+++ b/modules/smart-agent_galera/conf/02-state.yaml
@@ -1,0 +1,14 @@
+module: galera
+name: "node state"
+transformation: true
+aggregation: true
+disable: true
+signals:
+  signal:
+    metric: "mysql_wsrep_local_state"
+rules:
+  critical:
+    lasting_duration: 10m
+    description: "is not Synced"
+    threshold: 4
+    comparator: "!="

--- a/modules/smart-agent_galera/conf/03-flow-control.yaml
+++ b/modules/smart-agent_galera/conf/03-flow-control.yaml
@@ -1,0 +1,18 @@
+module: galera
+name: "replication paused ratio"
+transformation: true
+aggregation: true 
+disabled: true
+signals:
+  signal:
+    metric: "mysql_wsrep_flow_control_paused"
+rules:
+  major:
+    lasting_duration: 10m
+    threshold: 0.05
+    comparator: ">"
+  minor:
+    lasting_duration: 10m
+    threshold: 0
+    comparator: ">"
+    dependency: major

--- a/modules/smart-agent_galera/conf/04-recv-queue.yaml
+++ b/modules/smart-agent_galera/conf/04-recv-queue.yaml
@@ -1,0 +1,18 @@
+module: galera
+name: "Recv queue length"
+transformation: true
+aggregation: true
+disabled: true
+signals:
+  signal:
+    metric: "mysql_wsrep_local_recv_queue_avg"
+rules:
+  major:
+    lasting_duration: 10m
+    threshold: 0.1
+    comparator: ">"
+  minor:
+    lasting_duration: 10m
+    threshold: 0
+    comparator: ">"
+    dependency: major

--- a/modules/smart-agent_galera/conf/readme.yaml
+++ b/modules/smart-agent_galera/conf/readme.yaml
@@ -1,0 +1,55 @@
+documentations:
+  - name: Official SQL documentation
+    url: https://docs.signalfx.com/en/latest/integrations/integrations-reference/integrations.mysql.html
+  - name: Galera Status variables
+    url: https://galeracluster.com/library/documentation/galera-status-variables.html
+  - name: Galera monitoring
+    url: https://galeracluster.com/library/documentation/monitoring-cluster.html
+notes: |
+  To prepare the Mysql server allowing monitoring you can use [this terraform module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/database/mysql).
+
+  This module is usually used in addition with the [MySQL](../database/mysql) module.
+
+source_doc: |
+  This module is only based on the [sql](https://docs.signalfx.com/en/latest/integrations/agent/monitors/sql.html) monitor.
+  
+  Here is a full configuration example working with these detectors:
+  
+  ```yaml
+    - type: sql
+      dbDriver: mysql
+      host: &mysqlHost localhost
+      port: &mysqlPort 3306
+      extraDimensions:
+        mysql_port: *mysqlPort
+      params:
+        host: *mysqlHost
+        port: *mysqlPort
+        dbname: mysql
+        username: {"#from": "vault:secret/my-database[username]"}
+        password: {"#from": "vault:secret/my-database[password]"}
+      connectionString: '{{.username}}:{{.password}}@tcp({{.host}}:{{.port}})/{{.dbname}}'
+      queries:
+        - query: 'SHOW STATUS LIKE "wsrep_ready";'
+          datapointExpressions:
+            - 'GAUGE("mysql_wsrep_ready", {}, Value== "ON" ? 1: 0)'
+  
+        - query: 'SHOW STATUS LIKE "wsrep_local_state";'
+          metrics:
+            - metricName: "mysql_wsrep_local_state"
+              valueColumn: "Value"
+   
+        - query: 'SHOW STATUS LIKE "wsrep_flow_control_paused";'
+          metrics:
+            - metricName: "mysql_wsrep_flow_control_paused"
+              valueColumn: "Value"
+  
+        - query: 'SHOW STATUS LIKE "wsrep_local_recv_queue_avg";'
+          metrics:
+            - metricName: "mysql_wsrep_local_recv_queue_avg"
+              valueColumn: "Value"
+  ```
+  
+  If you already use the MySQL module, you can just merge the `queries` attribute with the one already present in your configuration.
+  
+

--- a/modules/smart-agent_galera/detectors-gen.tf
+++ b/modules/smart-agent_galera/detectors-gen.tf
@@ -1,0 +1,134 @@
+resource "signalfx_detector" "node" {
+  name = format("%s %s", local.detector_name_prefix, "Galera node")
+
+  authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
+  tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
+
+  program_text = <<-EOF
+    signal = data('mysql_wsrep_ready', filter=${module.filtering.signalflow})${var.node_aggregation_function}${var.node_transformation_function}.publish('signal')
+    detect(when(signal < ${var.node_threshold_critical}, lasting=%{if var.node_lasting_duration_critical == null}None%{else}'${var.node_lasting_duration_critical}'%{endif}, at_least=${var.node_at_least_percentage_critical})).publish('CRIT')
+EOF
+
+  rule {
+    description           = "is not ready < ${var.node_threshold_critical}"
+    severity              = "Critical"
+    detect_label          = "CRIT"
+    disabled              = coalesce(var.node_disabled, var.detectors_disabled)
+    notifications         = try(coalescelist(lookup(var.node_notifications, "critical", []), var.notifications.critical), null)
+    runbook_url           = try(coalesce(var.node_runbook_url, var.runbook_url), "")
+    tip                   = var.node_tip
+    parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
+    parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
+  }
+
+  max_delay = var.node_max_delay
+}
+
+resource "signalfx_detector" "node_state" {
+  name = format("%s %s", local.detector_name_prefix, "Galera node state")
+
+  authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
+  tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
+
+  program_text = <<-EOF
+    signal = data('mysql_wsrep_local_state', filter=${module.filtering.signalflow})${var.node_state_aggregation_function}${var.node_state_transformation_function}.publish('signal')
+    detect(when(signal != ${var.node_state_threshold_critical}, lasting=%{if var.node_state_lasting_duration_critical == null}None%{else}'${var.node_state_lasting_duration_critical}'%{endif}, at_least=${var.node_state_at_least_percentage_critical})).publish('CRIT')
+EOF
+
+  rule {
+    description           = "is not Synced != ${var.node_state_threshold_critical}"
+    severity              = "Critical"
+    detect_label          = "CRIT"
+    disabled              = coalesce(var.node_state_disabled, var.detectors_disabled)
+    notifications         = try(coalescelist(lookup(var.node_state_notifications, "critical", []), var.notifications.critical), null)
+    runbook_url           = try(coalesce(var.node_state_runbook_url, var.runbook_url), "")
+    tip                   = var.node_state_tip
+    parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
+    parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
+  }
+
+  max_delay = var.node_state_max_delay
+}
+
+resource "signalfx_detector" "replication_paused_ratio" {
+  name = format("%s %s", local.detector_name_prefix, "Galera replication paused ratio")
+
+  authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
+  tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
+
+  program_text = <<-EOF
+    signal = data('mysql_wsrep_flow_control_paused', filter=${module.filtering.signalflow})${var.replication_paused_ratio_aggregation_function}${var.replication_paused_ratio_transformation_function}.publish('signal')
+    detect(when(signal > ${var.replication_paused_ratio_threshold_major}, lasting=%{if var.replication_paused_ratio_lasting_duration_major == null}None%{else}'${var.replication_paused_ratio_lasting_duration_major}'%{endif}, at_least=${var.replication_paused_ratio_at_least_percentage_major})).publish('MAJOR')
+    detect(when(signal > ${var.replication_paused_ratio_threshold_minor}, lasting=%{if var.replication_paused_ratio_lasting_duration_minor == null}None%{else}'${var.replication_paused_ratio_lasting_duration_minor}'%{endif}, at_least=${var.replication_paused_ratio_at_least_percentage_minor}) and (not when(signal > ${var.replication_paused_ratio_threshold_major}, lasting=%{if var.replication_paused_ratio_lasting_duration_major == null}None%{else}'${var.replication_paused_ratio_lasting_duration_major}'%{endif}, at_least=${var.replication_paused_ratio_at_least_percentage_major}))).publish('MINOR')
+EOF
+
+  rule {
+    description           = "is too high > ${var.replication_paused_ratio_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.replication_paused_ratio_disabled_major, var.replication_paused_ratio_disabled, var.detectors_disabled)
+    notifications         = try(coalescelist(lookup(var.replication_paused_ratio_notifications, "major", []), var.notifications.major), null)
+    runbook_url           = try(coalesce(var.replication_paused_ratio_runbook_url, var.runbook_url), "")
+    tip                   = var.replication_paused_ratio_tip
+    parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
+    parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
+  }
+
+  rule {
+    description           = "is too high > ${var.replication_paused_ratio_threshold_minor}"
+    severity              = "Minor"
+    detect_label          = "MINOR"
+    disabled              = coalesce(var.replication_paused_ratio_disabled_minor, var.replication_paused_ratio_disabled, var.detectors_disabled)
+    notifications         = try(coalescelist(lookup(var.replication_paused_ratio_notifications, "minor", []), var.notifications.minor), null)
+    runbook_url           = try(coalesce(var.replication_paused_ratio_runbook_url, var.runbook_url), "")
+    tip                   = var.replication_paused_ratio_tip
+    parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
+    parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
+  }
+
+  max_delay = var.replication_paused_ratio_max_delay
+}
+
+resource "signalfx_detector" "recv_queue_length" {
+  name = format("%s %s", local.detector_name_prefix, "Galera recv queue length")
+
+  authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
+  tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
+
+  program_text = <<-EOF
+    signal = data('mysql_wsrep_local_recv_queue_avg', filter=${module.filtering.signalflow})${var.recv_queue_length_aggregation_function}${var.recv_queue_length_transformation_function}.publish('signal')
+    detect(when(signal > ${var.recv_queue_length_threshold_major}, lasting=%{if var.recv_queue_length_lasting_duration_major == null}None%{else}'${var.recv_queue_length_lasting_duration_major}'%{endif}, at_least=${var.recv_queue_length_at_least_percentage_major})).publish('MAJOR')
+    detect(when(signal > ${var.recv_queue_length_threshold_minor}, lasting=%{if var.recv_queue_length_lasting_duration_minor == null}None%{else}'${var.recv_queue_length_lasting_duration_minor}'%{endif}, at_least=${var.recv_queue_length_at_least_percentage_minor}) and (not when(signal > ${var.recv_queue_length_threshold_major}, lasting=%{if var.recv_queue_length_lasting_duration_major == null}None%{else}'${var.recv_queue_length_lasting_duration_major}'%{endif}, at_least=${var.recv_queue_length_at_least_percentage_major}))).publish('MINOR')
+EOF
+
+  rule {
+    description           = "is too high > ${var.recv_queue_length_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.recv_queue_length_disabled_major, var.recv_queue_length_disabled, var.detectors_disabled)
+    notifications         = try(coalescelist(lookup(var.recv_queue_length_notifications, "major", []), var.notifications.major), null)
+    runbook_url           = try(coalesce(var.recv_queue_length_runbook_url, var.runbook_url), "")
+    tip                   = var.recv_queue_length_tip
+    parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
+    parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
+  }
+
+  rule {
+    description           = "is too high > ${var.recv_queue_length_threshold_minor}"
+    severity              = "Minor"
+    detect_label          = "MINOR"
+    disabled              = coalesce(var.recv_queue_length_disabled_minor, var.recv_queue_length_disabled, var.detectors_disabled)
+    notifications         = try(coalescelist(lookup(var.recv_queue_length_notifications, "minor", []), var.notifications.minor), null)
+    runbook_url           = try(coalesce(var.recv_queue_length_runbook_url, var.runbook_url), "")
+    tip                   = var.recv_queue_length_tip
+    parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
+    parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
+  }
+
+  max_delay = var.recv_queue_length_max_delay
+}
+

--- a/modules/smart-agent_galera/tags.tf
+++ b/modules/smart-agent_galera/tags.tf
@@ -1,0 +1,4 @@
+locals {
+  tags = ["smart-agent", "galera"]
+}
+

--- a/modules/smart-agent_galera/variables-gen.tf
+++ b/modules/smart-agent_galera/variables-gen.tf
@@ -1,0 +1,302 @@
+# node detector
+
+variable "node_notifications" {
+  description = "Notification recipients list per severity overridden for node detector"
+  type        = map(list(string))
+  default     = {}
+}
+
+variable "node_aggregation_function" {
+  description = "Aggregation function and group by for node detector (i.e. \".mean(by=['host'])\")"
+  type        = string
+  default     = ""
+}
+
+variable "node_transformation_function" {
+  description = "Transformation function for node detector (i.e. \".mean(over='5m')\")"
+  type        = string
+  default     = ""
+}
+
+variable "node_max_delay" {
+  description = "Enforce max delay for node detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
+variable "node_tip" {
+  description = "Suggested first course of action or any note useful for incident handling"
+  type        = string
+  default     = ""
+}
+
+variable "node_runbook_url" {
+  description = "URL like SignalFx dashboard or wiki page which can help to troubleshoot the incident cause"
+  type        = string
+  default     = ""
+}
+
+variable "node_disabled" {
+  description = "Disable all alerting rules for node detector"
+  type        = bool
+  default     = null
+}
+
+variable "node_threshold_critical" {
+  description = "Critical threshold for node detector"
+  type        = number
+  default     = 1
+}
+
+variable "node_lasting_duration_critical" {
+  description = "Minimum duration that conditions must be true before raising alert"
+  type        = string
+  default     = "10m"
+}
+
+variable "node_at_least_percentage_critical" {
+  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
+  type        = number
+  default     = 1
+}
+# node_state detector
+
+variable "node_state_notifications" {
+  description = "Notification recipients list per severity overridden for node_state detector"
+  type        = map(list(string))
+  default     = {}
+}
+
+variable "node_state_aggregation_function" {
+  description = "Aggregation function and group by for node_state detector (i.e. \".mean(by=['host'])\")"
+  type        = string
+  default     = ""
+}
+
+variable "node_state_transformation_function" {
+  description = "Transformation function for node_state detector (i.e. \".mean(over='5m')\")"
+  type        = string
+  default     = ""
+}
+
+variable "node_state_max_delay" {
+  description = "Enforce max delay for node_state detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
+variable "node_state_tip" {
+  description = "Suggested first course of action or any note useful for incident handling"
+  type        = string
+  default     = ""
+}
+
+variable "node_state_runbook_url" {
+  description = "URL like SignalFx dashboard or wiki page which can help to troubleshoot the incident cause"
+  type        = string
+  default     = ""
+}
+
+variable "node_state_disabled" {
+  description = "Disable all alerting rules for node_state detector"
+  type        = bool
+  default     = null
+}
+
+variable "node_state_threshold_critical" {
+  description = "Critical threshold for node_state detector"
+  type        = number
+  default     = 4
+}
+
+variable "node_state_lasting_duration_critical" {
+  description = "Minimum duration that conditions must be true before raising alert"
+  type        = string
+  default     = "10m"
+}
+
+variable "node_state_at_least_percentage_critical" {
+  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
+  type        = number
+  default     = 1
+}
+# replication_paused_ratio detector
+
+variable "replication_paused_ratio_notifications" {
+  description = "Notification recipients list per severity overridden for replication_paused_ratio detector"
+  type        = map(list(string))
+  default     = {}
+}
+
+variable "replication_paused_ratio_aggregation_function" {
+  description = "Aggregation function and group by for replication_paused_ratio detector (i.e. \".mean(by=['host'])\")"
+  type        = string
+  default     = ""
+}
+
+variable "replication_paused_ratio_transformation_function" {
+  description = "Transformation function for replication_paused_ratio detector (i.e. \".mean(over='5m')\")"
+  type        = string
+  default     = ""
+}
+
+variable "replication_paused_ratio_max_delay" {
+  description = "Enforce max delay for replication_paused_ratio detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
+variable "replication_paused_ratio_tip" {
+  description = "Suggested first course of action or any note useful for incident handling"
+  type        = string
+  default     = ""
+}
+
+variable "replication_paused_ratio_runbook_url" {
+  description = "URL like SignalFx dashboard or wiki page which can help to troubleshoot the incident cause"
+  type        = string
+  default     = ""
+}
+
+variable "replication_paused_ratio_disabled" {
+  description = "Disable all alerting rules for replication_paused_ratio detector"
+  type        = bool
+  default     = true
+}
+
+variable "replication_paused_ratio_disabled_major" {
+  description = "Disable major alerting rule for replication_paused_ratio detector"
+  type        = bool
+  default     = null
+}
+
+variable "replication_paused_ratio_disabled_minor" {
+  description = "Disable minor alerting rule for replication_paused_ratio detector"
+  type        = bool
+  default     = null
+}
+
+variable "replication_paused_ratio_threshold_major" {
+  description = "Major threshold for replication_paused_ratio detector"
+  type        = number
+  default     = 0.05
+}
+
+variable "replication_paused_ratio_lasting_duration_major" {
+  description = "Minimum duration that conditions must be true before raising alert"
+  type        = string
+  default     = "10m"
+}
+
+variable "replication_paused_ratio_at_least_percentage_major" {
+  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
+  type        = number
+  default     = 1
+}
+variable "replication_paused_ratio_threshold_minor" {
+  description = "Minor threshold for replication_paused_ratio detector"
+  type        = number
+  default     = 0
+}
+
+variable "replication_paused_ratio_lasting_duration_minor" {
+  description = "Minimum duration that conditions must be true before raising alert"
+  type        = string
+  default     = "10m"
+}
+
+variable "replication_paused_ratio_at_least_percentage_minor" {
+  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
+  type        = number
+  default     = 1
+}
+# recv_queue_length detector
+
+variable "recv_queue_length_notifications" {
+  description = "Notification recipients list per severity overridden for recv_queue_length detector"
+  type        = map(list(string))
+  default     = {}
+}
+
+variable "recv_queue_length_aggregation_function" {
+  description = "Aggregation function and group by for recv_queue_length detector (i.e. \".mean(by=['host'])\")"
+  type        = string
+  default     = ""
+}
+
+variable "recv_queue_length_transformation_function" {
+  description = "Transformation function for recv_queue_length detector (i.e. \".mean(over='5m')\")"
+  type        = string
+  default     = ""
+}
+
+variable "recv_queue_length_max_delay" {
+  description = "Enforce max delay for recv_queue_length detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
+variable "recv_queue_length_tip" {
+  description = "Suggested first course of action or any note useful for incident handling"
+  type        = string
+  default     = ""
+}
+
+variable "recv_queue_length_runbook_url" {
+  description = "URL like SignalFx dashboard or wiki page which can help to troubleshoot the incident cause"
+  type        = string
+  default     = ""
+}
+
+variable "recv_queue_length_disabled" {
+  description = "Disable all alerting rules for recv_queue_length detector"
+  type        = bool
+  default     = true
+}
+
+variable "recv_queue_length_disabled_major" {
+  description = "Disable major alerting rule for recv_queue_length detector"
+  type        = bool
+  default     = null
+}
+
+variable "recv_queue_length_disabled_minor" {
+  description = "Disable minor alerting rule for recv_queue_length detector"
+  type        = bool
+  default     = null
+}
+
+variable "recv_queue_length_threshold_major" {
+  description = "Major threshold for recv_queue_length detector"
+  type        = number
+  default     = 0.1
+}
+
+variable "recv_queue_length_lasting_duration_major" {
+  description = "Minimum duration that conditions must be true before raising alert"
+  type        = string
+  default     = "10m"
+}
+
+variable "recv_queue_length_at_least_percentage_major" {
+  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
+  type        = number
+  default     = 1
+}
+variable "recv_queue_length_threshold_minor" {
+  description = "Minor threshold for recv_queue_length detector"
+  type        = number
+  default     = 0
+}
+
+variable "recv_queue_length_lasting_duration_minor" {
+  description = "Minimum duration that conditions must be true before raising alert"
+  type        = string
+  default     = "10m"
+}
+
+variable "recv_queue_length_at_least_percentage_minor" {
+  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
+  type        = number
+  default     = 1
+}


### PR DESCRIPTION
Add new module to monitor MySQL Galera Cluster. 

Only the bare minimum is enabled by default :
* Check if the node is ready or not
* Check if the node is in the synced state (https://galeracluster.com/library/documentation/node-states.html#node-state-changes)  
* Check the replication queue length (disabled by default as threshold can vary a lot depending on the cluster usage)
* Check the replication paused ratio (also disable by default for the same reasons)
