### PR TITLE
fix: use lasting instead of transformation function

### DIFF
--- a/modules/smart-agent_system-common/conf/02-load.yaml
+++ b/modules/smart-agent_system-common/conf/02-load.yaml
@@ -1,7 +1,6 @@
 module: system
 name: "load 5m ratio"
 id: load
-transformation: ".min(over='30m')"
 signals:
   load:
     metric: load.midterm
@@ -13,7 +12,9 @@ rules:
   critical:
     threshold: 2.5
     comparator: ">"
+    lasting_duration: "30m"
   major:
     threshold: 2
     comparator: ">"
+    lasting_duration: "30m"
     dependency: critical

--- a/modules/smart-agent_system-common/conf/03-space.yaml
+++ b/modules/smart-agent_system-common/conf/03-space.yaml
@@ -1,7 +1,6 @@
 module: system
 name: "disk space utilization"
 id: disk_space
-transformation: ".max(over='5m')"
 value_unit: "%"
 signals:
   signal:
@@ -11,7 +10,9 @@ rules:
   critical:
     threshold: 90
     comparator: ">"
+    lasting_duration: "5m"
   major:
     threshold: 80
     comparator: ">"
+    lasting_duration: "5m"
     dependency: critical

--- a/modules/smart-agent_system-common/conf/04-filesystem-inodes.yaml
+++ b/modules/smart-agent_system-common/conf/04-filesystem-inodes.yaml
@@ -1,7 +1,6 @@
 module: system
 name: "filesystem inodes utilization"
 id: filesystem_inodes
-transformation: ".max(over='5m')"
 value_unit: "%"
 signals:
   used:
@@ -16,7 +15,9 @@ rules:
   critical:
     threshold: 95
     comparator: ">"
+    lasting_duration: "5m"
   major:
     threshold: 90
     comparator: ">"
+    lasting_duration: "5m"
     dependency: critical

--- a/modules/smart-agent_system-common/conf/04-inodes.yaml
+++ b/modules/smart-agent_system-common/conf/04-inodes.yaml
@@ -1,7 +1,6 @@
 module: system
 name: "disk inodes utilization"
 id: disk_inodes
-transformation: ".max(over='5m')"
 value_unit: "%"
 signals:
   signal:
@@ -10,7 +9,9 @@ rules:
   critical:
     threshold: 95
     comparator: ">"
+    lasting_duration: "5m"
   major:
     threshold: 90
     comparator: ">"
+    lasting_duration: "5m"
     dependency: critical

--- a/modules/smart-agent_system-common/conf/05-mem.yaml
+++ b/modules/smart-agent_system-common/conf/05-mem.yaml
@@ -1,7 +1,6 @@
 module: system
 name: "memory utilization"
 id: memory
-transformation: ".min(over='5m')"
 value_unit: "%"
 signals:
   signal:
@@ -10,7 +9,9 @@ rules:
   critical:
     threshold: 95
     comparator: ">"
+    lasting_duration: "5m"
   major:
     threshold: 90
     comparator: ">"
+    lasting_duration: "5m"
     dependency: critical

