### PR TITLE
Add splunk otel kubernetes common detectors

### DIFF
--- a/docs/severity.md
+++ b/docs/severity.md
@@ -69,6 +69,7 @@
 - [integration_gcp-pubsub-topic](#integration_gcp-pubsub-topic)
 - [integration_newrelic-apm](#integration_newrelic-apm)
 - [organization_usage](#organization_usage)
+- [otel-collector_kubernetes-common](#otel-collector_kubernetes-common)
 - [prometheus-exporter_active-directory](#prometheus-exporter_active-directory)
 - [prometheus-exporter_kong](#prometheus-exporter_kong)
 - [prometheus-exporter_oracledb](#prometheus-exporter_oracledb)
@@ -758,6 +759,28 @@
 |Organization usage custom metrics limit|-|X|-|-|-|
 |Organization usage containers ratio per host included|-|X|-|-|-|
 |Organization usage custom metrics ratio per host included|-|X|-|-|-|
+
+
+## otel-collector_kubernetes-common
+
+|Detector|Critical|Major|Minor|Warning|Info|
+|---|---|---|---|---|---|
+|Kubernetes heartbeat|X|-|-|-|-|
+|Kubernetes hpa scale exceeded capacity|-|X|-|-|-|
+|Kubernetes node status|-|X|X|-|-|
+|Kubernetes pod phase status|-|X|X|X|-|
+|Kubernetes pod terminated abnormally|-|X|-|-|-|
+|Kubernetes container killed by oom|-|X|-|-|-|
+|Kubernetes deployment in crashloopbackoff|-|X|-|-|-|
+|Kubernetes daemonset in crashloopbackoff|-|X|-|-|-|
+|Kubernetes job from cronjob failed|-|X|-|-|-|
+|Kubernetes daemonsets scheduled|X|-|-|-|-|
+|Kubernetes daemonsets ready|X|-|-|-|-|
+|Kubernetes daemonsets misscheduled|X|-|-|-|-|
+|Kubernetes deployments available|X|-|-|-|-|
+|Kubernetes replicasets available|X|-|-|-|-|
+|Kubernetes replication controllers available|X|-|-|-|-|
+|Kubernetes statefulsets ready|X|-|-|-|-|
 
 
 ## prometheus-exporter_active-directory

--- a/modules/otel-collector_kubernetes-common/README.md
+++ b/modules/otel-collector_kubernetes-common/README.md
@@ -1,0 +1,309 @@
+# KUBERNETES-COMMON SignalFx detectors
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+:link: **Contents**
+
+- [How to use this module?](#how-to-use-this-module)
+- [What are the available detectors in this module?](#what-are-the-available-detectors-in-this-module)
+- [How to collect required metrics?](#how-to-collect-required-metrics)
+  - [Agent](#agent)
+  - [Monitors](#monitors)
+  - [Examples](#examples)
+  - [Metrics](#metrics)
+- [Notes](#notes)
+  - [About `node_ready` detector](#about-node_ready-detector)
+  - [About `job_failed` detector](#about-job_failed-detector)
+  - [About `oom_killed` detector](#about-oom_killed-detector)
+- [Related documentation](#related-documentation)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## How to use this module?
+
+This directory defines a [Terraform](https://www.terraform.io/)
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
+existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
+`module` configuration and setting its `source` parameter to URL of this folder:
+
+```hcl
+module "signalfx-detectors-otel-collector-kubernetes-common" {
+  source = "github.com/claranet/terraform-signalfx-detectors.git//modules/otel-collector_kubernetes-common?ref={revision}"
+
+  environment   = var.environment
+  notifications = local.notifications
+}
+```
+
+Note the following parameters:
+
+* `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
+  Terraform uses it to specify subfolders within a Git repo (see [module
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
+  this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
+  like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
+  [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
+  instead of `git` which is more flexible but less future-proof.
+
+* `environment`: Use this parameter to specify the
+  [environment](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#environment) used by this
+  instance of the module.
+  Its value will be added to the `prefixes` list at the start of the [detector
+  name](https://github.com/claranet/terraform-signalfx-detectors/wiki/Templating#example).
+  In general, it will also be used in the `filtering` internal sub-module to [apply
+  filters](https://github.com/claranet/terraform-signalfx-detectors/wiki/Guidance#filtering) based on our default
+  [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
+
+* `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
+  and its value is a list of recipients. Every recipients must respect the [detector notification
+  format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
+  Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
+  documentation to understand the recommended role of each severity.
+
+These 3 parameters alongs with all variables defined in [common-variables.tf](common-variables.tf) are common to all
+[modules](../) in this repository. Other variables, specific to this module, are available in
+[variables-gen.tf](variables-gen.tf).
+In general, the default configuration "works" but all of these Terraform
+[variables](https://www.terraform.io/language/values/variables) make it possible to
+customize the detectors behavior to better fit your needs.
+
+Most of them represent usual tips and rules detailled in the
+[guidance](https://github.com/claranet/terraform-signalfx-detectors/wiki/Guidance) documentation and listed in the
+common [variables](https://github.com/claranet/terraform-signalfx-detectors/wiki/Variables) dedicated documentation.
+
+Feel free to explore the [wiki](https://github.com/claranet/terraform-signalfx-detectors/wiki) for more information about
+general usage of this repository.
+
+## What are the available detectors in this module?
+
+This module creates the following SignalFx detectors which could contain one or multiple alerting rules:
+
+|Detector|Critical|Major|Minor|Warning|Info|
+|---|---|---|---|---|---|
+|Kubernetes heartbeat|X|-|-|-|-|
+|Kubernetes hpa scale exceeded capacity|-|X|-|-|-|
+|Kubernetes node status|-|X|X|-|-|
+|Kubernetes pod phase status|-|X|X|X|-|
+|Kubernetes pod terminated abnormally|-|X|-|-|-|
+|Kubernetes container killed by oom|-|X|-|-|-|
+|Kubernetes deployment in crashloopbackoff|-|X|-|-|-|
+|Kubernetes daemonset in crashloopbackoff|-|X|-|-|-|
+|Kubernetes job from cronjob failed|-|X|-|-|-|
+|Kubernetes daemonsets scheduled|X|-|-|-|-|
+|Kubernetes daemonsets ready|X|-|-|-|-|
+|Kubernetes daemonsets misscheduled|X|-|-|-|-|
+|Kubernetes deployments available|X|-|-|-|-|
+|Kubernetes replicasets available|X|-|-|-|-|
+|Kubernetes replication controllers available|X|-|-|-|-|
+|Kubernetes statefulsets ready|X|-|-|-|-|
+
+## How to collect required metrics?
+
+This module deploys detectors using metrics reported by the
+[Receivers](https://github.com/open-telemetry/opentelemetry-collector/blob/master/receiver/README.md) of the [OpenTelemetry
+Collector](https://opentelemetry.io/docs/collector/), a new vendor-agnostic agent which replaces the [SignalFx Smart
+Agent](https://github.com/signalfx/signalfx-agent/) in Splunk Observability (fka SignalFx).
+
+It is surely more powerful but therefore more complex so give a look to the [official documentation](https://opentelemetry.io/docs/collector/configuration/)
+to learn how to configure Otel Collector and your receivers properly.
+
+The full list of available receivers are distributed through different sources:
+- the [officially supported receivers](https://github.com/open-telemetry/opentelemetry-collector/tree/main/receiver) from the core repository
+- the [contributions based receivers](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver) which represents
+a superset of the core repository.
+- the [splunk specific receivers](https://github.com/signalfx/splunk-otel-collector/tree/main/internal/receiver) from the Splunk distro of
+the OpenTelemetry Collector based on the contributions repository.
+
+
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
+
+### Agent
+
+Here is the official [main
+documentation](https://github.com/signalfx/integrations/blob/master/kubernetes/SMART_AGENT_MONITOR.md) for
+kubernetes including the `signalfx-agent` installation which must be installed as
+[daemonset](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/) on your cluster.
+
+### Monitors
+
+The detectors in this module are based on metrics reported by the following monitors:
+
+* [kubelet-metrics](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/kubelet-metrics.md) for Kubernetes `>= 1.18`
+* [kubelet-stats](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/kubelet-stats.md) for Kubernetes `< 1.18
+* [kubernetes-cluster](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/kubernetes-cluster.md)
+
+The `kubernetes-cluster` requires to enable the following `extraMetrics`:
+
+* `k8s.job.desired_successful_pods`
+* `k8s.job.active_pods`
+* `k8s.job.successful_pods`
+* `k8s.statefulset.ready_pods`
+* `k8s.statefulset.desired_pods`
+* `k8s.hpa.max_replicas`
+* `k8s.hpa.desired_replicas`
+
+### Examples
+
+Here is a sample configuration fragment for SignalFx Agent with `kubernetes-cluster` monitor:
+
+```yaml
+monitors:
+- type: kubernetes-cluster
+  extraMetrics:
+    - k8s.job.desired_successful_pods
+    - k8s.job.active_pods
+    - k8s.job.successful_pods
+    - k8s.statefulset.ready_pods
+    - k8s.statefulset.desired_pods
+    - k8s.hpa.max_replicas
+    - k8s.hpa.desired_replicas
+```
+
+You can replace `kubernetes-cluster` with `openshift-cluster` you monitor Openshift Kubernetes.
+
+Then add the monitor `kubelet-metrics` for Kubernetes version `>= 1.18`. Example for GKE:
+
+```yaml
+- type: kubelet-metrics
+  kubeletAPI:
+    authType: serviceAccount
+  usePodsEndpoint: true
+```
+
+__Note__: `usePodsEndpoint: true` allows to enhance containers metrics with `container.id` dimension.
+
+If you use a Kubernetes version `< 1.18` you have to replace `kubelet-metrics` monitor by `kubelet-stats`.
+Example for GKE:
+
+```yaml
+- type: kubelet-stats
+  kubeletAPI:
+    authType: serviceAccount
+  datapointsToExclude:
+  - dimensions:
+      container.image.name:
+      - '*pause-amd64*'
+      - 'k8s.gcr.io/pause*'
+    metricNames:
+      - '*'
+      - '!*network*'
+```
+
+Using the SignalFx [Helm](https://helm.sh/) [chart](https://github.com/signalfx/signalfx-agent/tree/master/deployments/k8s/helm/signalfx-agent)
+could ease the agent installation and configuration:
+
+```yaml
+# Increase depending on your use case
+resources:
+  limits:
+    cpu: 250m
+    memory: 768Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+# Change for your kubernetes cluster name
+clusterName: "sfx-doc"
+
+# Change for your realm
+signalFxRealm: eu0
+
+# Required to use the default filtering convention
+globalDimensions:
+  sfx_monitored: true
+  # Change for your env
+  env: sandbox
+
+# Required to use this module
+clusterExtraMetrics:
+  - k8s.job.desired_successful_pods
+  - k8s.job.active_pods
+  - k8s.job.successful_pods
+  - k8s.statefulset.ready_pods
+  - k8s.statefulset.desired_pods
+  - k8s.hpa.max_replicas
+  - k8s.hpa.desired_replicas
+
+# Required to use "system-generic" module
+loadPerCPU: true
+
+# Required to use "kubernetes-volumes" module
+gatherVolumesMetrics: true
+
+# Example of optional monitors to add for more cool metrics
+monitors:
+  - type: prometheus-exporter
+    discoveryRule: container.image.name =~ "nginx-ingress-controller" && port == 10254
+    port: 10254
+    datapointsToExclude:
+      - metricNames:
+        - '*'
+        - '!nginx_ingress_controller_requests'
+        - '!nginx_ingress_controller_ingress_upstream_latency_seconds'
+```
+
+__Note__: `clusterExtraMetrics` option is only available from the `1.7.1` version of the helm chart.
+
+
+### Metrics
+
+
+Here is the list of required metrics for detectors in this module.
+
+* `k8s.container.ready`
+* `k8s.container.restarts`
+* `k8s.daemonset.current_scheduled_nodes`
+* `k8s.daemonset.desired_scheduled_nodes`
+* `k8s.daemonset.misscheduled_nodes`
+* `k8s.daemonset.ready_nodes`
+* `k8s.deployment.available`
+* `k8s.deployment.desired`
+* `k8s.hpa.desired_replicas`
+* `k8s.hpa.max_replicas`
+* `k8s.job.active_pods`
+* `k8s.job.desired_successful_pods`
+* `k8s.job.successful_pods`
+* `k8s.node.condition_ready`
+* `k8s.pod.phase`
+* `k8s.replicaset.available`
+* `k8s.replicaset.desired`
+* `k8s.replication_controller.available`
+* `k8s.replication_controller.desired`
+* `k8s.statefulset.desired_pods`
+* `k8s.statefulset.ready_pods`
+
+
+## Notes
+
+This module should suit to every kubernetes clusters full managed or not and could be complete with others
+modules covering more data sources like `kubernetes-volumes` or use cases like `kubernetes-apiserver`.
+
+### About `node_ready` detector
+
+* it works as for most of the "heartbeat" detectors in this repo; using state property from cloud provider to ignore alerts on host which has been terminated / stopped (i.e. autoscaling group)
+* the goal is to avoid any alert considered as normal because of host has been removed (automatically or manually)
+* but the detector will always raise alert for environment outside the cloud while we do any way to know if "not ready node" comes from stopped / terminated host or a real problem.
+
+### About `job_failed` detector
+
+* it works only on job running from cronjob
+* this will obviously raise an alert when a job is considered as failed from kubernetes point of view. Indeed, some pods could eventually fail or retry without to mark the job as failed
+* but the alert will remain until you clean/purge jobs history. Indeed, even if a new, more recent, successful job has been running in the meantime the alert will continue until you delete the failed job
+
+### About `oom_killed` detector
+
+* default transformation function is used to avoid the detector to flap repeatedly
+* if unset, expect the detector to send several alerts per minute
+
+
+## Related documentation
+
+* [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
+* [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)
+* [Smart Agent monitor kubernetes-cluster](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/kubernetes-cluster.md)
+* [Smart Agent monitor kubelet-stats](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/kubelet-stats.md)
+* [Smart Agent monitor kubelet-metrics](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/kubelet-metrics.md)
+* [Splunk Observability integration](https://docs.splunk.com/Observability/gdi/kubernetes-cluster/kubernetes-cluster.html)

--- a/modules/otel-collector_kubernetes-common/common-filters.tf
+++ b/modules/otel-collector_kubernetes-common/common-filters.tf
@@ -1,0 +1,1 @@
+../../common/module/filters-otel-collector.tf

--- a/modules/otel-collector_kubernetes-common/common-locals.tf
+++ b/modules/otel-collector_kubernetes-common/common-locals.tf
@@ -1,0 +1,1 @@
+../../common/module/locals.tf

--- a/modules/otel-collector_kubernetes-common/common-modules.tf
+++ b/modules/otel-collector_kubernetes-common/common-modules.tf
@@ -1,0 +1,1 @@
+../../common/module/modules.tf

--- a/modules/otel-collector_kubernetes-common/common-variables.tf
+++ b/modules/otel-collector_kubernetes-common/common-variables.tf
@@ -1,0 +1,1 @@
+../../common/module/variables.tf

--- a/modules/otel-collector_kubernetes-common/common-versions.tf
+++ b/modules/otel-collector_kubernetes-common/common-versions.tf
@@ -1,0 +1,1 @@
+../../common/module/versions.tf

--- a/modules/otel-collector_kubernetes-common/conf/00-heartbeat.yaml
+++ b/modules/otel-collector_kubernetes-common/conf/00-heartbeat.yaml
@@ -1,0 +1,12 @@
+module: Kubernetes
+name: heartbeat
+
+transformation: false
+aggregation: ".mean(by=['k8s.cluster.name'])"
+exclude_not_running_vm: true
+
+signals:
+  signal:
+    metric: k8s.node.condition_ready
+rules:
+  critical:

--- a/modules/otel-collector_kubernetes-common/conf/01-hpa-scale-capacity.yaml
+++ b/modules/otel-collector_kubernetes-common/conf/01-hpa-scale-capacity.yaml
@@ -1,0 +1,25 @@
+module: Kubernetes
+name: "hpa scale exceeded capacity"
+id: hpa_capacity
+
+
+
+
+
+transformation: true
+aggregation: true
+tip: "hpa ask to scale for too long, the maximum number of desired Pods has been hit or there is a lack of resources"
+
+signals:
+  max:
+    metric: k8s.hpa.max_replicas
+  desired:
+    metric: k8s.hpa.desired_replicas
+  signal:
+    formula: (desired-max)
+
+rules:
+  major:
+    threshold: 0
+    comparator: ">="
+    lasting_duration: 5m

--- a/modules/otel-collector_kubernetes-common/conf/02-node-ready.yaml
+++ b/modules/otel-collector_kubernetes-common/conf/02-node-ready.yaml
@@ -1,0 +1,24 @@
+module: Kubernetes
+name: node status
+id: node_ready
+
+transformation: true
+aggregation: true
+
+signals:
+  ready:
+    metric: k8s.node.condition_ready
+  signal:
+    formula: (ready.fill(value=1))
+
+rules:
+  major:
+    threshold: 0
+    comparator: "=="
+    lasting_duration: 1h
+    description: is not ready
+  minor:
+    threshold: -1
+    comparator: "=="
+    lasting_duration: 20m
+    description: is in unknown state

--- a/modules/otel-collector_kubernetes-common/conf/03-pod-phase-status.yaml
+++ b/modules/otel-collector_kubernetes-common/conf/03-pod-phase-status.yaml
@@ -1,0 +1,29 @@
+module: Kubernetes
+name: pod phase status
+id: pod_phase_status
+
+transformation: true
+aggregation: true
+filtering: "(not filter('k8s.job.name', '*')) and (not filter('cronk8s.job.name', '*'))"
+
+signals:
+  signal:
+    metric: k8s.pod.phase
+
+rules:
+  warning:
+    threshold: 2
+    comparator: "<"
+    lasting_duration: 30m
+    description: is pending for too long
+  minor:
+    threshold: 4
+    comparator: ">"
+    lasting_duration: 15m
+    description: is unknown
+  major:
+    threshold: 3
+    comparator: ">"
+    lasting_duration: 5m
+    description: is failed
+    dependency: minor

--- a/modules/otel-collector_kubernetes-common/conf/04-termination.yaml
+++ b/modules/otel-collector_kubernetes-common/conf/04-termination.yaml
@@ -1,0 +1,17 @@
+module: Kubernetes
+name: pod terminated abnormally
+id: terminated
+
+transformation: true
+aggregation: ".sum(by=['k8s.cluster.name', 'k8s.namespace.name', 'k8s.pod.name'])"
+filtering: "filter('container.status', 'terminated') and (not filter('container.status.reason', 'Completed'))"
+
+signals:
+  signal:
+    metric: k8s.container.ready
+
+rules:
+  major:
+    threshold: 0
+    comparator: ">"
+    lasting_duration: 10m

--- a/modules/otel-collector_kubernetes-common/conf/05-oom.yaml
+++ b/modules/otel-collector_kubernetes-common/conf/05-oom.yaml
@@ -1,0 +1,19 @@
+module: Kubernetes
+name: container killed by OOM
+id: oom_killed
+
+transformation: true
+aggregation: true
+filtering: "filter('container.status', 'terminated') and filter('container.status.reason', 'OOMKilled')"
+
+signals:
+  killed:
+    metric: k8s.container.ready
+  signal:
+    formula: (killed.count())
+
+rules:
+  major:
+    threshold: 0
+    comparator: ">"
+    lasting_duration: 1m

--- a/modules/otel-collector_kubernetes-common/conf/06-deployment-crashloopbackoff.yaml
+++ b/modules/otel-collector_kubernetes-common/conf/06-deployment-crashloopbackoff.yaml
@@ -1,0 +1,17 @@
+module: Kubernetes
+name: deployment in CrashLoopBackOff
+id: deployment_crashloopbackoff
+
+transformation: ".sum(over='15m')"
+aggregation: ".sum(by=['k8s.cluster.name', 'k8s.namespace.name', 'k8s.deployment.name'])"
+filtering: "filter('container.status', 'waiting') and filter('k8s.deployment.name', '*') and filter('container.status.reason', 'CrashLoopBackOff')"
+
+signals:
+  signal:
+    metric: k8s.container.restarts
+    extrapolation: zero
+
+rules:
+  major:
+    threshold: 0
+    comparator: ">"

--- a/modules/otel-collector_kubernetes-common/conf/07-daemonset-crashloopbackoff.yaml
+++ b/modules/otel-collector_kubernetes-common/conf/07-daemonset-crashloopbackoff.yaml
@@ -1,0 +1,17 @@
+module: Kubernetes
+name: daemonset in CrashLoopBackOff
+id: daemonset_crashloopbackoff
+
+transformation: ".sum(over='15m')"
+aggregation: ".sum(by=['k8s.cluster.name', 'k8s.namespace.name', 'k8s.daemonset.name'])"
+filtering: "filter('container.status', 'waiting') and filter('k8s.daemonset.name', '*') and filter('container.status.reason', 'CrashLoopBackOff')"
+
+signals:
+  signal:
+    metric: k8s.container.restarts
+    extrapolation: zero
+
+rules:
+  major:
+    threshold: 0
+    comparator: ">"

--- a/modules/otel-collector_kubernetes-common/conf/08-job-failed.yaml
+++ b/modules/otel-collector_kubernetes-common/conf/08-job-failed.yaml
@@ -1,0 +1,26 @@
+module: Kubernetes
+name: job from cronjob failed
+id: job_failed
+
+transformation: true
+aggregation: true
+
+signals:
+  completions:
+    metric: k8s.job.desired_successful_pods
+    extrapolation: zero
+  active:
+    metric: k8s.job.active_pods
+    extrapolation: zero
+  succeeded:
+    metric: k8s.job.successful_pods
+    extrapolation: zero
+    rollup: max
+  signal:
+    formula: (completions-active-succeeded)
+
+rules:
+  major:
+    threshold: 0
+    comparator: ">"
+    lasting_duration: 1m

--- a/modules/otel-collector_kubernetes-common/conf/09-daemonset-scheduled.yaml
+++ b/modules/otel-collector_kubernetes-common/conf/09-daemonset-scheduled.yaml
@@ -1,0 +1,21 @@
+module: Kubernetes
+name: daemonsets scheduled
+id: daemonset_scheduled
+
+transformation: true
+aggregation: true
+
+signals:
+  desired:
+    metric: k8s.daemonset.desired_scheduled_nodes
+  current:
+    metric: k8s.daemonset.current_scheduled_nodes
+  signal:
+    formula: (desired-current).fill(value=0)
+
+rules:
+  critical:
+    threshold: 0
+    comparator: "!="
+    lasting_duration: 5m
+    description: do not match desired value

--- a/modules/otel-collector_kubernetes-common/conf/10-daemonset-ready.yaml
+++ b/modules/otel-collector_kubernetes-common/conf/10-daemonset-ready.yaml
@@ -1,0 +1,20 @@
+module: Kubernetes
+name: daemonsets ready
+id: daemonset_ready
+
+transformation: true
+aggregation: true
+
+signals:
+  ready:
+    metric: k8s.daemonset.ready_nodes
+  desired:
+    metric: k8s.daemonset.desired_scheduled_nodes
+  signal:
+    formula: (ready/desired).scale(100)
+
+rules:
+  critical:
+    threshold: 100
+    comparator: "<"
+    lasting_duration: 5m

--- a/modules/otel-collector_kubernetes-common/conf/11-daemonset-misscheduled.yaml
+++ b/modules/otel-collector_kubernetes-common/conf/11-daemonset-misscheduled.yaml
@@ -1,0 +1,16 @@
+module: Kubernetes
+name: daemonsets misscheduled
+id: daemonset_misscheduled
+
+transformation: true
+aggregation: true
+
+signals:
+  signal:
+    metric: k8s.daemonset.misscheduled_nodes
+
+rules:
+  critical:
+    threshold: 0
+    comparator: ">"
+    lasting_duration: 5m

--- a/modules/otel-collector_kubernetes-common/conf/12-deployment-available.yaml
+++ b/modules/otel-collector_kubernetes-common/conf/12-deployment-available.yaml
@@ -1,0 +1,21 @@
+module: Kubernetes
+name: deployments available
+id: deployment_available
+
+transformation: true
+aggregation: true
+
+signals:
+  desired:
+    metric: k8s.deployment.desired
+  available:
+    metric: k8s.deployment.available
+  signal:
+    formula: (desired-available).fill(value=0)
+
+rules:
+  critical:
+    threshold: 0
+    comparator: "!="
+    lasting_duration: 5m
+    description: do not match desired value

--- a/modules/otel-collector_kubernetes-common/conf/13-replicaset-available.yaml
+++ b/modules/otel-collector_kubernetes-common/conf/13-replicaset-available.yaml
@@ -1,0 +1,21 @@
+module: Kubernetes
+name: replicasets available
+id: replicaset_available
+
+transformation: true
+aggregation: true
+
+signals:
+  desired:
+    metric: k8s.replicaset.desired
+  available:
+    metric: k8s.replicaset.available
+  signal:
+    formula: (desired-available).fill(value=0)
+
+rules:
+  critical:
+    threshold: 0
+    comparator: "!="
+    lasting_duration: 5m
+    description: do not match desired value

--- a/modules/otel-collector_kubernetes-common/conf/14-replication-controller-available.yaml
+++ b/modules/otel-collector_kubernetes-common/conf/14-replication-controller-available.yaml
@@ -1,0 +1,21 @@
+module: Kubernetes
+name: replication controllers available
+id: replication_controller_available
+
+transformation: true
+aggregation: true
+
+signals:
+  desired:
+    metric: k8s.replication_controller.desired
+  available:
+    metric: k8s.replication_controller.available
+  signal:
+    formula: (desired-available).fill(value=0)
+
+rules:
+  critical:
+    threshold: 0
+    comparator: "!="
+    lasting_duration: 5m
+    description: do not match desired value

--- a/modules/otel-collector_kubernetes-common/conf/15-statefulset-ready.yaml
+++ b/modules/otel-collector_kubernetes-common/conf/15-statefulset-ready.yaml
@@ -1,0 +1,21 @@
+module: Kubernetes
+name: statefulsets ready
+id: statefulset_ready
+
+transformation: true
+aggregation: true
+
+signals:
+  desired:
+    metric: k8s.statefulset.desired_pods
+  ready:
+    metric: k8s.statefulset.ready_pods
+  signal:
+    formula: (desired-ready).fill(value=0)
+
+rules:
+  critical:
+    threshold: 0
+    comparator: "!="
+    lasting_duration: 5m
+    description: do not match desired value

--- a/modules/otel-collector_kubernetes-common/conf/readme.yaml
+++ b/modules/otel-collector_kubernetes-common/conf/readme.yaml
@@ -1,0 +1,159 @@
+documentations:
+  - name: Smart Agent monitor kubernetes-cluster
+    url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/kubernetes-cluster.md'
+  - name: Smart Agent monitor kubelet-stats
+    url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/kubelet-stats.md'
+  - name: Smart Agent monitor kubelet-metrics
+    url: 'https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/kubelet-metrics.md'
+  - name: Splunk Observability integration
+    url: 'https://docs.splunk.com/Observability/gdi/kubernetes-cluster/kubernetes-cluster.html'
+
+source_doc: |
+  ### Agent
+
+  Here is the official [main
+  documentation](https://github.com/signalfx/integrations/blob/master/kubernetes/SMART_AGENT_MONITOR.md) for
+  kubernetes including the `signalfx-agent` installation which must be installed as
+  [daemonset](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/) on your cluster.
+
+  ### Monitors
+
+  The detectors in this module are based on metrics reported by the following monitors:
+
+  * [kubelet-metrics](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/kubelet-metrics.md) for Kubernetes `>= 1.18`
+  * [kubelet-stats](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/kubelet-stats.md) for Kubernetes `< 1.18
+  * [kubernetes-cluster](https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/kubernetes-cluster.md)
+
+  The `kubernetes-cluster` requires to enable the following `extraMetrics`:
+
+  * `k8s.job.desired_successful_pods`
+  * `k8s.job.active_pods`
+  * `k8s.job.successful_pods`
+  * `k8s.statefulset.ready_pods`
+  * `k8s.statefulset.desired_pods`
+  * `k8s.hpa.max_replicas`
+  * `k8s.hpa.desired_replicas`
+
+  ### Examples
+
+  Here is a sample configuration fragment for SignalFx Agent with `kubernetes-cluster` monitor:
+
+  ```yaml
+  monitors:
+  - type: kubernetes-cluster
+    extraMetrics:
+      - k8s.job.desired_successful_pods
+      - k8s.job.active_pods
+      - k8s.job.successful_pods
+      - k8s.statefulset.ready_pods
+      - k8s.statefulset.desired_pods
+      - k8s.hpa.max_replicas
+      - k8s.hpa.desired_replicas
+  ```
+
+  You can replace `kubernetes-cluster` with `openshift-cluster` you monitor Openshift Kubernetes.
+
+  Then add the monitor `kubelet-metrics` for Kubernetes version `>= 1.18`. Example for GKE:
+
+  ```yaml
+  - type: kubelet-metrics
+    kubeletAPI:
+      authType: serviceAccount
+    usePodsEndpoint: true
+  ```
+
+  __Note__: `usePodsEndpoint: true` allows to enhance containers metrics with `container.id` dimension.
+
+  If you use a Kubernetes version `< 1.18` you have to replace `kubelet-metrics` monitor by `kubelet-stats`.
+  Example for GKE:
+
+  ```yaml
+  - type: kubelet-stats
+    kubeletAPI:
+      authType: serviceAccount
+    datapointsToExclude:
+    - dimensions:
+        container.image.name:
+        - '*pause-amd64*'
+        - 'k8s.gcr.io/pause*'
+      metricNames:
+        - '*'
+        - '!*network*'
+  ```
+
+  Using the SignalFx [Helm](https://helm.sh/) [chart](https://github.com/signalfx/signalfx-agent/tree/master/deployments/k8s/helm/signalfx-agent)
+  could ease the agent installation and configuration:
+
+  ```yaml
+  # Increase depending on your use case
+  resources:
+    limits:
+      cpu: 250m
+      memory: 768Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
+  # Change for your kubernetes cluster name
+  clusterName: "sfx-doc"
+
+  # Change for your realm
+  signalFxRealm: eu0
+
+  # Required to use the default filtering convention
+  globalDimensions:
+    sfx_monitored: true
+    # Change for your env
+    env: sandbox
+
+  # Required to use this module
+  clusterExtraMetrics:
+    - k8s.job.desired_successful_pods
+    - k8s.job.active_pods
+    - k8s.job.successful_pods
+    - k8s.statefulset.ready_pods
+    - k8s.statefulset.desired_pods
+    - k8s.hpa.max_replicas
+    - k8s.hpa.desired_replicas
+
+  # Required to use "system-generic" module
+  loadPerCPU: true
+
+  # Required to use "kubernetes-volumes" module
+  gatherVolumesMetrics: true
+
+  # Example of optional monitors to add for more cool metrics
+  monitors:
+    - type: prometheus-exporter
+      discoveryRule: container.image.name =~ "nginx-ingress-controller" && port == 10254
+      port: 10254
+      datapointsToExclude:
+        - metricNames:
+          - '*'
+          - '!nginx_ingress_controller_requests'
+          - '!nginx_ingress_controller_ingress_upstream_latency_seconds'
+  ```
+
+  __Note__: `clusterExtraMetrics` option is only available from the `1.7.1` version of the helm chart.
+
+
+notes: |
+  This module should suit to every kubernetes clusters full managed or not and could be complete with others
+  modules covering more data sources like `kubernetes-volumes` or use cases like `kubernetes-apiserver`.
+
+  ### About `node_ready` detector
+
+  * it works as for most of the "heartbeat" detectors in this repo; using state property from cloud provider to ignore alerts on host which has been terminated / stopped (i.e. autoscaling group)
+  * the goal is to avoid any alert considered as normal because of host has been removed (automatically or manually)
+  * but the detector will always raise alert for environment outside the cloud while we do any way to know if "not ready node" comes from stopped / terminated host or a real problem.
+
+  ### About `job_failed` detector
+
+  * it works only on job running from cronjob
+  * this will obviously raise an alert when a job is considered as failed from kubernetes point of view. Indeed, some pods could eventually fail or retry without to mark the job as failed
+  * but the alert will remain until you clean/purge jobs history. Indeed, even if a new, more recent, successful job has been running in the meantime the alert will continue until you delete the failed job
+
+  ### About `oom_killed` detector
+
+  * default transformation function is used to avoid the detector to flap repeatedly
+  * if unset, expect the detector to send several alerts per minute

--- a/modules/otel-collector_kubernetes-common/detectors-gen.tf
+++ b/modules/otel-collector_kubernetes-common/detectors-gen.tf
@@ -1,0 +1,496 @@
+resource "signalfx_detector" "heartbeat" {
+  name = format("%s %s", local.detector_name_prefix, "Kubernetes heartbeat")
+
+  authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
+  tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
+
+  program_text = <<-EOF
+    from signalfx.detectors.not_reporting import not_reporting
+    signal = data('k8s.node.condition_ready', filter=${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
+    not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
+EOF
+
+  rule {
+    description           = "has not reported in ${var.heartbeat_timeframe}"
+    severity              = "Critical"
+    detect_label          = "CRIT"
+    disabled              = coalesce(var.heartbeat_disabled, var.detectors_disabled)
+    notifications         = try(coalescelist(lookup(var.heartbeat_notifications, "critical", []), var.notifications.critical), null)
+    runbook_url           = try(coalesce(var.heartbeat_runbook_url, var.runbook_url), "")
+    tip                   = var.heartbeat_tip
+    parameterized_subject = var.message_subject == "" ? local.rule_subject_novalue : var.message_subject
+    parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
+  }
+
+  max_delay = var.heartbeat_max_delay
+}
+
+resource "signalfx_detector" "hpa_capacity" {
+  name = format("%s %s", local.detector_name_prefix, "Kubernetes hpa scale exceeded capacity")
+
+  authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
+  tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
+
+  program_text = <<-EOF
+    max = data('k8s.hpa.max_replicas', filter=${module.filtering.signalflow})${var.hpa_capacity_aggregation_function}${var.hpa_capacity_transformation_function}
+    desired = data('k8s.hpa.desired_replicas', filter=${module.filtering.signalflow})${var.hpa_capacity_aggregation_function}${var.hpa_capacity_transformation_function}
+    signal = (desired-max).publish('signal')
+    detect(when(signal >= ${var.hpa_capacity_threshold_major}, lasting=%{if var.hpa_capacity_lasting_duration_major == null}None%{else}'${var.hpa_capacity_lasting_duration_major}'%{endif}, at_least=${var.hpa_capacity_at_least_percentage_major})).publish('MAJOR')
+EOF
+
+  rule {
+    description           = "is too high >= ${var.hpa_capacity_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.hpa_capacity_disabled, var.detectors_disabled)
+    notifications         = try(coalescelist(lookup(var.hpa_capacity_notifications, "major", []), var.notifications.major), null)
+    runbook_url           = try(coalesce(var.hpa_capacity_runbook_url, var.runbook_url), "")
+    tip                   = var.hpa_capacity_tip
+    parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
+    parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
+  }
+
+  max_delay = var.hpa_capacity_max_delay
+}
+
+resource "signalfx_detector" "node_ready" {
+  name = format("%s %s", local.detector_name_prefix, "Kubernetes node status")
+
+  authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
+  tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
+
+  program_text = <<-EOF
+    ready = data('k8s.node.condition_ready', filter=${module.filtering.signalflow})${var.node_ready_aggregation_function}${var.node_ready_transformation_function}
+    signal = (ready.fill(value=1)).publish('signal')
+    detect(when(signal == ${var.node_ready_threshold_major}, lasting=%{if var.node_ready_lasting_duration_major == null}None%{else}'${var.node_ready_lasting_duration_major}'%{endif}, at_least=${var.node_ready_at_least_percentage_major})).publish('MAJOR')
+    detect(when(signal == ${var.node_ready_threshold_minor}, lasting=%{if var.node_ready_lasting_duration_minor == null}None%{else}'${var.node_ready_lasting_duration_minor}'%{endif}, at_least=${var.node_ready_at_least_percentage_minor})).publish('MINOR')
+EOF
+
+  rule {
+    description           = "is not ready == ${var.node_ready_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.node_ready_disabled_major, var.node_ready_disabled, var.detectors_disabled)
+    notifications         = try(coalescelist(lookup(var.node_ready_notifications, "major", []), var.notifications.major), null)
+    runbook_url           = try(coalesce(var.node_ready_runbook_url, var.runbook_url), "")
+    tip                   = var.node_ready_tip
+    parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
+    parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
+  }
+
+  rule {
+    description           = "is in unknown state == ${var.node_ready_threshold_minor}"
+    severity              = "Minor"
+    detect_label          = "MINOR"
+    disabled              = coalesce(var.node_ready_disabled_minor, var.node_ready_disabled, var.detectors_disabled)
+    notifications         = try(coalescelist(lookup(var.node_ready_notifications, "minor", []), var.notifications.minor), null)
+    runbook_url           = try(coalesce(var.node_ready_runbook_url, var.runbook_url), "")
+    tip                   = var.node_ready_tip
+    parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
+    parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
+  }
+
+  max_delay = var.node_ready_max_delay
+}
+
+resource "signalfx_detector" "pod_phase_status" {
+  name = format("%s %s", local.detector_name_prefix, "Kubernetes pod phase status")
+
+  authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
+  tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
+
+  program_text = <<-EOF
+    base_filtering = (not filter('k8s.job.name', '*')) and (not filter('cronk8s.job.name', '*'))
+    signal = data('k8s.pod.phase', filter=base_filtering and ${module.filtering.signalflow})${var.pod_phase_status_aggregation_function}${var.pod_phase_status_transformation_function}.publish('signal')
+    detect(when(signal < ${var.pod_phase_status_threshold_warning}, lasting=%{if var.pod_phase_status_lasting_duration_warning == null}None%{else}'${var.pod_phase_status_lasting_duration_warning}'%{endif}, at_least=${var.pod_phase_status_at_least_percentage_warning})).publish('WARN')
+    detect(when(signal > ${var.pod_phase_status_threshold_minor}, lasting=%{if var.pod_phase_status_lasting_duration_minor == null}None%{else}'${var.pod_phase_status_lasting_duration_minor}'%{endif}, at_least=${var.pod_phase_status_at_least_percentage_minor})).publish('MINOR')
+    detect(when(signal > ${var.pod_phase_status_threshold_major}, lasting=%{if var.pod_phase_status_lasting_duration_major == null}None%{else}'${var.pod_phase_status_lasting_duration_major}'%{endif}, at_least=${var.pod_phase_status_at_least_percentage_major}) and (not when(signal > ${var.pod_phase_status_threshold_minor}, lasting=%{if var.pod_phase_status_lasting_duration_minor == null}None%{else}'${var.pod_phase_status_lasting_duration_minor}'%{endif}, at_least=${var.pod_phase_status_at_least_percentage_minor}))).publish('MAJOR')
+EOF
+
+  rule {
+    description           = "is pending for too long < ${var.pod_phase_status_threshold_warning}"
+    severity              = "Warning"
+    detect_label          = "WARN"
+    disabled              = coalesce(var.pod_phase_status_disabled_warning, var.pod_phase_status_disabled, var.detectors_disabled)
+    notifications         = try(coalescelist(lookup(var.pod_phase_status_notifications, "warning", []), var.notifications.warning), null)
+    runbook_url           = try(coalesce(var.pod_phase_status_runbook_url, var.runbook_url), "")
+    tip                   = var.pod_phase_status_tip
+    parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
+    parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
+  }
+
+  rule {
+    description           = "is unknown > ${var.pod_phase_status_threshold_minor}"
+    severity              = "Minor"
+    detect_label          = "MINOR"
+    disabled              = coalesce(var.pod_phase_status_disabled_minor, var.pod_phase_status_disabled, var.detectors_disabled)
+    notifications         = try(coalescelist(lookup(var.pod_phase_status_notifications, "minor", []), var.notifications.minor), null)
+    runbook_url           = try(coalesce(var.pod_phase_status_runbook_url, var.runbook_url), "")
+    tip                   = var.pod_phase_status_tip
+    parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
+    parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
+  }
+
+  rule {
+    description           = "is failed > ${var.pod_phase_status_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.pod_phase_status_disabled_major, var.pod_phase_status_disabled, var.detectors_disabled)
+    notifications         = try(coalescelist(lookup(var.pod_phase_status_notifications, "major", []), var.notifications.major), null)
+    runbook_url           = try(coalesce(var.pod_phase_status_runbook_url, var.runbook_url), "")
+    tip                   = var.pod_phase_status_tip
+    parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
+    parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
+  }
+
+  max_delay = var.pod_phase_status_max_delay
+}
+
+resource "signalfx_detector" "terminated" {
+  name = format("%s %s", local.detector_name_prefix, "Kubernetes pod terminated abnormally")
+
+  authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
+  tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
+
+  program_text = <<-EOF
+    base_filtering = filter('container.status', 'terminated') and (not filter('container.status.reason', 'Completed'))
+    signal = data('k8s.container.ready', filter=base_filtering and ${module.filtering.signalflow})${var.terminated_aggregation_function}${var.terminated_transformation_function}.publish('signal')
+    detect(when(signal > ${var.terminated_threshold_major}, lasting=%{if var.terminated_lasting_duration_major == null}None%{else}'${var.terminated_lasting_duration_major}'%{endif}, at_least=${var.terminated_at_least_percentage_major})).publish('MAJOR')
+EOF
+
+  rule {
+    description           = "is too high > ${var.terminated_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.terminated_disabled, var.detectors_disabled)
+    notifications         = try(coalescelist(lookup(var.terminated_notifications, "major", []), var.notifications.major), null)
+    runbook_url           = try(coalesce(var.terminated_runbook_url, var.runbook_url), "")
+    tip                   = var.terminated_tip
+    parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
+    parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
+  }
+
+  max_delay = var.terminated_max_delay
+}
+
+resource "signalfx_detector" "oom_killed" {
+  name = format("%s %s", local.detector_name_prefix, "Kubernetes container killed by oom")
+
+  authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
+  tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
+
+  program_text = <<-EOF
+    base_filtering = filter('container.status', 'terminated') and filter('container.status.reason', 'OOMKilled')
+    killed = data('k8s.container.ready', filter=base_filtering and ${module.filtering.signalflow})${var.oom_killed_aggregation_function}${var.oom_killed_transformation_function}
+    signal = (killed.count()).publish('signal')
+    detect(when(signal > ${var.oom_killed_threshold_major}, lasting=%{if var.oom_killed_lasting_duration_major == null}None%{else}'${var.oom_killed_lasting_duration_major}'%{endif}, at_least=${var.oom_killed_at_least_percentage_major})).publish('MAJOR')
+EOF
+
+  rule {
+    description           = "is too high > ${var.oom_killed_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.oom_killed_disabled, var.detectors_disabled)
+    notifications         = try(coalescelist(lookup(var.oom_killed_notifications, "major", []), var.notifications.major), null)
+    runbook_url           = try(coalesce(var.oom_killed_runbook_url, var.runbook_url), "")
+    tip                   = var.oom_killed_tip
+    parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
+    parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
+  }
+
+  max_delay = var.oom_killed_max_delay
+}
+
+resource "signalfx_detector" "deployment_crashloopbackoff" {
+  name = format("%s %s", local.detector_name_prefix, "Kubernetes deployment in crashloopbackoff")
+
+  authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
+  tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
+
+  program_text = <<-EOF
+    base_filtering = filter('container.status', 'waiting') and filter('k8s.deployment.name', '*') and filter('container.status.reason', 'CrashLoopBackOff')
+    signal = data('k8s.container.restarts', filter=base_filtering and ${module.filtering.signalflow}, extrapolation='zero')${var.deployment_crashloopbackoff_aggregation_function}${var.deployment_crashloopbackoff_transformation_function}.publish('signal')
+    detect(when(signal > ${var.deployment_crashloopbackoff_threshold_major}, lasting=%{if var.deployment_crashloopbackoff_lasting_duration_major == null}None%{else}'${var.deployment_crashloopbackoff_lasting_duration_major}'%{endif}, at_least=${var.deployment_crashloopbackoff_at_least_percentage_major})).publish('MAJOR')
+EOF
+
+  rule {
+    description           = "is too high > ${var.deployment_crashloopbackoff_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.deployment_crashloopbackoff_disabled, var.detectors_disabled)
+    notifications         = try(coalescelist(lookup(var.deployment_crashloopbackoff_notifications, "major", []), var.notifications.major), null)
+    runbook_url           = try(coalesce(var.deployment_crashloopbackoff_runbook_url, var.runbook_url), "")
+    tip                   = var.deployment_crashloopbackoff_tip
+    parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
+    parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
+  }
+
+  max_delay = var.deployment_crashloopbackoff_max_delay
+}
+
+resource "signalfx_detector" "daemonset_crashloopbackoff" {
+  name = format("%s %s", local.detector_name_prefix, "Kubernetes daemonset in crashloopbackoff")
+
+  authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
+  tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
+
+  program_text = <<-EOF
+    base_filtering = filter('container.status', 'waiting') and filter('k8s.daemonset.name', '*') and filter('container.status.reason', 'CrashLoopBackOff')
+    signal = data('k8s.container.restarts', filter=base_filtering and ${module.filtering.signalflow}, extrapolation='zero')${var.daemonset_crashloopbackoff_aggregation_function}${var.daemonset_crashloopbackoff_transformation_function}.publish('signal')
+    detect(when(signal > ${var.daemonset_crashloopbackoff_threshold_major}, lasting=%{if var.daemonset_crashloopbackoff_lasting_duration_major == null}None%{else}'${var.daemonset_crashloopbackoff_lasting_duration_major}'%{endif}, at_least=${var.daemonset_crashloopbackoff_at_least_percentage_major})).publish('MAJOR')
+EOF
+
+  rule {
+    description           = "is too high > ${var.daemonset_crashloopbackoff_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.daemonset_crashloopbackoff_disabled, var.detectors_disabled)
+    notifications         = try(coalescelist(lookup(var.daemonset_crashloopbackoff_notifications, "major", []), var.notifications.major), null)
+    runbook_url           = try(coalesce(var.daemonset_crashloopbackoff_runbook_url, var.runbook_url), "")
+    tip                   = var.daemonset_crashloopbackoff_tip
+    parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
+    parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
+  }
+
+  max_delay = var.daemonset_crashloopbackoff_max_delay
+}
+
+resource "signalfx_detector" "job_failed" {
+  name = format("%s %s", local.detector_name_prefix, "Kubernetes job from cronjob failed")
+
+  authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
+  tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
+
+  program_text = <<-EOF
+    completions = data('k8s.job.desired_successful_pods', filter=${module.filtering.signalflow}, extrapolation='zero')${var.job_failed_aggregation_function}${var.job_failed_transformation_function}
+    active = data('k8s.job.active_pods', filter=${module.filtering.signalflow}, extrapolation='zero')${var.job_failed_aggregation_function}${var.job_failed_transformation_function}
+    succeeded = data('k8s.job.successful_pods', filter=${module.filtering.signalflow}, rollup='max', extrapolation='zero')${var.job_failed_aggregation_function}${var.job_failed_transformation_function}
+    signal = (completions-active-succeeded).publish('signal')
+    detect(when(signal > ${var.job_failed_threshold_major}, lasting=%{if var.job_failed_lasting_duration_major == null}None%{else}'${var.job_failed_lasting_duration_major}'%{endif}, at_least=${var.job_failed_at_least_percentage_major})).publish('MAJOR')
+EOF
+
+  rule {
+    description           = "is too high > ${var.job_failed_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.job_failed_disabled, var.detectors_disabled)
+    notifications         = try(coalescelist(lookup(var.job_failed_notifications, "major", []), var.notifications.major), null)
+    runbook_url           = try(coalesce(var.job_failed_runbook_url, var.runbook_url), "")
+    tip                   = var.job_failed_tip
+    parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
+    parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
+  }
+
+  max_delay = var.job_failed_max_delay
+}
+
+resource "signalfx_detector" "daemonset_scheduled" {
+  name = format("%s %s", local.detector_name_prefix, "Kubernetes daemonsets scheduled")
+
+  authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
+  tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
+
+  program_text = <<-EOF
+    desired = data('k8s.daemonset.desired_scheduled_nodes', filter=${module.filtering.signalflow})${var.daemonset_scheduled_aggregation_function}${var.daemonset_scheduled_transformation_function}
+    current = data('k8s.daemonset.current_scheduled_nodes', filter=${module.filtering.signalflow})${var.daemonset_scheduled_aggregation_function}${var.daemonset_scheduled_transformation_function}
+    signal = (desired-current).fill(value=0).publish('signal')
+    detect(when(signal != ${var.daemonset_scheduled_threshold_critical}, lasting=%{if var.daemonset_scheduled_lasting_duration_critical == null}None%{else}'${var.daemonset_scheduled_lasting_duration_critical}'%{endif}, at_least=${var.daemonset_scheduled_at_least_percentage_critical})).publish('CRIT')
+EOF
+
+  rule {
+    description           = "do not match desired value != ${var.daemonset_scheduled_threshold_critical}"
+    severity              = "Critical"
+    detect_label          = "CRIT"
+    disabled              = coalesce(var.daemonset_scheduled_disabled, var.detectors_disabled)
+    notifications         = try(coalescelist(lookup(var.daemonset_scheduled_notifications, "critical", []), var.notifications.critical), null)
+    runbook_url           = try(coalesce(var.daemonset_scheduled_runbook_url, var.runbook_url), "")
+    tip                   = var.daemonset_scheduled_tip
+    parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
+    parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
+  }
+
+  max_delay = var.daemonset_scheduled_max_delay
+}
+
+resource "signalfx_detector" "daemonset_ready" {
+  name = format("%s %s", local.detector_name_prefix, "Kubernetes daemonsets ready")
+
+  authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
+  tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
+
+  program_text = <<-EOF
+    ready = data('k8s.daemonset.ready_nodes', filter=${module.filtering.signalflow})${var.daemonset_ready_aggregation_function}${var.daemonset_ready_transformation_function}
+    desired = data('k8s.daemonset.desired_scheduled_nodes', filter=${module.filtering.signalflow})${var.daemonset_ready_aggregation_function}${var.daemonset_ready_transformation_function}
+    signal = (ready/desired).scale(100).publish('signal')
+    detect(when(signal < ${var.daemonset_ready_threshold_critical}, lasting=%{if var.daemonset_ready_lasting_duration_critical == null}None%{else}'${var.daemonset_ready_lasting_duration_critical}'%{endif}, at_least=${var.daemonset_ready_at_least_percentage_critical})).publish('CRIT')
+EOF
+
+  rule {
+    description           = "is too low < ${var.daemonset_ready_threshold_critical}"
+    severity              = "Critical"
+    detect_label          = "CRIT"
+    disabled              = coalesce(var.daemonset_ready_disabled, var.detectors_disabled)
+    notifications         = try(coalescelist(lookup(var.daemonset_ready_notifications, "critical", []), var.notifications.critical), null)
+    runbook_url           = try(coalesce(var.daemonset_ready_runbook_url, var.runbook_url), "")
+    tip                   = var.daemonset_ready_tip
+    parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
+    parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
+  }
+
+  max_delay = var.daemonset_ready_max_delay
+}
+
+resource "signalfx_detector" "daemonset_misscheduled" {
+  name = format("%s %s", local.detector_name_prefix, "Kubernetes daemonsets misscheduled")
+
+  authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
+  tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
+
+  program_text = <<-EOF
+    signal = data('k8s.daemonset.misscheduled_nodes', filter=${module.filtering.signalflow})${var.daemonset_misscheduled_aggregation_function}${var.daemonset_misscheduled_transformation_function}.publish('signal')
+    detect(when(signal > ${var.daemonset_misscheduled_threshold_critical}, lasting=%{if var.daemonset_misscheduled_lasting_duration_critical == null}None%{else}'${var.daemonset_misscheduled_lasting_duration_critical}'%{endif}, at_least=${var.daemonset_misscheduled_at_least_percentage_critical})).publish('CRIT')
+EOF
+
+  rule {
+    description           = "is too high > ${var.daemonset_misscheduled_threshold_critical}"
+    severity              = "Critical"
+    detect_label          = "CRIT"
+    disabled              = coalesce(var.daemonset_misscheduled_disabled, var.detectors_disabled)
+    notifications         = try(coalescelist(lookup(var.daemonset_misscheduled_notifications, "critical", []), var.notifications.critical), null)
+    runbook_url           = try(coalesce(var.daemonset_misscheduled_runbook_url, var.runbook_url), "")
+    tip                   = var.daemonset_misscheduled_tip
+    parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
+    parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
+  }
+
+  max_delay = var.daemonset_misscheduled_max_delay
+}
+
+resource "signalfx_detector" "deployment_available" {
+  name = format("%s %s", local.detector_name_prefix, "Kubernetes deployments available")
+
+  authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
+  tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
+
+  program_text = <<-EOF
+    desired = data('k8s.deployment.desired', filter=${module.filtering.signalflow})${var.deployment_available_aggregation_function}${var.deployment_available_transformation_function}
+    available = data('k8s.deployment.available', filter=${module.filtering.signalflow})${var.deployment_available_aggregation_function}${var.deployment_available_transformation_function}
+    signal = (desired-available).fill(value=0).publish('signal')
+    detect(when(signal != ${var.deployment_available_threshold_critical}, lasting=%{if var.deployment_available_lasting_duration_critical == null}None%{else}'${var.deployment_available_lasting_duration_critical}'%{endif}, at_least=${var.deployment_available_at_least_percentage_critical})).publish('CRIT')
+EOF
+
+  rule {
+    description           = "do not match desired value != ${var.deployment_available_threshold_critical}"
+    severity              = "Critical"
+    detect_label          = "CRIT"
+    disabled              = coalesce(var.deployment_available_disabled, var.detectors_disabled)
+    notifications         = try(coalescelist(lookup(var.deployment_available_notifications, "critical", []), var.notifications.critical), null)
+    runbook_url           = try(coalesce(var.deployment_available_runbook_url, var.runbook_url), "")
+    tip                   = var.deployment_available_tip
+    parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
+    parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
+  }
+
+  max_delay = var.deployment_available_max_delay
+}
+
+resource "signalfx_detector" "replicaset_available" {
+  name = format("%s %s", local.detector_name_prefix, "Kubernetes replicasets available")
+
+  authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
+  tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
+
+  program_text = <<-EOF
+    desired = data('k8s.replicaset.desired', filter=${module.filtering.signalflow})${var.replicaset_available_aggregation_function}${var.replicaset_available_transformation_function}
+    available = data('k8s.replicaset.available', filter=${module.filtering.signalflow})${var.replicaset_available_aggregation_function}${var.replicaset_available_transformation_function}
+    signal = (desired-available).fill(value=0).publish('signal')
+    detect(when(signal != ${var.replicaset_available_threshold_critical}, lasting=%{if var.replicaset_available_lasting_duration_critical == null}None%{else}'${var.replicaset_available_lasting_duration_critical}'%{endif}, at_least=${var.replicaset_available_at_least_percentage_critical})).publish('CRIT')
+EOF
+
+  rule {
+    description           = "do not match desired value != ${var.replicaset_available_threshold_critical}"
+    severity              = "Critical"
+    detect_label          = "CRIT"
+    disabled              = coalesce(var.replicaset_available_disabled, var.detectors_disabled)
+    notifications         = try(coalescelist(lookup(var.replicaset_available_notifications, "critical", []), var.notifications.critical), null)
+    runbook_url           = try(coalesce(var.replicaset_available_runbook_url, var.runbook_url), "")
+    tip                   = var.replicaset_available_tip
+    parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
+    parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
+  }
+
+  max_delay = var.replicaset_available_max_delay
+}
+
+resource "signalfx_detector" "replication_controller_available" {
+  name = format("%s %s", local.detector_name_prefix, "Kubernetes replication controllers available")
+
+  authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
+  tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
+
+  program_text = <<-EOF
+    desired = data('k8s.replication_controller.desired', filter=${module.filtering.signalflow})${var.replication_controller_available_aggregation_function}${var.replication_controller_available_transformation_function}
+    available = data('k8s.replication_controller.available', filter=${module.filtering.signalflow})${var.replication_controller_available_aggregation_function}${var.replication_controller_available_transformation_function}
+    signal = (desired-available).fill(value=0).publish('signal')
+    detect(when(signal != ${var.replication_controller_available_threshold_critical}, lasting=%{if var.replication_controller_available_lasting_duration_critical == null}None%{else}'${var.replication_controller_available_lasting_duration_critical}'%{endif}, at_least=${var.replication_controller_available_at_least_percentage_critical})).publish('CRIT')
+EOF
+
+  rule {
+    description           = "do not match desired value != ${var.replication_controller_available_threshold_critical}"
+    severity              = "Critical"
+    detect_label          = "CRIT"
+    disabled              = coalesce(var.replication_controller_available_disabled, var.detectors_disabled)
+    notifications         = try(coalescelist(lookup(var.replication_controller_available_notifications, "critical", []), var.notifications.critical), null)
+    runbook_url           = try(coalesce(var.replication_controller_available_runbook_url, var.runbook_url), "")
+    tip                   = var.replication_controller_available_tip
+    parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
+    parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
+  }
+
+  max_delay = var.replication_controller_available_max_delay
+}
+
+resource "signalfx_detector" "statefulset_ready" {
+  name = format("%s %s", local.detector_name_prefix, "Kubernetes statefulsets ready")
+
+  authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
+  tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
+
+  program_text = <<-EOF
+    desired = data('k8s.statefulset.desired_pods', filter=${module.filtering.signalflow})${var.statefulset_ready_aggregation_function}${var.statefulset_ready_transformation_function}
+    ready = data('k8s.statefulset.ready_pods', filter=${module.filtering.signalflow})${var.statefulset_ready_aggregation_function}${var.statefulset_ready_transformation_function}
+    signal = (desired-ready).fill(value=0).publish('signal')
+    detect(when(signal != ${var.statefulset_ready_threshold_critical}, lasting=%{if var.statefulset_ready_lasting_duration_critical == null}None%{else}'${var.statefulset_ready_lasting_duration_critical}'%{endif}, at_least=${var.statefulset_ready_at_least_percentage_critical})).publish('CRIT')
+EOF
+
+  rule {
+    description           = "do not match desired value != ${var.statefulset_ready_threshold_critical}"
+    severity              = "Critical"
+    detect_label          = "CRIT"
+    disabled              = coalesce(var.statefulset_ready_disabled, var.detectors_disabled)
+    notifications         = try(coalescelist(lookup(var.statefulset_ready_notifications, "critical", []), var.notifications.critical), null)
+    runbook_url           = try(coalesce(var.statefulset_ready_runbook_url, var.runbook_url), "")
+    tip                   = var.statefulset_ready_tip
+    parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
+    parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
+  }
+
+  max_delay = var.statefulset_ready_max_delay
+}
+

--- a/modules/otel-collector_kubernetes-common/outputs.tf
+++ b/modules/otel-collector_kubernetes-common/outputs.tf
@@ -1,0 +1,80 @@
+output "daemonset_crashloopbackoff" {
+  description = "Detector resource for daemonset_crashloopbackoff"
+  value       = signalfx_detector.daemonset_crashloopbackoff
+}
+
+output "daemonset_misscheduled" {
+  description = "Detector resource for daemonset_misscheduled"
+  value       = signalfx_detector.daemonset_misscheduled
+}
+
+output "daemonset_ready" {
+  description = "Detector resource for daemonset_ready"
+  value       = signalfx_detector.daemonset_ready
+}
+
+output "daemonset_scheduled" {
+  description = "Detector resource for daemonset_scheduled"
+  value       = signalfx_detector.daemonset_scheduled
+}
+
+output "deployment_available" {
+  description = "Detector resource for deployment_available"
+  value       = signalfx_detector.deployment_available
+}
+
+output "deployment_crashloopbackoff" {
+  description = "Detector resource for deployment_crashloopbackoff"
+  value       = signalfx_detector.deployment_crashloopbackoff
+}
+
+output "heartbeat" {
+  description = "Detector resource for heartbeat"
+  value       = signalfx_detector.heartbeat
+}
+
+output "hpa_capacity" {
+  description = "Detector resource for hpa_capacity"
+  value       = signalfx_detector.hpa_capacity
+}
+
+output "job_failed" {
+  description = "Detector resource for job_failed"
+  value       = signalfx_detector.job_failed
+}
+
+output "node_ready" {
+  description = "Detector resource for node_ready"
+  value       = signalfx_detector.node_ready
+}
+
+output "oom_killed" {
+  description = "Detector resource for oom_killed"
+  value       = signalfx_detector.oom_killed
+}
+
+output "pod_phase_status" {
+  description = "Detector resource for pod_phase_status"
+  value       = signalfx_detector.pod_phase_status
+}
+
+output "replicaset_available" {
+  description = "Detector resource for replicaset_available"
+  value       = signalfx_detector.replicaset_available
+}
+
+output "replication_controller_available" {
+  description = "Detector resource for replication_controller_available"
+  value       = signalfx_detector.replication_controller_available
+}
+
+output "statefulset_ready" {
+  description = "Detector resource for statefulset_ready"
+  value       = signalfx_detector.statefulset_ready
+}
+
+output "terminated" {
+  description = "Detector resource for terminated"
+  value       = signalfx_detector.terminated
+}
+

--- a/modules/otel-collector_kubernetes-common/tags.tf
+++ b/modules/otel-collector_kubernetes-common/tags.tf
@@ -1,0 +1,3 @@
+locals {
+  tags = ["otel-collector", "kubernetes-common"]
+}

--- a/modules/otel-collector_kubernetes-common/variables-gen.tf
+++ b/modules/otel-collector_kubernetes-common/variables-gen.tf
@@ -1,0 +1,1042 @@
+# heartbeat detector
+
+variable "heartbeat_notifications" {
+  description = "Notification recipients list per severity overridden for heartbeat detector"
+  type        = map(list(string))
+  default     = {}
+}
+
+variable "heartbeat_aggregation_function" {
+  description = "Aggregation function and group by for heartbeat detector (i.e. \".mean(by=['host'])\")"
+  type        = string
+  default     = ".mean(by=['k8s.cluster.name'])"
+}
+
+variable "heartbeat_max_delay" {
+  description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = 900
+}
+
+variable "heartbeat_tip" {
+  description = "Suggested first course of action or any note useful for incident handling"
+  type        = string
+  default     = ""
+}
+
+variable "heartbeat_runbook_url" {
+  description = "URL like SignalFx dashboard or wiki page which can help to troubleshoot the incident cause"
+  type        = string
+  default     = ""
+}
+
+variable "heartbeat_disabled" {
+  description = "Disable all alerting rules for heartbeat detector"
+  type        = bool
+  default     = null
+}
+
+variable "heartbeat_timeframe" {
+  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  type        = string
+  default     = "10m"
+}
+
+# hpa_capacity detector
+
+variable "hpa_capacity_notifications" {
+  description = "Notification recipients list per severity overridden for hpa_capacity detector"
+  type        = map(list(string))
+  default     = {}
+}
+
+variable "hpa_capacity_aggregation_function" {
+  description = "Aggregation function and group by for hpa_capacity detector (i.e. \".mean(by=['host'])\")"
+  type        = string
+  default     = ""
+}
+
+variable "hpa_capacity_transformation_function" {
+  description = "Transformation function for hpa_capacity detector (i.e. \".mean(over='5m')\")"
+  type        = string
+  default     = ""
+}
+
+variable "hpa_capacity_max_delay" {
+  description = "Enforce max delay for hpa_capacity detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
+variable "hpa_capacity_tip" {
+  description = "Suggested first course of action or any note useful for incident handling"
+  type        = string
+  default     = <<-EOF
+    hpa ask to scale for too long, the maximum number of desired Pods has been hit or there is a lack of resources
+EOF
+}
+
+variable "hpa_capacity_runbook_url" {
+  description = "URL like SignalFx dashboard or wiki page which can help to troubleshoot the incident cause"
+  type        = string
+  default     = ""
+}
+
+variable "hpa_capacity_disabled" {
+  description = "Disable all alerting rules for hpa_capacity detector"
+  type        = bool
+  default     = null
+}
+
+variable "hpa_capacity_threshold_major" {
+  description = "Major threshold for hpa_capacity detector"
+  type        = number
+  default     = 0
+}
+
+variable "hpa_capacity_lasting_duration_major" {
+  description = "Minimum duration that conditions must be true before raising alert"
+  type        = string
+  default     = "5m"
+}
+
+variable "hpa_capacity_at_least_percentage_major" {
+  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
+  type        = number
+  default     = 1
+}
+# node_ready detector
+
+variable "node_ready_notifications" {
+  description = "Notification recipients list per severity overridden for node_ready detector"
+  type        = map(list(string))
+  default     = {}
+}
+
+variable "node_ready_aggregation_function" {
+  description = "Aggregation function and group by for node_ready detector (i.e. \".mean(by=['host'])\")"
+  type        = string
+  default     = ""
+}
+
+variable "node_ready_transformation_function" {
+  description = "Transformation function for node_ready detector (i.e. \".mean(over='5m')\")"
+  type        = string
+  default     = ""
+}
+
+variable "node_ready_max_delay" {
+  description = "Enforce max delay for node_ready detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
+variable "node_ready_tip" {
+  description = "Suggested first course of action or any note useful for incident handling"
+  type        = string
+  default     = ""
+}
+
+variable "node_ready_runbook_url" {
+  description = "URL like SignalFx dashboard or wiki page which can help to troubleshoot the incident cause"
+  type        = string
+  default     = ""
+}
+
+variable "node_ready_disabled" {
+  description = "Disable all alerting rules for node_ready detector"
+  type        = bool
+  default     = null
+}
+
+variable "node_ready_disabled_major" {
+  description = "Disable major alerting rule for node_ready detector"
+  type        = bool
+  default     = null
+}
+
+variable "node_ready_disabled_minor" {
+  description = "Disable minor alerting rule for node_ready detector"
+  type        = bool
+  default     = null
+}
+
+variable "node_ready_threshold_major" {
+  description = "Major threshold for node_ready detector"
+  type        = number
+  default     = 0
+}
+
+variable "node_ready_lasting_duration_major" {
+  description = "Minimum duration that conditions must be true before raising alert"
+  type        = string
+  default     = "1h"
+}
+
+variable "node_ready_at_least_percentage_major" {
+  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
+  type        = number
+  default     = 1
+}
+variable "node_ready_threshold_minor" {
+  description = "Minor threshold for node_ready detector"
+  type        = number
+  default     = -1
+}
+
+variable "node_ready_lasting_duration_minor" {
+  description = "Minimum duration that conditions must be true before raising alert"
+  type        = string
+  default     = "20m"
+}
+
+variable "node_ready_at_least_percentage_minor" {
+  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
+  type        = number
+  default     = 1
+}
+# pod_phase_status detector
+
+variable "pod_phase_status_notifications" {
+  description = "Notification recipients list per severity overridden for pod_phase_status detector"
+  type        = map(list(string))
+  default     = {}
+}
+
+variable "pod_phase_status_aggregation_function" {
+  description = "Aggregation function and group by for pod_phase_status detector (i.e. \".mean(by=['host'])\")"
+  type        = string
+  default     = ""
+}
+
+variable "pod_phase_status_transformation_function" {
+  description = "Transformation function for pod_phase_status detector (i.e. \".mean(over='5m')\")"
+  type        = string
+  default     = ""
+}
+
+variable "pod_phase_status_max_delay" {
+  description = "Enforce max delay for pod_phase_status detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
+variable "pod_phase_status_tip" {
+  description = "Suggested first course of action or any note useful for incident handling"
+  type        = string
+  default     = ""
+}
+
+variable "pod_phase_status_runbook_url" {
+  description = "URL like SignalFx dashboard or wiki page which can help to troubleshoot the incident cause"
+  type        = string
+  default     = ""
+}
+
+variable "pod_phase_status_disabled" {
+  description = "Disable all alerting rules for pod_phase_status detector"
+  type        = bool
+  default     = null
+}
+
+variable "pod_phase_status_disabled_warning" {
+  description = "Disable warning alerting rule for pod_phase_status detector"
+  type        = bool
+  default     = null
+}
+
+variable "pod_phase_status_disabled_minor" {
+  description = "Disable minor alerting rule for pod_phase_status detector"
+  type        = bool
+  default     = null
+}
+
+variable "pod_phase_status_disabled_major" {
+  description = "Disable major alerting rule for pod_phase_status detector"
+  type        = bool
+  default     = null
+}
+
+variable "pod_phase_status_threshold_warning" {
+  description = "Warning threshold for pod_phase_status detector"
+  type        = number
+  default     = 2
+}
+
+variable "pod_phase_status_lasting_duration_warning" {
+  description = "Minimum duration that conditions must be true before raising alert"
+  type        = string
+  default     = "30m"
+}
+
+variable "pod_phase_status_at_least_percentage_warning" {
+  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
+  type        = number
+  default     = 1
+}
+variable "pod_phase_status_threshold_minor" {
+  description = "Minor threshold for pod_phase_status detector"
+  type        = number
+  default     = 4
+}
+
+variable "pod_phase_status_lasting_duration_minor" {
+  description = "Minimum duration that conditions must be true before raising alert"
+  type        = string
+  default     = "15m"
+}
+
+variable "pod_phase_status_at_least_percentage_minor" {
+  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
+  type        = number
+  default     = 1
+}
+variable "pod_phase_status_threshold_major" {
+  description = "Major threshold for pod_phase_status detector"
+  type        = number
+  default     = 3
+}
+
+variable "pod_phase_status_lasting_duration_major" {
+  description = "Minimum duration that conditions must be true before raising alert"
+  type        = string
+  default     = "5m"
+}
+
+variable "pod_phase_status_at_least_percentage_major" {
+  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
+  type        = number
+  default     = 1
+}
+# terminated detector
+
+variable "terminated_notifications" {
+  description = "Notification recipients list per severity overridden for terminated detector"
+  type        = map(list(string))
+  default     = {}
+}
+
+variable "terminated_aggregation_function" {
+  description = "Aggregation function and group by for terminated detector (i.e. \".mean(by=['host'])\")"
+  type        = string
+  default     = ".sum(by=['k8s.cluster.name', 'k8s.namespace.name', 'k8s.pod.name'])"
+}
+
+variable "terminated_transformation_function" {
+  description = "Transformation function for terminated detector (i.e. \".mean(over='5m')\")"
+  type        = string
+  default     = ""
+}
+
+variable "terminated_max_delay" {
+  description = "Enforce max delay for terminated detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
+variable "terminated_tip" {
+  description = "Suggested first course of action or any note useful for incident handling"
+  type        = string
+  default     = ""
+}
+
+variable "terminated_runbook_url" {
+  description = "URL like SignalFx dashboard or wiki page which can help to troubleshoot the incident cause"
+  type        = string
+  default     = ""
+}
+
+variable "terminated_disabled" {
+  description = "Disable all alerting rules for terminated detector"
+  type        = bool
+  default     = null
+}
+
+variable "terminated_threshold_major" {
+  description = "Major threshold for terminated detector"
+  type        = number
+  default     = 0
+}
+
+variable "terminated_lasting_duration_major" {
+  description = "Minimum duration that conditions must be true before raising alert"
+  type        = string
+  default     = "10m"
+}
+
+variable "terminated_at_least_percentage_major" {
+  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
+  type        = number
+  default     = 1
+}
+# oom_killed detector
+
+variable "oom_killed_notifications" {
+  description = "Notification recipients list per severity overridden for oom_killed detector"
+  type        = map(list(string))
+  default     = {}
+}
+
+variable "oom_killed_aggregation_function" {
+  description = "Aggregation function and group by for oom_killed detector (i.e. \".mean(by=['host'])\")"
+  type        = string
+  default     = ""
+}
+
+variable "oom_killed_transformation_function" {
+  description = "Transformation function for oom_killed detector (i.e. \".mean(over='5m')\")"
+  type        = string
+  default     = ""
+}
+
+variable "oom_killed_max_delay" {
+  description = "Enforce max delay for oom_killed detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
+variable "oom_killed_tip" {
+  description = "Suggested first course of action or any note useful for incident handling"
+  type        = string
+  default     = ""
+}
+
+variable "oom_killed_runbook_url" {
+  description = "URL like SignalFx dashboard or wiki page which can help to troubleshoot the incident cause"
+  type        = string
+  default     = ""
+}
+
+variable "oom_killed_disabled" {
+  description = "Disable all alerting rules for oom_killed detector"
+  type        = bool
+  default     = null
+}
+
+variable "oom_killed_threshold_major" {
+  description = "Major threshold for oom_killed detector"
+  type        = number
+  default     = 0
+}
+
+variable "oom_killed_lasting_duration_major" {
+  description = "Minimum duration that conditions must be true before raising alert"
+  type        = string
+  default     = "1m"
+}
+
+variable "oom_killed_at_least_percentage_major" {
+  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
+  type        = number
+  default     = 1
+}
+# deployment_crashloopbackoff detector
+
+variable "deployment_crashloopbackoff_notifications" {
+  description = "Notification recipients list per severity overridden for deployment_crashloopbackoff detector"
+  type        = map(list(string))
+  default     = {}
+}
+
+variable "deployment_crashloopbackoff_aggregation_function" {
+  description = "Aggregation function and group by for deployment_crashloopbackoff detector (i.e. \".mean(by=['host'])\")"
+  type        = string
+  default     = ".sum(by=['k8s.cluster.name', 'k8s.namespace.name', 'k8s.deployment.name'])"
+}
+
+variable "deployment_crashloopbackoff_transformation_function" {
+  description = "Transformation function for deployment_crashloopbackoff detector (i.e. \".mean(over='5m')\")"
+  type        = string
+  default     = ".sum(over='15m')"
+}
+
+variable "deployment_crashloopbackoff_max_delay" {
+  description = "Enforce max delay for deployment_crashloopbackoff detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
+variable "deployment_crashloopbackoff_tip" {
+  description = "Suggested first course of action or any note useful for incident handling"
+  type        = string
+  default     = ""
+}
+
+variable "deployment_crashloopbackoff_runbook_url" {
+  description = "URL like SignalFx dashboard or wiki page which can help to troubleshoot the incident cause"
+  type        = string
+  default     = ""
+}
+
+variable "deployment_crashloopbackoff_disabled" {
+  description = "Disable all alerting rules for deployment_crashloopbackoff detector"
+  type        = bool
+  default     = null
+}
+
+variable "deployment_crashloopbackoff_threshold_major" {
+  description = "Major threshold for deployment_crashloopbackoff detector"
+  type        = number
+  default     = 0
+}
+
+variable "deployment_crashloopbackoff_lasting_duration_major" {
+  description = "Minimum duration that conditions must be true before raising alert"
+  type        = string
+  default     = null
+}
+
+variable "deployment_crashloopbackoff_at_least_percentage_major" {
+  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
+  type        = number
+  default     = 1
+}
+# daemonset_crashloopbackoff detector
+
+variable "daemonset_crashloopbackoff_notifications" {
+  description = "Notification recipients list per severity overridden for daemonset_crashloopbackoff detector"
+  type        = map(list(string))
+  default     = {}
+}
+
+variable "daemonset_crashloopbackoff_aggregation_function" {
+  description = "Aggregation function and group by for daemonset_crashloopbackoff detector (i.e. \".mean(by=['host'])\")"
+  type        = string
+  default     = ".sum(by=['k8s.cluster.name', 'k8s.namespace.name', 'k8s.daemonset.name'])"
+}
+
+variable "daemonset_crashloopbackoff_transformation_function" {
+  description = "Transformation function for daemonset_crashloopbackoff detector (i.e. \".mean(over='5m')\")"
+  type        = string
+  default     = ".sum(over='15m')"
+}
+
+variable "daemonset_crashloopbackoff_max_delay" {
+  description = "Enforce max delay for daemonset_crashloopbackoff detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
+variable "daemonset_crashloopbackoff_tip" {
+  description = "Suggested first course of action or any note useful for incident handling"
+  type        = string
+  default     = ""
+}
+
+variable "daemonset_crashloopbackoff_runbook_url" {
+  description = "URL like SignalFx dashboard or wiki page which can help to troubleshoot the incident cause"
+  type        = string
+  default     = ""
+}
+
+variable "daemonset_crashloopbackoff_disabled" {
+  description = "Disable all alerting rules for daemonset_crashloopbackoff detector"
+  type        = bool
+  default     = null
+}
+
+variable "daemonset_crashloopbackoff_threshold_major" {
+  description = "Major threshold for daemonset_crashloopbackoff detector"
+  type        = number
+  default     = 0
+}
+
+variable "daemonset_crashloopbackoff_lasting_duration_major" {
+  description = "Minimum duration that conditions must be true before raising alert"
+  type        = string
+  default     = null
+}
+
+variable "daemonset_crashloopbackoff_at_least_percentage_major" {
+  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
+  type        = number
+  default     = 1
+}
+# job_failed detector
+
+variable "job_failed_notifications" {
+  description = "Notification recipients list per severity overridden for job_failed detector"
+  type        = map(list(string))
+  default     = {}
+}
+
+variable "job_failed_aggregation_function" {
+  description = "Aggregation function and group by for job_failed detector (i.e. \".mean(by=['host'])\")"
+  type        = string
+  default     = ""
+}
+
+variable "job_failed_transformation_function" {
+  description = "Transformation function for job_failed detector (i.e. \".mean(over='5m')\")"
+  type        = string
+  default     = ""
+}
+
+variable "job_failed_max_delay" {
+  description = "Enforce max delay for job_failed detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
+variable "job_failed_tip" {
+  description = "Suggested first course of action or any note useful for incident handling"
+  type        = string
+  default     = ""
+}
+
+variable "job_failed_runbook_url" {
+  description = "URL like SignalFx dashboard or wiki page which can help to troubleshoot the incident cause"
+  type        = string
+  default     = ""
+}
+
+variable "job_failed_disabled" {
+  description = "Disable all alerting rules for job_failed detector"
+  type        = bool
+  default     = null
+}
+
+variable "job_failed_threshold_major" {
+  description = "Major threshold for job_failed detector"
+  type        = number
+  default     = 0
+}
+
+variable "job_failed_lasting_duration_major" {
+  description = "Minimum duration that conditions must be true before raising alert"
+  type        = string
+  default     = "1m"
+}
+
+variable "job_failed_at_least_percentage_major" {
+  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
+  type        = number
+  default     = 1
+}
+# daemonset_scheduled detector
+
+variable "daemonset_scheduled_notifications" {
+  description = "Notification recipients list per severity overridden for daemonset_scheduled detector"
+  type        = map(list(string))
+  default     = {}
+}
+
+variable "daemonset_scheduled_aggregation_function" {
+  description = "Aggregation function and group by for daemonset_scheduled detector (i.e. \".mean(by=['host'])\")"
+  type        = string
+  default     = ""
+}
+
+variable "daemonset_scheduled_transformation_function" {
+  description = "Transformation function for daemonset_scheduled detector (i.e. \".mean(over='5m')\")"
+  type        = string
+  default     = ""
+}
+
+variable "daemonset_scheduled_max_delay" {
+  description = "Enforce max delay for daemonset_scheduled detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
+variable "daemonset_scheduled_tip" {
+  description = "Suggested first course of action or any note useful for incident handling"
+  type        = string
+  default     = ""
+}
+
+variable "daemonset_scheduled_runbook_url" {
+  description = "URL like SignalFx dashboard or wiki page which can help to troubleshoot the incident cause"
+  type        = string
+  default     = ""
+}
+
+variable "daemonset_scheduled_disabled" {
+  description = "Disable all alerting rules for daemonset_scheduled detector"
+  type        = bool
+  default     = null
+}
+
+variable "daemonset_scheduled_threshold_critical" {
+  description = "Critical threshold for daemonset_scheduled detector"
+  type        = number
+  default     = 0
+}
+
+variable "daemonset_scheduled_lasting_duration_critical" {
+  description = "Minimum duration that conditions must be true before raising alert"
+  type        = string
+  default     = "5m"
+}
+
+variable "daemonset_scheduled_at_least_percentage_critical" {
+  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
+  type        = number
+  default     = 1
+}
+# daemonset_ready detector
+
+variable "daemonset_ready_notifications" {
+  description = "Notification recipients list per severity overridden for daemonset_ready detector"
+  type        = map(list(string))
+  default     = {}
+}
+
+variable "daemonset_ready_aggregation_function" {
+  description = "Aggregation function and group by for daemonset_ready detector (i.e. \".mean(by=['host'])\")"
+  type        = string
+  default     = ""
+}
+
+variable "daemonset_ready_transformation_function" {
+  description = "Transformation function for daemonset_ready detector (i.e. \".mean(over='5m')\")"
+  type        = string
+  default     = ""
+}
+
+variable "daemonset_ready_max_delay" {
+  description = "Enforce max delay for daemonset_ready detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
+variable "daemonset_ready_tip" {
+  description = "Suggested first course of action or any note useful for incident handling"
+  type        = string
+  default     = ""
+}
+
+variable "daemonset_ready_runbook_url" {
+  description = "URL like SignalFx dashboard or wiki page which can help to troubleshoot the incident cause"
+  type        = string
+  default     = ""
+}
+
+variable "daemonset_ready_disabled" {
+  description = "Disable all alerting rules for daemonset_ready detector"
+  type        = bool
+  default     = null
+}
+
+variable "daemonset_ready_threshold_critical" {
+  description = "Critical threshold for daemonset_ready detector"
+  type        = number
+  default     = 100
+}
+
+variable "daemonset_ready_lasting_duration_critical" {
+  description = "Minimum duration that conditions must be true before raising alert"
+  type        = string
+  default     = "5m"
+}
+
+variable "daemonset_ready_at_least_percentage_critical" {
+  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
+  type        = number
+  default     = 1
+}
+# daemonset_misscheduled detector
+
+variable "daemonset_misscheduled_notifications" {
+  description = "Notification recipients list per severity overridden for daemonset_misscheduled detector"
+  type        = map(list(string))
+  default     = {}
+}
+
+variable "daemonset_misscheduled_aggregation_function" {
+  description = "Aggregation function and group by for daemonset_misscheduled detector (i.e. \".mean(by=['host'])\")"
+  type        = string
+  default     = ""
+}
+
+variable "daemonset_misscheduled_transformation_function" {
+  description = "Transformation function for daemonset_misscheduled detector (i.e. \".mean(over='5m')\")"
+  type        = string
+  default     = ""
+}
+
+variable "daemonset_misscheduled_max_delay" {
+  description = "Enforce max delay for daemonset_misscheduled detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
+variable "daemonset_misscheduled_tip" {
+  description = "Suggested first course of action or any note useful for incident handling"
+  type        = string
+  default     = ""
+}
+
+variable "daemonset_misscheduled_runbook_url" {
+  description = "URL like SignalFx dashboard or wiki page which can help to troubleshoot the incident cause"
+  type        = string
+  default     = ""
+}
+
+variable "daemonset_misscheduled_disabled" {
+  description = "Disable all alerting rules for daemonset_misscheduled detector"
+  type        = bool
+  default     = null
+}
+
+variable "daemonset_misscheduled_threshold_critical" {
+  description = "Critical threshold for daemonset_misscheduled detector"
+  type        = number
+  default     = 0
+}
+
+variable "daemonset_misscheduled_lasting_duration_critical" {
+  description = "Minimum duration that conditions must be true before raising alert"
+  type        = string
+  default     = "5m"
+}
+
+variable "daemonset_misscheduled_at_least_percentage_critical" {
+  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
+  type        = number
+  default     = 1
+}
+# deployment_available detector
+
+variable "deployment_available_notifications" {
+  description = "Notification recipients list per severity overridden for deployment_available detector"
+  type        = map(list(string))
+  default     = {}
+}
+
+variable "deployment_available_aggregation_function" {
+  description = "Aggregation function and group by for deployment_available detector (i.e. \".mean(by=['host'])\")"
+  type        = string
+  default     = ""
+}
+
+variable "deployment_available_transformation_function" {
+  description = "Transformation function for deployment_available detector (i.e. \".mean(over='5m')\")"
+  type        = string
+  default     = ""
+}
+
+variable "deployment_available_max_delay" {
+  description = "Enforce max delay for deployment_available detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
+variable "deployment_available_tip" {
+  description = "Suggested first course of action or any note useful for incident handling"
+  type        = string
+  default     = ""
+}
+
+variable "deployment_available_runbook_url" {
+  description = "URL like SignalFx dashboard or wiki page which can help to troubleshoot the incident cause"
+  type        = string
+  default     = ""
+}
+
+variable "deployment_available_disabled" {
+  description = "Disable all alerting rules for deployment_available detector"
+  type        = bool
+  default     = null
+}
+
+variable "deployment_available_threshold_critical" {
+  description = "Critical threshold for deployment_available detector"
+  type        = number
+  default     = 0
+}
+
+variable "deployment_available_lasting_duration_critical" {
+  description = "Minimum duration that conditions must be true before raising alert"
+  type        = string
+  default     = "5m"
+}
+
+variable "deployment_available_at_least_percentage_critical" {
+  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
+  type        = number
+  default     = 1
+}
+# replicaset_available detector
+
+variable "replicaset_available_notifications" {
+  description = "Notification recipients list per severity overridden for replicaset_available detector"
+  type        = map(list(string))
+  default     = {}
+}
+
+variable "replicaset_available_aggregation_function" {
+  description = "Aggregation function and group by for replicaset_available detector (i.e. \".mean(by=['host'])\")"
+  type        = string
+  default     = ""
+}
+
+variable "replicaset_available_transformation_function" {
+  description = "Transformation function for replicaset_available detector (i.e. \".mean(over='5m')\")"
+  type        = string
+  default     = ""
+}
+
+variable "replicaset_available_max_delay" {
+  description = "Enforce max delay for replicaset_available detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
+variable "replicaset_available_tip" {
+  description = "Suggested first course of action or any note useful for incident handling"
+  type        = string
+  default     = ""
+}
+
+variable "replicaset_available_runbook_url" {
+  description = "URL like SignalFx dashboard or wiki page which can help to troubleshoot the incident cause"
+  type        = string
+  default     = ""
+}
+
+variable "replicaset_available_disabled" {
+  description = "Disable all alerting rules for replicaset_available detector"
+  type        = bool
+  default     = null
+}
+
+variable "replicaset_available_threshold_critical" {
+  description = "Critical threshold for replicaset_available detector"
+  type        = number
+  default     = 0
+}
+
+variable "replicaset_available_lasting_duration_critical" {
+  description = "Minimum duration that conditions must be true before raising alert"
+  type        = string
+  default     = "5m"
+}
+
+variable "replicaset_available_at_least_percentage_critical" {
+  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
+  type        = number
+  default     = 1
+}
+# replication_controller_available detector
+
+variable "replication_controller_available_notifications" {
+  description = "Notification recipients list per severity overridden for replication_controller_available detector"
+  type        = map(list(string))
+  default     = {}
+}
+
+variable "replication_controller_available_aggregation_function" {
+  description = "Aggregation function and group by for replication_controller_available detector (i.e. \".mean(by=['host'])\")"
+  type        = string
+  default     = ""
+}
+
+variable "replication_controller_available_transformation_function" {
+  description = "Transformation function for replication_controller_available detector (i.e. \".mean(over='5m')\")"
+  type        = string
+  default     = ""
+}
+
+variable "replication_controller_available_max_delay" {
+  description = "Enforce max delay for replication_controller_available detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
+variable "replication_controller_available_tip" {
+  description = "Suggested first course of action or any note useful for incident handling"
+  type        = string
+  default     = ""
+}
+
+variable "replication_controller_available_runbook_url" {
+  description = "URL like SignalFx dashboard or wiki page which can help to troubleshoot the incident cause"
+  type        = string
+  default     = ""
+}
+
+variable "replication_controller_available_disabled" {
+  description = "Disable all alerting rules for replication_controller_available detector"
+  type        = bool
+  default     = null
+}
+
+variable "replication_controller_available_threshold_critical" {
+  description = "Critical threshold for replication_controller_available detector"
+  type        = number
+  default     = 0
+}
+
+variable "replication_controller_available_lasting_duration_critical" {
+  description = "Minimum duration that conditions must be true before raising alert"
+  type        = string
+  default     = "5m"
+}
+
+variable "replication_controller_available_at_least_percentage_critical" {
+  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
+  type        = number
+  default     = 1
+}
+# statefulset_ready detector
+
+variable "statefulset_ready_notifications" {
+  description = "Notification recipients list per severity overridden for statefulset_ready detector"
+  type        = map(list(string))
+  default     = {}
+}
+
+variable "statefulset_ready_aggregation_function" {
+  description = "Aggregation function and group by for statefulset_ready detector (i.e. \".mean(by=['host'])\")"
+  type        = string
+  default     = ""
+}
+
+variable "statefulset_ready_transformation_function" {
+  description = "Transformation function for statefulset_ready detector (i.e. \".mean(over='5m')\")"
+  type        = string
+  default     = ""
+}
+
+variable "statefulset_ready_max_delay" {
+  description = "Enforce max delay for statefulset_ready detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
+variable "statefulset_ready_tip" {
+  description = "Suggested first course of action or any note useful for incident handling"
+  type        = string
+  default     = ""
+}
+
+variable "statefulset_ready_runbook_url" {
+  description = "URL like SignalFx dashboard or wiki page which can help to troubleshoot the incident cause"
+  type        = string
+  default     = ""
+}
+
+variable "statefulset_ready_disabled" {
+  description = "Disable all alerting rules for statefulset_ready detector"
+  type        = bool
+  default     = null
+}
+
+variable "statefulset_ready_threshold_critical" {
+  description = "Critical threshold for statefulset_ready detector"
+  type        = number
+  default     = 0
+}
+
+variable "statefulset_ready_lasting_duration_critical" {
+  description = "Minimum duration that conditions must be true before raising alert"
+  type        = string
+  default     = "5m"
+}
+
+variable "statefulset_ready_at_least_percentage_critical" {
+  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
+  type        = number
+  default     = 1
+}


### PR DESCRIPTION
Due to deprecation of smart-agent, we need to propose a module that is splunk otel compatible for kubernetes.
Metrics and dimensions were renamed and the purpose of this merge request is to support them correctly to allow alerts to be raised properly.
as the directory was named with smart-agent, we propose to change it by splunk-otel prefix.
integrations should simply use this new module name to work.
source: https://docs.splunk.com/Observability/gdi/opentelemetry/legacy-otel-mappings.html#opentelemetry-values-and-their-legacy-equivalents