### PR TITLE
Fix rabbitMQ monitoring

### DIFF
--- a/modules/smart-agent_rabbitmq-queue/README.md
+++ b/modules/smart-agent_rabbitmq-queue/README.md
@@ -133,6 +133,7 @@ monitors:
       - gauge.queue.messages_unacknowledged
       - counter.queue.message_stats.ack
       - gauge.queue.consumer_utilisation
+      - gauge.queue.messages
 ```
 
 
@@ -148,7 +149,7 @@ parameter to the corresponding monitor configuration:
       - metricNames:
         - '*'
         - '!counter.queue.message_stats.ack'
-        - '!gauge.queue.consumer_use'
+        - '!gauge.queue.consumer_utilisation'
         - '!gauge.queue.messages'
         - '!gauge.queue.messages_ready'
         - '!gauge.queue.messages_unacknowledged'

--- a/modules/smart-agent_rabbitmq-queue/conf/04-consumer-use.yaml
+++ b/modules/smart-agent_rabbitmq-queue/conf/04-consumer-use.yaml
@@ -10,7 +10,7 @@ signals:
   msg:
     metric: gauge.queue.messages
   signal:
-    metric: gauge.queue.consumer_use
+    metric: gauge.queue.consumer_utilisation
 
 rules:
   critical:

--- a/modules/smart-agent_rabbitmq-queue/conf/readme.yaml
+++ b/modules/smart-agent_rabbitmq-queue/conf/readme.yaml
@@ -33,6 +33,7 @@ source_doc: |
         - gauge.queue.messages_unacknowledged
         - counter.queue.message_stats.ack
         - gauge.queue.consumer_utilisation
+        - gauge.queue.messages
   ```
 
 notes: |

--- a/modules/smart-agent_rabbitmq-queue/detectors-gen.tf
+++ b/modules/smart-agent_rabbitmq-queue/detectors-gen.tf
@@ -132,7 +132,7 @@ resource "signalfx_detector" "consumer_use" {
   program_text = <<-EOF
     base_filtering = filter('plugin', 'rabbitmq')
     msg = data('gauge.queue.messages', filter=base_filtering and ${module.filtering.signalflow})${var.consumer_use_aggregation_function}${var.consumer_use_transformation_function}
-    signal = data('gauge.queue.consumer_use', filter=base_filtering and ${module.filtering.signalflow})${var.consumer_use_aggregation_function}${var.consumer_use_transformation_function}.publish('signal')
+    signal = data('gauge.queue.consumer_utilisation', filter=base_filtering and ${module.filtering.signalflow})${var.consumer_use_aggregation_function}${var.consumer_use_transformation_function}.publish('signal')
     detect(when(signal < ${var.consumer_use_threshold_critical}, lasting=%{if var.consumer_use_lasting_duration_critical == null}None%{else}'${var.consumer_use_lasting_duration_critical}'%{endif}, at_least=${var.consumer_use_at_least_percentage_critical}) and when(msg > 0)).publish('CRIT')
     detect(when(signal < ${var.consumer_use_threshold_major}, lasting=%{if var.consumer_use_lasting_duration_major == null}None%{else}'${var.consumer_use_lasting_duration_major}'%{endif}, at_least=${var.consumer_use_at_least_percentage_major}) and when(msg > 0) and (not when(signal < ${var.consumer_use_threshold_critical}, lasting=%{if var.consumer_use_lasting_duration_critical == null}None%{else}'${var.consumer_use_lasting_duration_critical}'%{endif}, at_least=${var.consumer_use_at_least_percentage_critical}) and when(msg > 0))).publish('MAJOR')
 EOF


### PR DESCRIPTION
Two fixes : 

Fixed RabbitMQ Queue consumer use : correct name of the metric is `gauge.queue.consumer_utilisation` , and not `gauge.queue.consumer_use`

![image](https://github.com/claranet/terraform-signalfx-detectors/assets/138576425/d3cd7070-c9da-46aa-8f4f-ea78dfb55d7a)


Added the metric `gauge.queue.messages` in the extra metrics for the otel configuration . According to the official documentation it is a custom metric : https://docs.splunk.com/observability/en/gdi/monitors-messaging/rabbitmq.html
