### PR TITLE
Add a duration for which conditions must be true before triggering an alert on Integration_aws-rds-common

### DIFF
--- a/modules/integration_aws-rds-common/detectors-rds-common.tf
+++ b/modules/integration_aws-rds-common/detectors-rds-common.tf
@@ -35,8 +35,8 @@ resource "signalfx_detector" "cpu_90_15min" {
 
   program_text = <<-EOF
     signal = data('CPUUtilization', filter=filter('namespace', 'AWS/RDS') and filter('stat', 'mean') and filter('DBInstanceIdentifier', '*') and ${module.filtering.signalflow})${var.cpu_90_15min_aggregation_function}${var.cpu_90_15min_transformation_function}.publish('signal')
-    detect(when(signal > ${var.cpu_90_15min_threshold_critical})).publish('CRIT')
-    detect(when(signal > ${var.cpu_90_15min_threshold_major}) and (not when(signal > ${var.cpu_90_15min_threshold_critical}))).publish('MAJOR')
+    detect(when(signal > ${var.cpu_90_15min_threshold_critical}, lasting=%{if var.cpu_90_15min_lasting_duration_critical == null}None%{else}'${var.cpu_90_15min_lasting_duration_critical}'%{endif}, at_least=${var.cpu_90_15min_at_least_percentage_critical})).publish('CRIT')
+    detect(when(signal > ${var.cpu_90_15min_threshold_major}, lasting=%{if var.cpu_90_15min_lasting_duration_major == null}None%{else}'${var.cpu_90_15min_lasting_duration_major}'%{endif}, at_least=${var.cpu_90_15min_at_least_percentage_major}) and (not when(signal > ${var.cpu_90_15min_threshold_critical}, lasting=%{if var.cpu_90_15min_lasting_duration_critical == null}None%{else}'${var.cpu_90_15min_lasting_duration_critical}'%{endif}, at_least=${var.cpu_90_15min_at_least_percentage_critical}))).publish('MAJOR')
 EOF
 
   rule {
@@ -81,8 +81,8 @@ resource "signalfx_detector" "free_space_low" {
   program_text = <<-EOF
     free = data('FreeStorageSpace', filter=filter('namespace', 'AWS/RDS') and filter('stat', 'mean') and filter('DBInstanceIdentifier', '*') and ${module.filtering.signalflow})${var.free_space_low_aggregation_function}${var.free_space_low_transformation_function}
     signal = free.scale(1/1024**3).publish('signal') # Bytes to Gibibytes
-    detect(when(signal < ${var.free_space_low_threshold_critical})).publish('CRIT')
-    detect(when(signal < ${var.free_space_low_threshold_major}) and (not when(signal < ${var.free_space_low_threshold_critical}))).publish('MAJOR')
+    detect(when(signal < ${var.free_space_low_threshold_critical}, lasting=%{if var.free_space_low_lasting_duration_critical == null}None%{else}'${var.free_space_low_lasting_duration_critical}'%{endif}, at_least=${var.free_space_low_at_least_percentage_critical})).publish('CRIT')
+    detect(when(signal < ${var.free_space_low_threshold_major}, lasting=%{if var.free_space_low_lasting_duration_major == null}None%{else}'${var.free_space_low_lasting_duration_major}'%{endif}, at_least=${var.free_space_low_at_least_percentage_major}) and (not when(signal < ${var.free_space_low_threshold_critical}, lasting=%{if var.free_space_low_lasting_duration_critical == null}None%{else}'${var.free_space_low_lasting_duration_critical}'%{endif}, at_least=${var.free_space_low_at_least_percentage_critical}))).publish('MAJOR')
 EOF
 
   rule {
@@ -121,8 +121,8 @@ resource "signalfx_detector" "replica_lag" {
 
   program_text = <<-EOF
     signal = data('ReplicaLag', filter=filter('namespace', 'AWS/RDS') and filter('stat', 'mean') and filter('DBInstanceIdentifier', '*') and ${module.filtering.signalflow})${var.replica_lag_aggregation_function}${var.replica_lag_transformation_function}.publish('signal')
-    detect(when(signal > ${var.replica_lag_threshold_critical})).publish('CRIT')
-    detect(when(signal > ${var.replica_lag_threshold_major}) and (not when(signal > ${var.replica_lag_threshold_critical}))).publish('MAJOR')
+    detect(when(signal > ${var.replica_lag_threshold_critical}, lasting=%{if var.replica_lag_lasting_duration_critical == null}None%{else}'${var.replica_lag_lasting_duration_critical}'%{endif}, at_least=${var.replica_lag_at_least_percentage_critical})).publish('CRIT')
+    detect(when(signal > ${var.replica_lag_threshold_major}, lasting=%{if var.replica_lag_lasting_duration_major == null}None%{else}'${var.replica_lag_lasting_duration_major}'%{endif}, at_least=${var.replica_lag_at_least_percentage_major}) and (not when(signal > ${var.replica_lag_threshold_critical}, lasting=%{if var.replica_lag_lasting_duration_critical == null}None%{else}'${var.replica_lag_lasting_duration_critical}'%{endif}, at_least=${var.replica_lag_at_least_percentage_critical}))).publish('MAJOR')
 EOF
 
   rule {

--- a/modules/integration_aws-rds-common/variables.tf
+++ b/modules/integration_aws-rds-common/variables.tf
@@ -115,7 +115,7 @@ variable "cpu_90_15min_threshold_major" {
 variable "cpu_90_15min_lasting_duration_critical" {
   description = "Minimum duration that conditions must be true before raising alert"
   type        = string
-  default     = ""
+  default     = null
 }
 
 variable "cpu_90_15min_at_least_percentage_critical" {
@@ -127,7 +127,7 @@ variable "cpu_90_15min_at_least_percentage_critical" {
 variable "cpu_90_15min_lasting_duration_major" {
   description = "Minimum duration that conditions must be true before raising alert"
   type        = string
-  default     = ""
+  default     = null
 }
 
 variable "cpu_90_15min_at_least_percentage_major" {
@@ -207,7 +207,7 @@ variable "free_space_low_threshold_major" {
 variable "free_space_low_lasting_duration_critical" {
   description = "Minimum duration that conditions must be true before raising alert"
   type        = string
-  default     = ""
+  default     = null
 }
 
 variable "free_space_low_at_least_percentage_critical" {
@@ -219,7 +219,7 @@ variable "free_space_low_at_least_percentage_critical" {
 variable "free_space_low_lasting_duration_major" {
   description = "Minimum duration that conditions must be true before raising alert"
   type        = string
-  default     = ""
+  default     = null
 }
 
 variable "free_space_low_at_least_percentage_major" {
@@ -299,7 +299,7 @@ variable "replica_lag_threshold_major" {
 variable "replica_lag_lasting_duration_critical" {
   description = "Minimum duration that conditions must be true before raising alert"
   type        = string
-  default     = ""
+  default     = null
 }
 
 variable "replica_lag_at_least_percentage_critical" {
@@ -311,7 +311,7 @@ variable "replica_lag_at_least_percentage_critical" {
 variable "replica_lag_lasting_duration_major" {
   description = "Minimum duration that conditions must be true before raising alert"
   type        = string
-  default     = ""
+  default     = null
 }
 
 variable "replica_lag_at_least_percentage_major" {

--- a/modules/integration_aws-rds-common/variables.tf
+++ b/modules/integration_aws-rds-common/variables.tf
@@ -112,6 +112,30 @@ variable "cpu_90_15min_threshold_major" {
   default     = 80
 }
 
+variable "cpu_90_15min_lasting_duration_critical" {
+  description = "Minimum duration that conditions must be true before raising alert"
+  type        = string
+  default     = "15m"
+}
+
+variable "cpu_90_15min_at_least_percentage_critical" {
+  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
+  type        = number
+  default     = 1
+}
+
+variable "cpu_90_15min_lasting_duration_major" {
+  description = "Minimum duration that conditions must be true before raising alert"
+  type        = string
+  default     = "15m"
+}
+
+variable "cpu_90_15min_at_least_percentage_major" {
+  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
+  type        = number
+  default     = 1
+}
+
 # Free_space_low detector
 
 variable "free_space_low_max_delay" {
@@ -178,6 +202,30 @@ variable "free_space_low_threshold_major" {
   description = "Major threshold for free_space_low detector"
   type        = number
   default     = 40
+}
+
+variable "free_space_low_lasting_duration_critical" {
+  description = "Minimum duration that conditions must be true before raising alert"
+  type        = string
+  default     = "15m"
+}
+
+variable "free_space_low_at_least_percentage_critical" {
+  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
+  type        = number
+  default     = 1
+}
+
+variable "free_space_low_lasting_duration_major" {
+  description = "Minimum duration that conditions must be true before raising alert"
+  type        = string
+  default     = "15m"
+}
+
+variable "free_space_low_at_least_percentage_major" {
+  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
+  type        = number
+  default     = 1
 }
 
 # Replica_lag detector
@@ -248,3 +296,26 @@ variable "replica_lag_threshold_major" {
   default     = 200
 }
 
+variable "replica_lag_lasting_duration_critical" {
+  description = "Minimum duration that conditions must be true before raising alert"
+  type        = string
+  default     = "15m"
+}
+
+variable "replica_lag_at_least_percentage_critical" {
+  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
+  type        = number
+  default     = 1
+}
+
+variable "replica_lag_lasting_duration_major" {
+  description = "Minimum duration that conditions must be true before raising alert"
+  type        = string
+  default     = "15m"
+}
+
+variable "replica_lag_at_least_percentage_major" {
+  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
+  type        = number
+  default     = 1
+}

--- a/modules/integration_aws-rds-common/variables.tf
+++ b/modules/integration_aws-rds-common/variables.tf
@@ -115,7 +115,7 @@ variable "cpu_90_15min_threshold_major" {
 variable "cpu_90_15min_lasting_duration_critical" {
   description = "Minimum duration that conditions must be true before raising alert"
   type        = string
-  default     = "15m"
+  default     = ""
 }
 
 variable "cpu_90_15min_at_least_percentage_critical" {
@@ -127,7 +127,7 @@ variable "cpu_90_15min_at_least_percentage_critical" {
 variable "cpu_90_15min_lasting_duration_major" {
   description = "Minimum duration that conditions must be true before raising alert"
   type        = string
-  default     = "15m"
+  default     = ""
 }
 
 variable "cpu_90_15min_at_least_percentage_major" {
@@ -207,7 +207,7 @@ variable "free_space_low_threshold_major" {
 variable "free_space_low_lasting_duration_critical" {
   description = "Minimum duration that conditions must be true before raising alert"
   type        = string
-  default     = "15m"
+  default     = ""
 }
 
 variable "free_space_low_at_least_percentage_critical" {
@@ -219,7 +219,7 @@ variable "free_space_low_at_least_percentage_critical" {
 variable "free_space_low_lasting_duration_major" {
   description = "Minimum duration that conditions must be true before raising alert"
   type        = string
-  default     = "15m"
+  default     = ""
 }
 
 variable "free_space_low_at_least_percentage_major" {
@@ -299,7 +299,7 @@ variable "replica_lag_threshold_major" {
 variable "replica_lag_lasting_duration_critical" {
   description = "Minimum duration that conditions must be true before raising alert"
   type        = string
-  default     = "15m"
+  default     = ""
 }
 
 variable "replica_lag_at_least_percentage_critical" {
@@ -311,7 +311,7 @@ variable "replica_lag_at_least_percentage_critical" {
 variable "replica_lag_lasting_duration_major" {
   description = "Minimum duration that conditions must be true before raising alert"
   type        = string
-  default     = "15m"
+  default     = ""
 }
 
 variable "replica_lag_at_least_percentage_major" {


### PR DESCRIPTION
Add a duration for which conditions must be true before triggering an alert on Integration_aws-rds-common
The default *lasting_duration* is set to none to avoid changing the actual behavior