### PR TITLE
Wrong hitrate calculation for smart agent Redis 

### DIFF
--- a/modules/smart-agent_redis/conf/10-hitrate.yaml
+++ b/modules/smart-agent_redis/conf/10-hitrate.yaml
@@ -8,7 +8,7 @@ signals:
     metric: '${var.use_otel_receiver ? "redis.keyspace.hits" : "derive.keyspace_hits"}'
     rollup: delta
   B:
-    metric: '${var.use_otel_receiver ? "redis.keyspace.hits" : "derive.keyspace_hits"}'
+    metric: '${var.use_otel_receiver ? "redis.keyspace.misses" : "derive.keyspace_misses"}'
     rollup: delta
   signal:
     formula: (A/(A+B)).scale(100)

--- a/modules/smart-agent_redis/detectors-gen.tf
+++ b/modules/smart-agent_redis/detectors-gen.tf
@@ -421,7 +421,7 @@ resource "signalfx_detector" "hitrate" {
 
   program_text = <<-EOF
     A = data('${var.use_otel_receiver ? "redis.keyspace.hits" : "derive.keyspace_hits"}', filter=${module.filtering.signalflow}, rollup='delta')${var.hitrate_aggregation_function}${var.hitrate_transformation_function}
-    B = data('${var.use_otel_receiver ? "redis.keyspace.hits" : "derive.keyspace_hits"}', filter=${module.filtering.signalflow}, rollup='delta')${var.hitrate_aggregation_function}${var.hitrate_transformation_function}
+    B = data('${var.use_otel_receiver ? "redis.keyspace.misses" : "derive.keyspace_misses"}', filter=${module.filtering.signalflow}, rollup='delta')${var.hitrate_aggregation_function}${var.hitrate_transformation_function}
     signal = (A/(A+B)).scale(100).publish('signal')
     detect(when(signal < ${var.hitrate_threshold_critical}, lasting=%{if var.hitrate_lasting_duration_critical == null}None%{else}'${var.hitrate_lasting_duration_critical}'%{endif}, at_least=${var.hitrate_at_least_percentage_critical})).publish('CRIT')
     detect(when(signal < ${var.hitrate_threshold_major}, lasting=%{if var.hitrate_lasting_duration_major == null}None%{else}'${var.hitrate_lasting_duration_major}'%{endif}, at_least=${var.hitrate_at_least_percentage_major}) and (not when(signal < ${var.hitrate_threshold_critical}, lasting=%{if var.hitrate_lasting_duration_critical == null}None%{else}'${var.hitrate_lasting_duration_critical}'%{endif}, at_least=${var.hitrate_at_least_percentage_critical}))).publish('MAJOR')


### PR DESCRIPTION
Currently, the Redis hitrate detector for smart_agent_redis uses the following formula

A / ( A + B )

Where both A and B have the same value ( derive.keyspace_hits ) which will always give a result of 50 % .

this fix will replace B by derive.keyspace_misses instead,  (according to the official documentation : https://github.com/signalfx/signalfx-agent/blob/main/docs/monitors/collectd-redis.md ) , which will give the correct value for the redis hitrate

![image](https://github.com/claranet/terraform-signalfx-detectors/assets/138576425/2a380aa7-a77f-46e0-b8c3-ba6379ed5cac)
