### PR TITLE
draft: fix: remove pointless CPU transformation

### DIFF
--- a/modules/smart-agent_system-common/conf/01-cpu.yaml
+++ b/modules/smart-agent_system-common/conf/01-cpu.yaml
@@ -2,7 +2,6 @@ module: system
 
 name: "cpu utilization"
 id: cpu
-transformation: ""
 value_unit: "%"
 signals:
   signal:

--- a/modules/smart-agent_system-common/conf/01-cpu.yaml
+++ b/modules/smart-agent_system-common/conf/01-cpu.yaml
@@ -2,7 +2,7 @@ module: system
 
 name: "cpu utilization"
 id: cpu
-transformation: ".min(over='1h')"
+transformation: ""
 value_unit: "%"
 signals:
   signal:
@@ -12,7 +12,9 @@ rules:
   critical:
     threshold: 90
     comparator: ">"
+    lasting_duration: "1h"
   major:
     threshold: 85
     comparator: ">"
+    lasting_duration: "1h"
     dependency: critical

--- a/modules/smart-agent_system-common/detectors-gen.tf
+++ b/modules/smart-agent_system-common/detectors-gen.tf
@@ -40,8 +40,8 @@ resource "signalfx_detector" "cpu" {
 
   program_text = <<-EOF
     signal = data('cpu.utilization', filter=${module.filtering.signalflow}, extrapolation='zero')${var.cpu_aggregation_function}${var.cpu_transformation_function}.publish('signal')
-    detect(when(signal > ${var.cpu_threshold_critical}, lasting=%{if var.cpu_lasting_duration_critical == null}None%{else}'${var.cpu_lasting_duration_critical}'%{endif}%{if var.cpu_at_least_percentage_critical != null}, at_least=${var.cpu_at_least_percentage_critical}%{endif})).publish('CRIT')
-    detect(when(signal > ${var.cpu_threshold_major}, lasting=%{if var.cpu_lasting_duration_major == null}None%{else}'${var.cpu_lasting_duration_major}'%{endif}%{if var.cpu_at_least_percentage_major != null}, at_least=${var.cpu_at_least_percentage_major}%{endif}) and (not when(signal > ${var.cpu_threshold_critical}, lasting=%{if var.cpu_lasting_duration_critical == null}None%{else}'${var.cpu_lasting_duration_critical}'%{endif}%{if var.cpu_at_least_percentage_critical != null}, at_least=${var.cpu_at_least_percentage_critical}%{endif}))).publish('MAJOR')
+    detect(when(signal > ${var.cpu_threshold_critical}, lasting=%{if var.cpu_lasting_duration_critical == null}None%{else}'${var.cpu_lasting_duration_critical}'%{endif}, at_least=${var.cpu_at_least_percentage_critical})).publish('CRIT')
+    detect(when(signal > ${var.cpu_threshold_major}, lasting=%{if var.cpu_lasting_duration_major == null}None%{else}'${var.cpu_lasting_duration_major}'%{endif}, at_least=${var.cpu_at_least_percentage_major}) and (not when(signal > ${var.cpu_threshold_critical}, lasting=%{if var.cpu_lasting_duration_critical == null}None%{else}'${var.cpu_lasting_duration_critical}'%{endif}, at_least=${var.cpu_at_least_percentage_critical}))).publish('MAJOR')
 EOF
 
   rule {

--- a/modules/smart-agent_system-common/detectors-gen.tf
+++ b/modules/smart-agent_system-common/detectors-gen.tf
@@ -39,7 +39,7 @@ resource "signalfx_detector" "cpu" {
   }
 
   program_text = <<-EOF
-    signal = data('cpu.utilization', filter=${module.filtering.signalflow}, extrapolation='zero')${var.cpu_aggregation_function}.publish('signal')
+    signal = data('cpu.utilization', filter=${module.filtering.signalflow}, extrapolation='zero')${var.cpu_aggregation_function}${var.cpu_transformation_function}.publish('signal')
     detect(when(signal > ${var.cpu_threshold_critical}, lasting=%{if var.cpu_lasting_duration_critical == null}None%{else}'${var.cpu_lasting_duration_critical}'%{endif}, at_least=${var.cpu_at_least_percentage_critical})).publish('CRIT')
     detect(when(signal > ${var.cpu_threshold_major}, lasting=%{if var.cpu_lasting_duration_major == null}None%{else}'${var.cpu_lasting_duration_major}'%{endif}, at_least=${var.cpu_at_least_percentage_major}) and (not when(signal > ${var.cpu_threshold_critical}, lasting=%{if var.cpu_lasting_duration_critical == null}None%{else}'${var.cpu_lasting_duration_critical}'%{endif}, at_least=${var.cpu_at_least_percentage_critical}))).publish('MAJOR')
 EOF

--- a/modules/smart-agent_system-common/detectors-gen.tf
+++ b/modules/smart-agent_system-common/detectors-gen.tf
@@ -39,7 +39,7 @@ resource "signalfx_detector" "cpu" {
   }
 
   program_text = <<-EOF
-    signal = data('cpu.utilization', filter=${module.filtering.signalflow}, extrapolation='zero')${var.cpu_aggregation_function}${var.cpu_transformation_function}.publish('signal')
+    signal = data('cpu.utilization', filter=${module.filtering.signalflow}, extrapolation='zero')${var.cpu_aggregation_function}.publish('signal')
     detect(when(signal > ${var.cpu_threshold_critical}, lasting=%{if var.cpu_lasting_duration_critical == null}None%{else}'${var.cpu_lasting_duration_critical}'%{endif}, at_least=${var.cpu_at_least_percentage_critical})).publish('CRIT')
     detect(when(signal > ${var.cpu_threshold_major}, lasting=%{if var.cpu_lasting_duration_major == null}None%{else}'${var.cpu_lasting_duration_major}'%{endif}, at_least=${var.cpu_at_least_percentage_major}) and (not when(signal > ${var.cpu_threshold_critical}, lasting=%{if var.cpu_lasting_duration_critical == null}None%{else}'${var.cpu_lasting_duration_critical}'%{endif}, at_least=${var.cpu_at_least_percentage_critical}))).publish('MAJOR')
 EOF

--- a/modules/smart-agent_system-common/detectors-gen.tf
+++ b/modules/smart-agent_system-common/detectors-gen.tf
@@ -40,8 +40,8 @@ resource "signalfx_detector" "cpu" {
 
   program_text = <<-EOF
     signal = data('cpu.utilization', filter=${module.filtering.signalflow}, extrapolation='zero')${var.cpu_aggregation_function}${var.cpu_transformation_function}.publish('signal')
-    detect(when(signal > ${var.cpu_threshold_critical}, lasting=%{if var.cpu_lasting_duration_critical == null}None%{else}'${var.cpu_lasting_duration_critical}'%{endif}, at_least=${var.cpu_at_least_percentage_critical})).publish('CRIT')
-    detect(when(signal > ${var.cpu_threshold_major}, lasting=%{if var.cpu_lasting_duration_major == null}None%{else}'${var.cpu_lasting_duration_major}'%{endif}, at_least=${var.cpu_at_least_percentage_major}) and (not when(signal > ${var.cpu_threshold_critical}, lasting=%{if var.cpu_lasting_duration_critical == null}None%{else}'${var.cpu_lasting_duration_critical}'%{endif}, at_least=${var.cpu_at_least_percentage_critical}))).publish('MAJOR')
+    detect(when(signal > ${var.cpu_threshold_critical}, lasting=%{if var.cpu_lasting_duration_critical == null}None%{else}'${var.cpu_lasting_duration_critical}'%{endif}%{if var.cpu_at_least_percentage_critical != null}, at_least=${var.cpu_at_least_percentage_critical}%{endif})).publish('CRIT')
+    detect(when(signal > ${var.cpu_threshold_major}, lasting=%{if var.cpu_lasting_duration_major == null}None%{else}'${var.cpu_lasting_duration_major}'%{endif}%{if var.cpu_at_least_percentage_major != null}, at_least=${var.cpu_at_least_percentage_major}%{endif}) and (not when(signal > ${var.cpu_threshold_critical}, lasting=%{if var.cpu_lasting_duration_critical == null}None%{else}'${var.cpu_lasting_duration_critical}'%{endif}%{if var.cpu_at_least_percentage_critical != null}, at_least=${var.cpu_at_least_percentage_critical}%{endif}))).publish('MAJOR')
 EOF
 
   rule {

--- a/modules/smart-agent_system-common/variables-gen.tf
+++ b/modules/smart-agent_system-common/variables-gen.tf
@@ -56,6 +56,12 @@ variable "cpu_aggregation_function" {
   default     = ""
 }
 
+variable "cpu_transformation_function" {
+  description = "Transformation function for cpu detector (i.e. \".mean(over='5m')\")"
+  type        = string
+  default     = ""
+}
+
 variable "cpu_max_delay" {
   description = "Enforce max delay for cpu detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number

--- a/modules/smart-agent_system-common/variables-gen.tf
+++ b/modules/smart-agent_system-common/variables-gen.tf
@@ -56,12 +56,6 @@ variable "cpu_aggregation_function" {
   default     = ""
 }
 
-variable "cpu_transformation_function" {
-  description = "Transformation function for cpu detector (i.e. \".mean(over='5m')\")"
-  type        = string
-  default     = ""
-}
-
 variable "cpu_max_delay" {
   description = "Enforce max delay for cpu detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number

--- a/modules/smart-agent_system-common/variables-gen.tf
+++ b/modules/smart-agent_system-common/variables-gen.tf
@@ -113,7 +113,7 @@ variable "cpu_lasting_duration_critical" {
 variable "cpu_at_least_percentage_critical" {
   description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
   type        = number
-  default     = null
+  default     = 1
 }
 variable "cpu_threshold_major" {
   description = "Major threshold for cpu detector in %"
@@ -130,7 +130,7 @@ variable "cpu_lasting_duration_major" {
 variable "cpu_at_least_percentage_major" {
   description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
   type        = number
-  default     = null
+  default     = 1
 }
 # load detector
 

--- a/modules/smart-agent_system-common/variables-gen.tf
+++ b/modules/smart-agent_system-common/variables-gen.tf
@@ -59,7 +59,7 @@ variable "cpu_aggregation_function" {
 variable "cpu_transformation_function" {
   description = "Transformation function for cpu detector (i.e. \".mean(over='5m')\")"
   type        = string
-  default     = ".min(over='1h')"
+  default     = ""
 }
 
 variable "cpu_max_delay" {

--- a/modules/smart-agent_system-common/variables-gen.tf
+++ b/modules/smart-agent_system-common/variables-gen.tf
@@ -107,13 +107,13 @@ variable "cpu_threshold_critical" {
 variable "cpu_lasting_duration_critical" {
   description = "Minimum duration that conditions must be true before raising alert"
   type        = string
-  default     = null
+  default     = "1h"
 }
 
 variable "cpu_at_least_percentage_critical" {
   description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
   type        = number
-  default     = 1
+  default     = null
 }
 variable "cpu_threshold_major" {
   description = "Major threshold for cpu detector in %"
@@ -124,13 +124,13 @@ variable "cpu_threshold_major" {
 variable "cpu_lasting_duration_major" {
   description = "Minimum duration that conditions must be true before raising alert"
   type        = string
-  default     = null
+  default     = "1h"
 }
 
 variable "cpu_at_least_percentage_major" {
   description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
   type        = number
-  default     = 1
+  default     = null
 }
 # load detector
 


### PR DESCRIPTION
The `min(over='1h')` transformation will gather minimal values on a rolling period of 1h which doesn't make sense since this monitor intends to display CPU usage. Plus this transformation happens **after** splunk time aggregation which means values will vary depending on the displayed period time, ie: a 24h window will likely show lower values than a 7 days period since time aggregation is done with mean().

I think it was an error from the original commit.