### PR TITLE
Ajout de lasting au sonde CPU Aws RDS

### DIFF
--- a/modules/integration_aws-rds-common/detectors-rds-common.tf
+++ b/modules/integration_aws-rds-common/detectors-rds-common.tf
@@ -35,10 +35,8 @@ resource "signalfx_detector" "cpu_90_15min" {
 
   program_text = <<-EOF
     signal = data('CPUUtilization', filter=filter('namespace', 'AWS/RDS') and filter('stat', 'mean') and filter('DBInstanceIdentifier', '*') and ${module.filtering.signalflow})${var.cpu_90_15min_aggregation_function}${var.cpu_90_15min_transformation_function}.publish('signal')
-    detect(when(signal > ${var.cpu_90_15min_threshold_critical})).publish('CRIT')
-    detect(when(signal > ${var.cpu_90_15min_threshold_major}) and (not when(signal > ${var.cpu_90_15min_threshold_critical}))).publish('MAJOR')
-detect(when(signal > ${var.cpu_90_15min_threshold_critical}, lasting=%{if var.cpu_90_15_lasting_duration_critical == null}None%{else}'${var.cpu_90_15_lasting_duration_critical}'%{endif}, at_least=${var.cpu_90_15_at_least_percentage_critical})).publish('CRIT')
-detect(when(signal > ${var.cpu_90_15min_threshold_major}, lasting=%{if var.cpu_90_15_lasting_duration_major == null}None%{else}'${var.cpu_90_15_lasting_duration_major}'%{endif}, at_least=${var.cpu_90_15_at_least_percentage_major}) and (not when(signal > ${var.cpu_90_15min_threshold_critical}, lasting=%{if var.cpu_90_15_lasting_duration_critical == null}None%{else}'${var.cpu_90_15_lasting_duration_critical}'%{endif}, at_least=${var.cpu_90_15_at_least_percentage_critical}))).publish('MAJOR')
+    detect(when(signal > ${var.cpu_90_15min_threshold_critical}, lasting=%{if var.cpu_90_15_lasting_duration_critical == null}None%{else}'${var.cpu_90_15_lasting_duration_critical}'%{endif}, at_least=${var.cpu_90_15_at_least_percentage_critical})).publish('CRIT')
+    detect(when(signal > ${var.cpu_90_15min_threshold_major}, lasting=%{if var.cpu_90_15_lasting_duration_major == null}None%{else}'${var.cpu_90_15_lasting_duration_major}'%{endif}, at_least=${var.cpu_90_15_at_least_percentage_major}) and (not when(signal > ${var.cpu_90_15min_threshold_critical}, lasting=%{if var.cpu_90_15_lasting_duration_critical == null}None%{else}'${var.cpu_90_15_lasting_duration_critical}'%{endif}, at_least=${var.cpu_90_15_at_least_percentage_critical}))).publish('MAJOR')
 EOF
 
   rule {

--- a/modules/integration_aws-rds-common/detectors-rds-common.tf
+++ b/modules/integration_aws-rds-common/detectors-rds-common.tf
@@ -37,6 +37,8 @@ resource "signalfx_detector" "cpu_90_15min" {
     signal = data('CPUUtilization', filter=filter('namespace', 'AWS/RDS') and filter('stat', 'mean') and filter('DBInstanceIdentifier', '*') and ${module.filtering.signalflow})${var.cpu_90_15min_aggregation_function}${var.cpu_90_15min_transformation_function}.publish('signal')
     detect(when(signal > ${var.cpu_90_15min_threshold_critical})).publish('CRIT')
     detect(when(signal > ${var.cpu_90_15min_threshold_major}) and (not when(signal > ${var.cpu_90_15min_threshold_critical}))).publish('MAJOR')
+detect(when(signal > ${var.cpu_90_15min_threshold_critical}, lasting=%{if var.cpu_90_15_lasting_duration_critical == null}None%{else}'${var.cpu_90_15_lasting_duration_critical}'%{endif}, at_least=${var.cpu_90_15_at_least_percentage_critical})).publish('CRIT')
+detect(when(signal > ${var.cpu_90_15min_threshold_major}, lasting=%{if var.cpu_90_15_lasting_duration_major == null}None%{else}'${var.cpu_90_15_lasting_duration_major}'%{endif}, at_least=${var.cpu_90_15_at_least_percentage_major}) and (not when(signal > ${var.cpu_90_15min_threshold_critical}, lasting=%{if var.cpu_90_15_lasting_duration_critical == null}None%{else}'${var.cpu_90_15_lasting_duration_critical}'%{endif}, at_least=${var.cpu_90_15_at_least_percentage_critical}))).publish('MAJOR')
 EOF
 
   rule {

--- a/modules/integration_aws-rds-common/variables.tf
+++ b/modules/integration_aws-rds-common/variables.tf
@@ -64,6 +64,30 @@ variable "cpu_90_15min_runbook_url" {
   default     = ""
 }
 
+variable "cpu_90_15_lasting_duration_critical" {
+  description = "Minimum duration that conditions must be true before raising alert"
+  type        = string
+  default     = "15m"
+}
+
+variable "cpu_90_15_lasting_duration_major" {
+  description = "Minimum duration that conditions must be true before raising alert"
+  type        = string
+  default     = "10m"
+}
+
+variable "cpu_90_15_at_least_percentage_critical" {
+  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
+  type        = number
+  default     = 1
+}
+
+variable "cpu_90_15_at_least_percentage_major" {
+  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
+  type        = number
+  default     = 1
+}
+
 variable "cpu_90_15min_disabled" {
   description = "Disable all alerting rules for cpu_90_15min detector"
   type        = bool


### PR DESCRIPTION
Bonjour à vous,

Nous avons besoin de modifier le signalflow du détecteur AWS RDS Common, afin que nos sondes CPU ne sonnent que si l'alerte est active pendant 10 minute et 15 criticals. Sinon, celles-ci ne sonnent pas.

N'ayant pas les droits de faire une branch, j'ai fais avec ma solution Bis.