### PR TITLE
duplicate elasticsearch.jvm.gc.count - missing elasticsearch.jvm.gc.old-count

### DIFF
--- a/modules/smart-agent_elasticsearch/README.md
+++ b/modules/smart-agent_elasticsearch/README.md
@@ -134,7 +134,7 @@ You have to enable the following `extraMetrics` in your monitor configuration:
 * `elasticsearch.cluster.status`
 * `elasticsearch.cluster.task-max-wait-time`
 * `elasticsearch.jvm.gc.old-time`
-* `elasticsearch.jvm.gc.count`
+* `elasticsearch.jvm.gc.old-count`
 * `elasticsearch.jvm.mem.heap-used-percent`
 * `elasticsearch.jvm.mem.pools.old.used_in_bytes`
 * `elasticsearch.jvm.mem.pools.old.max_in_bytes`
@@ -185,7 +185,7 @@ node or if the master and data are the same node.
       - elasticsearch.cluster.status
       - elasticsearch.cluster.task-max-wait-time
       - elasticsearch.jvm.gc.old-time
-      - elasticsearch.jvm.gc.count
+      - elasticsearch.jvm.gc.old-count
       - elasticsearch.jvm.mem.heap-used-percent
       - elasticsearch.jvm.mem.pools.old.used_in_bytes
       - elasticsearch.jvm.mem.pools.old.max_in_bytes

--- a/modules/smart-agent_elasticsearch/conf/readme.yaml
+++ b/modules/smart-agent_elasticsearch/conf/readme.yaml
@@ -16,7 +16,7 @@ source_doc: |
   * `elasticsearch.cluster.status`
   * `elasticsearch.cluster.task-max-wait-time`
   * `elasticsearch.jvm.gc.old-time`
-  * `elasticsearch.jvm.gc.count`
+  * `elasticsearch.jvm.gc.old-count`
   * `elasticsearch.jvm.mem.heap-used-percent`
   * `elasticsearch.jvm.mem.pools.old.used_in_bytes`
   * `elasticsearch.jvm.mem.pools.old.max_in_bytes`
@@ -67,7 +67,7 @@ source_doc: |
         - elasticsearch.cluster.status
         - elasticsearch.cluster.task-max-wait-time
         - elasticsearch.jvm.gc.old-time
-        - elasticsearch.jvm.gc.count
+        - elasticsearch.jvm.gc.old-count
         - elasticsearch.jvm.mem.heap-used-percent
         - elasticsearch.jvm.mem.pools.old.used_in_bytes
         - elasticsearch.jvm.mem.pools.old.max_in_bytes


### PR DESCRIPTION
Fix README with duplicate metric `elasticsearch.jvm.gc.count` and missing metric `elasticsearch.jvm.gc.old-count`
the correct metrics are already used in detectors.  