### PR TITLE
fix redis keyspace_hits, use derive.keyspace_hits

### DIFF
--- a/modules/smart-agent_redis/README.md
+++ b/modules/smart-agent_redis/README.md
@@ -146,7 +146,7 @@ parameter to the corresponding monitor configuration:
         - '!${var.use_otel_receiver ? "redis.db.keys" : "gauge.db0_keys"}'
         - '!${var.use_otel_receiver ? "redis.keys.evicted" : "counter.evicted_keys"}'
         - '!${var.use_otel_receiver ? "redis.keys.expired" : "counter.expired_keys"}'
-        - '!${var.use_otel_receiver ? "redis.keyspace.hits" : "counter.keyspace_hits"}'
+        - '!${var.use_otel_receiver ? "redis.keyspace.hits" : "derive.keyspace_hits"}'
         - '!${var.use_otel_receiver ? "redis.memory.rss" : "bytes.used_memory_rss"}'
         - '!${var.use_otel_receiver ? "redis.memory.used" : "bytes.used_memory"}'
 

--- a/modules/smart-agent_redis/conf/10-hitrate.yaml
+++ b/modules/smart-agent_redis/conf/10-hitrate.yaml
@@ -5,10 +5,10 @@ value_unit: "%"
 
 signals:
   A:
-    metric: '${var.use_otel_receiver ? "redis.keyspace.hits" : "counter.keyspace_hits"}'
+    metric: '${var.use_otel_receiver ? "redis.keyspace.hits" : "derive.keyspace_hits"}'
     rollup: delta
   B:
-    metric: '${var.use_otel_receiver ? "redis.keyspace.hits" : "counter.keyspace_hits"}'
+    metric: '${var.use_otel_receiver ? "redis.keyspace.hits" : "derive.keyspace_hits"}'
     rollup: delta
   signal:
     formula: (A/(A+B)).scale(100)

--- a/modules/smart-agent_redis/detectors-gen.tf
+++ b/modules/smart-agent_redis/detectors-gen.tf
@@ -420,8 +420,8 @@ resource "signalfx_detector" "hitrate" {
   }
 
   program_text = <<-EOF
-    A = data('${var.use_otel_receiver ? "redis.keyspace.hits" : "counter.keyspace_hits"}', filter=${module.filtering.signalflow}, rollup='delta')${var.hitrate_aggregation_function}${var.hitrate_transformation_function}
-    B = data('${var.use_otel_receiver ? "redis.keyspace.hits" : "counter.keyspace_hits"}', filter=${module.filtering.signalflow}, rollup='delta')${var.hitrate_aggregation_function}${var.hitrate_transformation_function}
+    A = data('${var.use_otel_receiver ? "redis.keyspace.hits" : "derive.keyspace_hits"}', filter=${module.filtering.signalflow}, rollup='delta')${var.hitrate_aggregation_function}${var.hitrate_transformation_function}
+    B = data('${var.use_otel_receiver ? "redis.keyspace.hits" : "derive.keyspace_hits"}', filter=${module.filtering.signalflow}, rollup='delta')${var.hitrate_aggregation_function}${var.hitrate_transformation_function}
     signal = (A/(A+B)).scale(100).publish('signal')
     detect(when(signal < ${var.hitrate_threshold_critical}, lasting=%{if var.hitrate_lasting_duration_critical == null}None%{else}'${var.hitrate_lasting_duration_critical}'%{endif}, at_least=${var.hitrate_at_least_percentage_critical})).publish('CRIT')
     detect(when(signal < ${var.hitrate_threshold_major}, lasting=%{if var.hitrate_lasting_duration_major == null}None%{else}'${var.hitrate_lasting_duration_major}'%{endif}, at_least=${var.hitrate_at_least_percentage_major}) and (not when(signal < ${var.hitrate_threshold_critical}, lasting=%{if var.hitrate_lasting_duration_critical == null}None%{else}'${var.hitrate_lasting_duration_critical}'%{endif}, at_least=${var.hitrate_at_least_percentage_critical}))).publish('MAJOR')


### PR DESCRIPTION
The hitrate detector doesn't have any metrics cause `counter.keyspace_hits` does not exist.
the metric used in collectd/redis for signal-fx is `derive.keyspace_hits`
https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-redis.md

and our collector splunk-otel-collector is using the correct metric `derive.keyspace_hits`