### PR TITLE
Replace backend latency aggregation function sum by mean

### DIFF
--- a/modules/integration_gcp-load-balancing/conf/03-latency-service.yaml
+++ b/modules/integration_gcp-load-balancing/conf/03-latency-service.yaml
@@ -3,7 +3,7 @@ name: backend latency per service
 id: backend_latency_service
 
 transformation: true
-aggregation: ".sum(by=['forwarding_rule_name', 'backend_target_name'])"
+aggregation: ".mean(by=['forwarding_rule_name', 'backend_target_name'])"
 filtering: "filter('service', 'loadbalancing')"
 value_unit: "Millisecond"
 

--- a/modules/integration_gcp-load-balancing/conf/04-latency-bucket.yaml
+++ b/modules/integration_gcp-load-balancing/conf/04-latency-bucket.yaml
@@ -3,7 +3,7 @@ name: backend latency per bucket
 id: backend_latency_bucket
 
 transformation: true
-aggregation: ".sum(by=['forwarding_rule_name', 'backend_target_name'])"
+aggregation: ".mean(by=['forwarding_rule_name', 'backend_target_name'])"
 filtering: "filter('service', 'loadbalancing')"
 value_unit: "Millisecond"
 

--- a/modules/integration_gcp-load-balancing/variables-gen.tf
+++ b/modules/integration_gcp-load-balancing/variables-gen.tf
@@ -212,7 +212,7 @@ variable "backend_latency_service_notifications" {
 variable "backend_latency_service_aggregation_function" {
   description = "Aggregation function and group by for backend_latency_service detector (i.e. \".mean(by=['host'])\")"
   type        = string
-  default     = ".sum(by=['forwarding_rule_name', 'backend_target_name'])"
+  default     = ".mean(by=['forwarding_rule_name', 'backend_target_name'])"
 }
 
 variable "backend_latency_service_transformation_function" {
@@ -302,7 +302,7 @@ variable "backend_latency_bucket_notifications" {
 variable "backend_latency_bucket_aggregation_function" {
   description = "Aggregation function and group by for backend_latency_bucket detector (i.e. \".mean(by=['host'])\")"
   type        = string
-  default     = ".sum(by=['forwarding_rule_name', 'backend_target_name'])"
+  default     = ".mean(by=['forwarding_rule_name', 'backend_target_name'])"
 }
 
 variable "backend_latency_bucket_transformation_function" {


### PR DESCRIPTION
It doesn't make sense to use `sum()` function for the bakend latency.  I replaced it by `mean()` function.