--- a/modules/smart-agent_system-common/variables-gen.tf
+++ b/modules/smart-agent_system-common/variables-gen.tf
@@ -149,7 +149,7 @@ variable "load_aggregation_function" {
 variable "load_transformation_function" {
   description = "Transformation function for load detector (i.e. \".mean(over='5m')\")"
   type        = string
-  default     = ".min(over='30m')"
+  default     = ""
 }
 
 variable "load_max_delay" {
@@ -197,7 +197,7 @@ variable "load_threshold_critical" {
 variable "load_lasting_duration_critical" {
   description = "Minimum duration that conditions must be true before raising alert"
   type        = string
-  default     = null
+  default     = "30m"
 }
 
 variable "load_at_least_percentage_critical" {
@@ -214,7 +214,7 @@ variable "load_threshold_major" {
 variable "load_lasting_duration_major" {
   description = "Minimum duration that conditions must be true before raising alert"
   type        = string
-  default     = null
+  default     = "30m"
 }
 
 variable "load_at_least_percentage_major" {
@@ -239,7 +239,7 @@ variable "disk_space_aggregation_function" {
 variable "disk_space_transformation_function" {
   description = "Transformation function for disk_space detector (i.e. \".mean(over='5m')\")"
   type        = string
-  default     = ".max(over='5m')"
+  default     = ""
 }
 
 variable "disk_space_max_delay" {
@@ -287,7 +287,7 @@ variable "disk_space_threshold_critical" {
 variable "disk_space_lasting_duration_critical" {
   description = "Minimum duration that conditions must be true before raising alert"
   type        = string
-  default     = null
+  default     = "5m"
 }
 
 variable "disk_space_at_least_percentage_critical" {
@@ -304,7 +304,7 @@ variable "disk_space_threshold_major" {
 variable "disk_space_lasting_duration_major" {
   description = "Minimum duration that conditions must be true before raising alert"
   type        = string
-  default     = null
+  default     = "5m"
 }
 
 variable "disk_space_at_least_percentage_major" {
@@ -329,7 +329,7 @@ variable "filesystem_inodes_aggregation_function" {
 variable "filesystem_inodes_transformation_function" {
   description = "Transformation function for filesystem_inodes detector (i.e. \".mean(over='5m')\")"
   type        = string
-  default     = ".max(over='5m')"
+  default     = ""
 }
 
 variable "filesystem_inodes_max_delay" {
@@ -377,7 +377,7 @@ variable "filesystem_inodes_threshold_critical" {
 variable "filesystem_inodes_lasting_duration_critical" {
   description = "Minimum duration that conditions must be true before raising alert"
   type        = string
-  default     = null
+  default     = "5m"
 }
 
 variable "filesystem_inodes_at_least_percentage_critical" {
@@ -394,7 +394,7 @@ variable "filesystem_inodes_threshold_major" {
 variable "filesystem_inodes_lasting_duration_major" {
   description = "Minimum duration that conditions must be true before raising alert"
   type        = string
-  default     = null
+  default     = "5m"
 }
 
 variable "filesystem_inodes_at_least_percentage_major" {
@@ -419,7 +419,7 @@ variable "disk_inodes_aggregation_function" {
 variable "disk_inodes_transformation_function" {
   description = "Transformation function for disk_inodes detector (i.e. \".mean(over='5m')\")"
   type        = string
-  default     = ".max(over='5m')"
+  default     = ""
 }
 
 variable "disk_inodes_max_delay" {
@@ -467,7 +467,7 @@ variable "disk_inodes_threshold_critical" {
 variable "disk_inodes_lasting_duration_critical" {
   description = "Minimum duration that conditions must be true before raising alert"
   type        = string
-  default     = null
+  default     = "5m"
 }
 
 variable "disk_inodes_at_least_percentage_critical" {
@@ -484,7 +484,7 @@ variable "disk_inodes_threshold_major" {
 variable "disk_inodes_lasting_duration_major" {
   description = "Minimum duration that conditions must be true before raising alert"
   type        = string
-  default     = null
+  default     = "5m"
 }
 
 variable "disk_inodes_at_least_percentage_major" {
@@ -509,7 +509,7 @@ variable "memory_aggregation_function" {
 variable "memory_transformation_function" {
   description = "Transformation function for memory detector (i.e. \".mean(over='5m')\")"
   type        = string
-  default     = ".min(over='5m')"
+  default     = ""
 }
 
 variable "memory_max_delay" {
@@ -557,7 +557,7 @@ variable "memory_threshold_critical" {
 variable "memory_lasting_duration_critical" {
   description = "Minimum duration that conditions must be true before raising alert"
   type        = string
-  default     = null
+  default     = "5m"
 }
 
 variable "memory_at_least_percentage_critical" {
@@ -574,7 +574,7 @@ variable "memory_threshold_major" {
 variable "memory_lasting_duration_major" {
   description = "Minimum duration that conditions must be true before raising alert"
   type        = string
-  default     = null
+  default     = "5m"
 }
 
 variable "memory_at_least_percentage_major" {


### PR DESCRIPTION
Similarly to efcee1ff0aeb397850aed3a8cdd053e3e55e975a, replace transformation function with appropriate `when()` **lasting** argument for various system detectors.