### PR TITLE
Key vault latency detector: remove critical status

### DIFF
--- a/docs/severity.md
+++ b/docs/severity.md
@@ -508,7 +508,7 @@
 |Detector|Critical|Major|Minor|Warning|Info|
 |---|---|---|---|---|---|
 |Azure Key Vault API result rate|X|X|-|-|-|
-|Azure Key Vault API latency|X|X|-|-|-|
+|Azure Key Vault API latency|-|X|X|-|-|
 
 
 ## integration_azure-load-balancer

--- a/modules/integration_azure-key-vault/README.md
+++ b/modules/integration_azure-key-vault/README.md
@@ -76,7 +76,7 @@ This module creates the following SignalFx detectors which could contain one or 
 |Detector|Critical|Major|Minor|Warning|Info|
 |---|---|---|---|---|---|
 |Azure Key Vault API result rate|X|X|-|-|-|
-|Azure Key Vault API latency|X|X|-|-|-|
+|Azure Key Vault API latency|-|X|X|-|-|
 
 ## How to collect required metrics?
 

--- a/modules/integration_azure-key-vault/detectors-keyvault.tf
+++ b/modules/integration_azure-key-vault/detectors-keyvault.tf
@@ -51,16 +51,16 @@ resource "signalfx_detector" "api_latency" {
   program_text = <<-EOF
         base_filter = filter('resource_type', 'Microsoft.KeyVault/vaults') and filter('primary_aggregation_type', 'true')
         signal = data('ServiceApiLatency', extrapolation="zero", filter=base_filter and not filter('activityname', 'secretlist') and ${module.filtering.signalflow})${var.api_latency_aggregation_function}.publish('signal')
-        detect(when(signal > threshold(${var.api_latency_threshold_critical}), lasting="${var.api_latency_lasting_duration_critical}")).publish('CRIT')
-        detect(when(signal > threshold(${var.api_latency_threshold_major}), lasting="${var.api_latency_lasting_duration_major}") and (not when(signal > ${var.api_latency_threshold_critical}, lasting="${var.api_latency_lasting_duration_critical}"))).publish('MAJOR')
+        detect(when(signal > threshold(${var.api_latency_threshold_major}), lasting="${var.api_latency_lasting_duration_major}")).publish('MAJOR')
+        detect(when(signal > threshold(${var.api_latency_threshold_minor}), lasting="${var.api_latency_lasting_duration_minor}") and (not when(signal > ${var.api_latency_threshold_major}, lasting="${var.api_latency_lasting_duration_major}"))).publish('MINOR')
     EOF
 
   rule {
-    description           = "is too high > ${var.api_latency_threshold_critical}ms"
-    severity              = "Critical"
-    detect_label          = "CRIT"
+    description           = "is too high > ${var.api_latency_threshold_major}ms"
+    severity              = "Major"
+    detect_label          = "MAJOR"
     disabled              = coalesce(var.api_latency_disabled_critical, var.api_latency_disabled, var.detectors_disabled)
-    notifications         = try(coalescelist(lookup(var.api_latency_notifications, "critical", []), var.notifications.critical), null)
+    notifications         = try(coalescelist(lookup(var.api_latency_notifications, "major", []), var.notifications.major), null)
     runbook_url           = try(coalesce(var.api_latency_runbook_url, var.runbook_url), "")
     tip                   = var.api_latency_tip
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
@@ -68,11 +68,11 @@ resource "signalfx_detector" "api_latency" {
   }
 
   rule {
-    description           = "is too high > ${var.api_latency_threshold_major}ms"
-    severity              = "Major"
-    detect_label          = "MAJOR"
-    disabled              = coalesce(var.api_latency_disabled_major, var.api_latency_disabled, var.detectors_disabled)
-    notifications         = try(coalescelist(lookup(var.api_latency_notifications, "major", []), var.notifications.major), null)
+    description           = "is too high > ${var.api_latency_threshold_minor}ms"
+    severity              = "Minor"
+    detect_label          = "MINOR"
+    disabled              = coalesce(var.api_latency_disabled_minor, var.api_latency_disabled, var.detectors_disabled)
+    notifications         = try(coalescelist(lookup(var.api_latency_notifications, "minor", []), var.notifications.minor), null)
     runbook_url           = try(coalesce(var.api_latency_runbook_url, var.runbook_url), "")
     tip                   = var.api_latency_tip
     parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject

--- a/modules/integration_azure-key-vault/detectors-keyvault.tf
+++ b/modules/integration_azure-key-vault/detectors-keyvault.tf
@@ -59,7 +59,7 @@ resource "signalfx_detector" "api_latency" {
     description           = "is too high > ${var.api_latency_threshold_major}ms"
     severity              = "Major"
     detect_label          = "MAJOR"
-    disabled              = coalesce(var.api_latency_disabled_critical, var.api_latency_disabled, var.detectors_disabled)
+    disabled              = coalesce(var.api_latency_disabled_major, var.api_latency_disabled, var.detectors_disabled)
     notifications         = try(coalescelist(lookup(var.api_latency_notifications, "major", []), var.notifications.major), null)
     runbook_url           = try(coalesce(var.api_latency_runbook_url, var.runbook_url), "")
     tip                   = var.api_latency_tip
@@ -71,7 +71,7 @@ resource "signalfx_detector" "api_latency" {
     description           = "is too high > ${var.api_latency_threshold_minor}ms"
     severity              = "Minor"
     detect_label          = "MINOR"
-    disabled              = coalesce(var.api_latency_disabled_minor, var.api_latency_disabled, var.detectors_disabled)
+    disabled              = coalesce(var.api_latency_disabled, var.detectors_disabled)
     notifications         = try(coalescelist(lookup(var.api_latency_notifications, "minor", []), var.notifications.minor), null)
     runbook_url           = try(coalesce(var.api_latency_runbook_url, var.runbook_url), "")
     tip                   = var.api_latency_tip

--- a/modules/integration_azure-key-vault/detectors-keyvault.tf
+++ b/modules/integration_azure-key-vault/detectors-keyvault.tf
@@ -71,7 +71,7 @@ resource "signalfx_detector" "api_latency" {
     description           = "is too high > ${var.api_latency_threshold_minor}ms"
     severity              = "Minor"
     detect_label          = "MINOR"
-    disabled              = coalesce(var.api_latency_disabled, var.detectors_disabled)
+    disabled              = coalesce(var.api_latency_disabled_minor, var.api_latency_disabled, var.detectors_disabled)
     notifications         = try(coalescelist(lookup(var.api_latency_notifications, "minor", []), var.notifications.minor), null)
     runbook_url           = try(coalesce(var.api_latency_runbook_url, var.runbook_url), "")
     tip                   = var.api_latency_tip

--- a/modules/integration_azure-key-vault/variables.tf
+++ b/modules/integration_azure-key-vault/variables.tf
@@ -101,7 +101,7 @@ variable "api_latency_disabled" {
 }
 
 variable "api_latency_disabled_minor" {
-  description = "Disable major alerting rule for api_latency detector"
+  description = "Disable minor alerting rule for api_latency detector"
   type        = bool
   default     = null
 }

--- a/modules/integration_azure-key-vault/variables.tf
+++ b/modules/integration_azure-key-vault/variables.tf
@@ -100,12 +100,6 @@ variable "api_latency_disabled" {
   default     = null
 }
 
-variable "api_latency_disabled_critical" {
-  description = "Disable critical alerting rule for api_latency detector"
-  type        = bool
-  default     = null
-}
-
 variable "api_latency_disabled_major" {
   description = "Disable major alerting rule for api_latency detector"
   type        = bool
@@ -124,22 +118,22 @@ variable "api_latency_aggregation_function" {
   default     = ".mean(by=['azure_resource_name', 'azure_resource_group_name', 'azure_region'])"
 }
 
-variable "api_latency_lasting_duration_critical" {
+variable "api_latency_lasting_duration_minor" {
   description = "Evaluation window for api_latency detector (i.e. 5m, 20m, 1h, 1d)"
   type        = string
-  default     = "1h"
-}
-
-variable "api_latency_threshold_critical" {
-  description = "Critical threshold for api_latency detector"
-  type        = number
-  default     = 500
+  default     = "30m"
 }
 
 variable "api_latency_lasting_duration_major" {
   description = "Evaluation window for api_latency detector (i.e. 5m, 20m, 1h, 1d)"
   type        = string
-  default     = "30m"
+  default     = "1h"
+}
+
+variable "api_latency_threshold_minor" {
+  description = "Minor threshold for api_latency detector"
+  type        = number
+  default     = 500
 }
 
 variable "api_latency_threshold_major" {

--- a/modules/integration_azure-key-vault/variables.tf
+++ b/modules/integration_azure-key-vault/variables.tf
@@ -100,6 +100,12 @@ variable "api_latency_disabled" {
   default     = null
 }
 
+variable "api_latency_disabled_minor" {
+  description = "Disable major alerting rule for api_latency detector"
+  type        = bool
+  default     = null
+}
+
 variable "api_latency_disabled_major" {
   description = "Disable major alerting rule for api_latency detector"
   type        = bool


### PR DESCRIPTION
This commit is to remove the critical status from the keyvault latency detector, and use only major and minor