### PR TITLE
integration_azure-key-vault: Fix default api latency values

### DIFF
--- a/modules/integration_azure-key-vault/variables.tf
+++ b/modules/integration_azure-key-vault/variables.tf
@@ -127,23 +127,23 @@ variable "api_latency_aggregation_function" {
 variable "api_latency_lasting_duration_critical" {
   description = "Evaluation window for api_latency detector (i.e. 5m, 20m, 1h, 1d)"
   type        = string
-  default     = "5m"
+  default     = "1h"
 }
 
 variable "api_latency_threshold_critical" {
   description = "Critical threshold for api_latency detector"
   type        = number
-  default     = 100
+  default     = 500
 }
 
 variable "api_latency_lasting_duration_major" {
   description = "Evaluation window for api_latency detector (i.e. 5m, 20m, 1h, 1d)"
   type        = string
-  default     = "5m"
+  default     = "30m"
 }
 
 variable "api_latency_threshold_major" {
   description = "Major threshold for api_latency detector"
   type        = number
-  default     = 80
+  default     = 500
 }


### PR DESCRIPTION
Increase the duration before raising an alert on API Latency to avoid false positive.
Also, increase the latency value to 500ms.

New threshold:
* Major if latency is above 500ms for 30m or more
* Critical if latency is above 500ms for 1h or more.