### PR TITLE
ignore squashfs type for inodes

### DIFF
--- a/modules/smart-agent_system-common/conf/04-filesystem-inodes.yaml
+++ b/modules/smart-agent_system-common/conf/04-filesystem-inodes.yaml
@@ -6,10 +6,10 @@ value_unit: "%"
 signals:
   used:
     metric: system.filesystem.inodes.usage
-    filter: filter('state', 'used')
+    filter: "(filter('state', 'used') and not filter('type', 'squashfs'))"
   free:
     metric: system.filesystem.inodes.usage
-    filter: filter('state', 'free')
+    filter: "(filter('state', 'free') and not filter('type', 'squashfs'))"
   signal:
     formula: (used / (used + free) * 100)
 rules:

--- a/modules/smart-agent_system-common/conf/04-inodes.yaml
+++ b/modules/smart-agent_system-common/conf/04-inodes.yaml
@@ -6,6 +6,7 @@ value_unit: "%"
 signals:
   signal:
     metric: percent_inodes.used
+    filter: not filter('fs_type', 'squashfs')
 rules:
   critical:
     threshold: 95

--- a/modules/smart-agent_system-common/detectors-gen.tf
+++ b/modules/smart-agent_system-common/detectors-gen.tf
@@ -171,8 +171,8 @@ resource "signalfx_detector" "filesystem_inodes" {
   }
 
   program_text = <<-EOF
-    used = data('system.filesystem.inodes.usage', filter=filter('state', 'used') and ${module.filtering.signalflow})${var.filesystem_inodes_aggregation_function}${var.filesystem_inodes_transformation_function}
-    free = data('system.filesystem.inodes.usage', filter=filter('state', 'free') and ${module.filtering.signalflow})${var.filesystem_inodes_aggregation_function}${var.filesystem_inodes_transformation_function}
+    used = data('system.filesystem.inodes.usage', filter=(filter('state', 'used') and not filter('type', 'squashfs')) and ${module.filtering.signalflow})${var.filesystem_inodes_aggregation_function}${var.filesystem_inodes_transformation_function}
+    free = data('system.filesystem.inodes.usage', filter=(filter('state', 'free') and not filter('type', 'squashfs')) and ${module.filtering.signalflow})${var.filesystem_inodes_aggregation_function}${var.filesystem_inodes_transformation_function}
     signal = (used / (used + free) * 100).publish('signal')
     detect(when(signal > ${var.filesystem_inodes_threshold_critical}, lasting=%{if var.filesystem_inodes_lasting_duration_critical == null}None%{else}'${var.filesystem_inodes_lasting_duration_critical}'%{endif}, at_least=${var.filesystem_inodes_at_least_percentage_critical})).publish('CRIT')
     detect(when(signal > ${var.filesystem_inodes_threshold_major}, lasting=%{if var.filesystem_inodes_lasting_duration_major == null}None%{else}'${var.filesystem_inodes_lasting_duration_major}'%{endif}, at_least=${var.filesystem_inodes_at_least_percentage_major}) and (not when(signal > ${var.filesystem_inodes_threshold_critical}, lasting=%{if var.filesystem_inodes_lasting_duration_critical == null}None%{else}'${var.filesystem_inodes_lasting_duration_critical}'%{endif}, at_least=${var.filesystem_inodes_at_least_percentage_critical}))).publish('MAJOR')
@@ -218,7 +218,7 @@ resource "signalfx_detector" "disk_inodes" {
   }
 
   program_text = <<-EOF
-    signal = data('percent_inodes.used', filter=${module.filtering.signalflow})${var.disk_inodes_aggregation_function}${var.disk_inodes_transformation_function}.publish('signal')
+    signal = data('percent_inodes.used', filter=not filter('fs_type', 'squashfs') and ${module.filtering.signalflow})${var.disk_inodes_aggregation_function}${var.disk_inodes_transformation_function}.publish('signal')
     detect(when(signal > ${var.disk_inodes_threshold_critical}, lasting=%{if var.disk_inodes_lasting_duration_critical == null}None%{else}'${var.disk_inodes_lasting_duration_critical}'%{endif}, at_least=${var.disk_inodes_at_least_percentage_critical})).publish('CRIT')
     detect(when(signal > ${var.disk_inodes_threshold_major}, lasting=%{if var.disk_inodes_lasting_duration_major == null}None%{else}'${var.disk_inodes_lasting_duration_major}'%{endif}, at_least=${var.disk_inodes_at_least_percentage_major}) and (not when(signal > ${var.disk_inodes_threshold_critical}, lasting=%{if var.disk_inodes_lasting_duration_critical == null}None%{else}'${var.disk_inodes_lasting_duration_critical}'%{endif}, at_least=${var.disk_inodes_at_least_percentage_critical}))).publish('MAJOR')
 EOF


### PR DESCRIPTION
Currently both inodes detectors on module smart-agent_system-common can detect squashfs partitions , triggering false positive alerts at 100% utilisation .

System disk inodes utilization :

![image](https://github.com/claranet/terraform-signalfx-detectors/assets/138576425/d1f47f5b-25c1-4ac6-ad17-4cf8be06e805)

System filesystem inodes utilization :  

![image](https://github.com/claranet/terraform-signalfx-detectors/assets/138576425/32ec149a-4b1d-4442-9e0a-7021985d8c5a)

This fix will add a filter on squashfs partitions for both detectors , to prevent false positive alerts