### PR TITLE
Aws ecs transformation fix

### DIFF
--- a/modules/integration_aws-ecs-service/detectors-ecs-service.tf
+++ b/modules/integration_aws-ecs-service/detectors-ecs-service.tf
@@ -35,7 +35,7 @@ resource "signalfx_detector" "cpu_utilization" {
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
   program_text = <<-EOF
-    signal = data('CPUUtilization', filter=filter('namespace', 'AWS/ECS') and filter('stat', 'mean') and filter('ServiceName', '*') and ${module.filtering.signalflow}).mean(by=['ServiceName'])${var.cpu_utilization_aggregation_function}${var.cpu_utilization_transformation_function}.publish('signal')
+    signal = data('CPUUtilization', filter=filter('namespace', 'AWS/ECS') and filter('stat', 'mean') and filter('ServiceName', '*') and ${module.filtering.signalflow})${var.cpu_utilization_aggregation_function}${var.cpu_utilization_transformation_function}.publish('signal')
     detect(when(signal > ${var.cpu_utilization_threshold_critical}, lasting=%{if var.cpu_utilization_lasting_duration_critical == null}None%{else}'${var.cpu_utilization_lasting_duration_critical}'%{endif})).publish('CRIT')
     detect(when(signal > ${var.cpu_utilization_threshold_major}, lasting=%{if var.cpu_utilization_lasting_duration_major == null}None%{else}'${var.cpu_utilization_lasting_duration_major}'%{endif}) and (not when(signal > ${var.cpu_utilization_threshold_critical}, lasting=%{if var.cpu_utilization_lasting_duration_critical == null}None%{else}'${var.cpu_utilization_lasting_duration_critical}'%{endif}))).publish('MAJOR')
 EOF
@@ -75,7 +75,7 @@ resource "signalfx_detector" "memory_utilization" {
   tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
 
   program_text = <<-EOF
-    signal = data('MemoryUtilization', filter=filter('namespace', 'AWS/ECS') and filter('stat', 'mean') and filter('ServiceName', '*') and ${module.filtering.signalflow}).mean(by=['ServiceName'])${var.memory_utilization_aggregation_function}${var.memory_utilization_transformation_function}.publish('signal')
+    signal = data('MemoryUtilization', filter=filter('namespace', 'AWS/ECS') and filter('stat', 'mean') and filter('ServiceName', '*') and ${module.filtering.signalflow})${var.memory_utilization_aggregation_function}${var.memory_utilization_transformation_function}.publish('signal')
     detect(when(signal > ${var.memory_utilization_threshold_critical}, lasting=%{if var.memory_utilization_lasting_duration_critical == null}None%{else}'${var.memory_utilization_lasting_duration_critical}'%{endif})).publish('CRIT')
     detect(when(signal > ${var.memory_utilization_threshold_major}, lasting=%{if var.memory_utilization_lasting_duration_major == null}None%{else}'${var.memory_utilization_lasting_duration_major}'%{endif}) and (not when(signal > ${var.memory_utilization_threshold_critical}, lasting=%{if var.memory_utilization_lasting_duration_critical == null}None%{else}'${var.memory_utilization_lasting_duration_critical}'%{endif}))).publish('MAJOR')
 EOF

--- a/modules/integration_aws-ecs-service/detectors-ecs-service.tf
+++ b/modules/integration_aws-ecs-service/detectors-ecs-service.tf
@@ -36,8 +36,8 @@ resource "signalfx_detector" "cpu_utilization" {
 
   program_text = <<-EOF
     signal = data('CPUUtilization', filter=filter('namespace', 'AWS/ECS') and filter('stat', 'mean') and filter('ServiceName', '*') and ${module.filtering.signalflow}).mean(by=['ServiceName'])${var.cpu_utilization_aggregation_function}${var.cpu_utilization_transformation_function}.publish('signal')
-    detect(when(signal > ${var.cpu_utilization_threshold_critical})).publish('CRIT')
-    detect(when(signal > ${var.cpu_utilization_threshold_major}) and (not when(signal > ${var.cpu_utilization_threshold_critical}))).publish('MAJOR')
+    detect(when(signal > ${var.cpu_utilization_threshold_critical}, lasting=%{if var.cpu_utilization_lasting_duration_critical == null}None%{else}'${var.cpu_utilization_lasting_duration_critical}'%{endif})).publish('CRIT')
+    detect(when(signal > ${var.cpu_utilization_threshold_major}, lasting=%{if var.cpu_utilization_lasting_duration_major == null}None%{else}'${var.cpu_utilization_lasting_duration_major}'%{endif}) and (not when(signal > ${var.cpu_utilization_threshold_critical}, lasting=%{if var.cpu_utilization_lasting_duration_critical == null}None%{else}'${var.cpu_utilization_lasting_duration_critical}'%{endif}))).publish('MAJOR')
 EOF
 
   rule {
@@ -76,8 +76,8 @@ resource "signalfx_detector" "memory_utilization" {
 
   program_text = <<-EOF
     signal = data('MemoryUtilization', filter=filter('namespace', 'AWS/ECS') and filter('stat', 'mean') and filter('ServiceName', '*') and ${module.filtering.signalflow}).mean(by=['ServiceName'])${var.memory_utilization_aggregation_function}${var.memory_utilization_transformation_function}.publish('signal')
-    detect(when(signal > ${var.memory_utilization_threshold_critical})).publish('CRIT')
-    detect(when(signal > ${var.memory_utilization_threshold_major}) and (not when(signal > ${var.memory_utilization_threshold_critical}))).publish('MAJOR')
+    detect(when(signal > ${var.memory_utilization_threshold_critical}, lasting=%{if var.memory_utilization_lasting_duration_critical == null}None%{else}'${var.memory_utilization_lasting_duration_critical}'%{endif})).publish('CRIT')
+    detect(when(signal > ${var.memory_utilization_threshold_major}, lasting=%{if var.memory_utilization_lasting_duration_major == null}None%{else}'${var.memory_utilization_lasting_duration_major}'%{endif}) and (not when(signal > ${var.memory_utilization_threshold_critical}, lasting=%{if var.memory_utilization_lasting_duration_critical == null}None%{else}'${var.memory_utilization_lasting_duration_critical}'%{endif}))).publish('MAJOR')
 EOF
 
   rule {

--- a/modules/integration_aws-ecs-service/variables.tf
+++ b/modules/integration_aws-ecs-service/variables.tf
@@ -97,7 +97,7 @@ variable "cpu_utilization_aggregation_function" {
 variable "cpu_utilization_transformation_function" {
   description = "Transformation function for cpu_utilization detector (i.e. \".mean(over='5m')\")"
   type        = string
-  default     = ".min(over='5m')"
+  default     = ""
 }
 
 variable "cpu_utilization_threshold_critical" {
@@ -106,10 +106,20 @@ variable "cpu_utilization_threshold_critical" {
   default     = 90
 }
 
+variable "cpu_utilization_lasting_duration_critical" {
+  type        = string
+  default     = "30m"
+}
+
 variable "cpu_utilization_threshold_major" {
   description = "Major threshold for cpu_utilization detector"
   type        = number
   default     = 80
+}
+
+variable "cpu_utilization_lasting_duration_major" {
+  type        = string
+  default     = "5m"
 }
 
 # Memory_utilization detector
@@ -165,7 +175,7 @@ variable "memory_utilization_aggregation_function" {
 variable "memory_utilization_transformation_function" {
   description = "Transformation function for memory_utilization detector (i.e. \".mean(over='5m')\")"
   type        = string
-  default     = ".min(over='5m')"
+  default     = ""
 }
 
 variable "memory_utilization_threshold_critical" {
@@ -174,9 +184,18 @@ variable "memory_utilization_threshold_critical" {
   default     = 90
 }
 
+variable "memory_utilization_lasting_duration_critical" {
+  type        = string
+  default     = "30m"
+}
+
 variable "memory_utilization_threshold_major" {
   description = "Major threshold for memory_utilization detector"
   type        = number
   default     = 85
 }
 
+variable "memory_utilization_lasting_duration_major" {
+  type        = string
+  default     = "5m"
+}


### PR DESCRIPTION
Fix AWS ECS monitor :

1. Remove usage of mean() which is dangerous to use as it may merge metrics of similar service names from different clusters (ex: cluster1/myservice and cluster2/myservice would be calculated as a single myservice metric)
2. Replace usage of min() transformation function with lasting() argument, similarly to #520 and #522 