### PR TITLE
Heartbeat fixes and improvments for running vm

### DIFF
--- a/modules/cwagent-ec2/detectors-gen.tf
+++ b/modules/cwagent-ec2/detectors-gen.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
-    signal = data('mem_used_percent', filter=%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
+    signal = data('mem_used_percent', filter=%{if var.heartbeat_exclude_not_running_vm}${local.not_running_vm_filters} and %{endif}${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 

--- a/modules/cwagent-ec2/detectors-gen.tf
+++ b/modules/cwagent-ec2/detectors-gen.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
-    signal = data('mem_used_percent', filter=${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
+    signal = data('mem_used_percent', filter=%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 

--- a/modules/cwagent-ec2/variables-gen.tf
+++ b/modules/cwagent-ec2/variables-gen.tf
@@ -43,7 +43,7 @@ variable "heartbeat_exclude_not_running_vm" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if \"heartbeat_exclude_not_running_vm\" is true"
   type        = string
   default     = "25m"
 }

--- a/modules/cwagent-ec2/variables-gen.tf
+++ b/modules/cwagent-ec2/variables-gen.tf
@@ -15,7 +15,7 @@ variable "heartbeat_aggregation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -36,10 +36,16 @@ variable "heartbeat_disabled" {
   default     = null
 }
 
+variable "heartbeat_exclude_not_running_vm" {
+  description = "Don’t send alerts if associated VM is stopped or stopping (metadata provided by cloud provider integration). Can be useful for ephemeral infrastructure (such as auto scaling groups) as VM will be stopped and started regularly. Note that timeframe must be at least 25 minutes for the metadata to be available to the detector."
+  type        = bool
+  default     = true
+}
+
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # mem detector

--- a/modules/fame_azure-vpn/variables-gen.tf
+++ b/modules/fame_azure-vpn/variables-gen.tf
@@ -43,7 +43,7 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\")."
   type        = string
   default     = "25m"
 }

--- a/modules/fame_azure-vpn/variables-gen.tf
+++ b/modules/fame_azure-vpn/variables-gen.tf
@@ -21,7 +21,7 @@ variable "heartbeat_transformation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -43,9 +43,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # totalflowcount detector

--- a/modules/integration_aws-alb/variables-gen.tf
+++ b/modules/integration_aws-alb/variables-gen.tf
@@ -15,7 +15,7 @@ variable "heartbeat_aggregation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -37,9 +37,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # latency detector

--- a/modules/integration_aws-alb/variables-gen.tf
+++ b/modules/integration_aws-alb/variables-gen.tf
@@ -37,7 +37,7 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\")."
   type        = string
   default     = "25m"
 }

--- a/modules/integration_aws-beanstalk/variables-gen.tf
+++ b/modules/integration_aws-beanstalk/variables-gen.tf
@@ -43,7 +43,7 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\")."
   type        = string
   default     = "25m"
 }

--- a/modules/integration_aws-beanstalk/variables-gen.tf
+++ b/modules/integration_aws-beanstalk/variables-gen.tf
@@ -21,7 +21,7 @@ variable "heartbeat_transformation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -43,9 +43,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # health detector

--- a/modules/integration_aws-ecs-cluster/variables-gen.tf
+++ b/modules/integration_aws-ecs-cluster/variables-gen.tf
@@ -15,7 +15,7 @@ variable "heartbeat_aggregation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -37,9 +37,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # cpu_utilization detector

--- a/modules/integration_aws-ecs-cluster/variables-gen.tf
+++ b/modules/integration_aws-ecs-cluster/variables-gen.tf
@@ -37,7 +37,7 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\")."
   type        = string
   default     = "25m"
 }

--- a/modules/integration_aws-ecs-service/variables-gen.tf
+++ b/modules/integration_aws-ecs-service/variables-gen.tf
@@ -15,7 +15,7 @@ variable "heartbeat_aggregation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -37,9 +37,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # cpu_utilization detector

--- a/modules/integration_aws-ecs-service/variables-gen.tf
+++ b/modules/integration_aws-ecs-service/variables-gen.tf
@@ -37,7 +37,7 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\")."
   type        = string
   default     = "25m"
 }

--- a/modules/integration_aws-elasticache-common/variables-gen.tf
+++ b/modules/integration_aws-elasticache-common/variables-gen.tf
@@ -37,7 +37,7 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\")."
   type        = string
   default     = "25m"
 }

--- a/modules/integration_aws-elasticache-common/variables-gen.tf
+++ b/modules/integration_aws-elasticache-common/variables-gen.tf
@@ -15,7 +15,7 @@ variable "heartbeat_aggregation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -37,9 +37,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # evictions detector

--- a/modules/integration_aws-elasticsearch/variables-gen.tf
+++ b/modules/integration_aws-elasticsearch/variables-gen.tf
@@ -15,7 +15,7 @@ variable "heartbeat_aggregation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -37,9 +37,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # jvm_memory_pressure detector

--- a/modules/integration_aws-elasticsearch/variables-gen.tf
+++ b/modules/integration_aws-elasticsearch/variables-gen.tf
@@ -37,7 +37,7 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\")."
   type        = string
   default     = "25m"
 }

--- a/modules/integration_aws-elb/variables-gen.tf
+++ b/modules/integration_aws-elb/variables-gen.tf
@@ -37,7 +37,7 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\")."
   type        = string
   default     = "25m"
 }

--- a/modules/integration_aws-elb/variables-gen.tf
+++ b/modules/integration_aws-elb/variables-gen.tf
@@ -15,7 +15,7 @@ variable "heartbeat_aggregation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -37,9 +37,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # backend_latency detector

--- a/modules/integration_aws-kinesis-firehose/variables-gen.tf
+++ b/modules/integration_aws-kinesis-firehose/variables-gen.tf
@@ -43,7 +43,7 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\")."
   type        = string
   default     = "25m"
 }

--- a/modules/integration_aws-kinesis-firehose/variables-gen.tf
+++ b/modules/integration_aws-kinesis-firehose/variables-gen.tf
@@ -21,7 +21,7 @@ variable "heartbeat_transformation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -43,9 +43,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # incoming_records detector

--- a/modules/integration_aws-nlb/variables-gen.tf
+++ b/modules/integration_aws-nlb/variables-gen.tf
@@ -43,7 +43,7 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\")."
   type        = string
   default     = "25m"
 }

--- a/modules/integration_aws-nlb/variables-gen.tf
+++ b/modules/integration_aws-nlb/variables-gen.tf
@@ -21,7 +21,7 @@ variable "heartbeat_transformation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -43,9 +43,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # no_healthy_instances detector

--- a/modules/integration_aws-rds-common/variables-gen.tf
+++ b/modules/integration_aws-rds-common/variables-gen.tf
@@ -15,7 +15,7 @@ variable "heartbeat_aggregation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -37,9 +37,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # cpu_usage detector

--- a/modules/integration_aws-rds-common/variables-gen.tf
+++ b/modules/integration_aws-rds-common/variables-gen.tf
@@ -37,7 +37,7 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\")."
   type        = string
   default     = "25m"
 }

--- a/modules/integration_aws-redshift/variables-gen.tf
+++ b/modules/integration_aws-redshift/variables-gen.tf
@@ -15,7 +15,7 @@ variable "heartbeat_aggregation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -37,9 +37,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # cpu_usage detector

--- a/modules/integration_aws-redshift/variables-gen.tf
+++ b/modules/integration_aws-redshift/variables-gen.tf
@@ -37,7 +37,7 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\")."
   type        = string
   default     = "25m"
 }

--- a/modules/integration_aws-sqs/variables-gen.tf
+++ b/modules/integration_aws-sqs/variables-gen.tf
@@ -43,7 +43,7 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\")."
   type        = string
   default     = "25m"
 }

--- a/modules/integration_aws-sqs/variables-gen.tf
+++ b/modules/integration_aws-sqs/variables-gen.tf
@@ -21,7 +21,7 @@ variable "heartbeat_transformation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -43,9 +43,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # visible_messages detector

--- a/modules/integration_aws-vpn/variables-gen.tf
+++ b/modules/integration_aws-vpn/variables-gen.tf
@@ -43,7 +43,7 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\")."
   type        = string
   default     = "25m"
 }

--- a/modules/integration_aws-vpn/variables-gen.tf
+++ b/modules/integration_aws-vpn/variables-gen.tf
@@ -21,7 +21,7 @@ variable "heartbeat_transformation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -43,9 +43,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # vpn_status detector

--- a/modules/integration_azure-api-management-service/variables-gen.tf
+++ b/modules/integration_azure-api-management-service/variables-gen.tf
@@ -21,7 +21,7 @@ variable "heartbeat_transformation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -43,9 +43,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # capacity detector

--- a/modules/integration_azure-api-management-service/variables-gen.tf
+++ b/modules/integration_azure-api-management-service/variables-gen.tf
@@ -43,7 +43,7 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\")."
   type        = string
   default     = "25m"
 }

--- a/modules/integration_azure-app-service-plan/variables-gen.tf
+++ b/modules/integration_azure-app-service-plan/variables-gen.tf
@@ -43,7 +43,7 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\")."
   type        = string
   default     = "25m"
 }

--- a/modules/integration_azure-app-service-plan/variables-gen.tf
+++ b/modules/integration_azure-app-service-plan/variables-gen.tf
@@ -21,7 +21,7 @@ variable "heartbeat_transformation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -43,9 +43,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # cpu detector

--- a/modules/integration_azure-app-service/variables-gen.tf
+++ b/modules/integration_azure-app-service/variables-gen.tf
@@ -21,7 +21,7 @@ variable "heartbeat_transformation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -43,9 +43,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # response_time detector

--- a/modules/integration_azure-app-service/variables-gen.tf
+++ b/modules/integration_azure-app-service/variables-gen.tf
@@ -43,7 +43,7 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\")."
   type        = string
   default     = "25m"
 }

--- a/modules/integration_azure-application-gateway/variables-gen.tf
+++ b/modules/integration_azure-application-gateway/variables-gen.tf
@@ -43,7 +43,7 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\")."
   type        = string
   default     = "25m"
 }

--- a/modules/integration_azure-application-gateway/variables-gen.tf
+++ b/modules/integration_azure-application-gateway/variables-gen.tf
@@ -21,7 +21,7 @@ variable "heartbeat_transformation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -43,9 +43,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # compute_units detector

--- a/modules/integration_azure-container-apps/variables-gen.tf
+++ b/modules/integration_azure-container-apps/variables-gen.tf
@@ -43,7 +43,7 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\")."
   type        = string
   default     = "25m"
 }

--- a/modules/integration_azure-container-apps/variables-gen.tf
+++ b/modules/integration_azure-container-apps/variables-gen.tf
@@ -21,7 +21,7 @@ variable "heartbeat_transformation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -43,9 +43,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # restarts detector

--- a/modules/integration_azure-container-instance/variables-gen.tf
+++ b/modules/integration_azure-container-instance/variables-gen.tf
@@ -15,7 +15,7 @@ variable "heartbeat_aggregation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -37,8 +37,8 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 

--- a/modules/integration_azure-container-instance/variables-gen.tf
+++ b/modules/integration_azure-container-instance/variables-gen.tf
@@ -37,7 +37,7 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\")."
   type        = string
   default     = "25m"
 }

--- a/modules/integration_azure-cosmos-db/variables-gen.tf
+++ b/modules/integration_azure-cosmos-db/variables-gen.tf
@@ -43,7 +43,7 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\")."
   type        = string
   default     = "25m"
 }

--- a/modules/integration_azure-cosmos-db/variables-gen.tf
+++ b/modules/integration_azure-cosmos-db/variables-gen.tf
@@ -21,7 +21,7 @@ variable "heartbeat_transformation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -43,9 +43,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # database_4xx_request_rate detector

--- a/modules/integration_azure-express-route/variables-gen.tf
+++ b/modules/integration_azure-express-route/variables-gen.tf
@@ -43,7 +43,7 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\")."
   type        = string
   default     = "25m"
 }

--- a/modules/integration_azure-express-route/variables-gen.tf
+++ b/modules/integration_azure-express-route/variables-gen.tf
@@ -21,7 +21,7 @@ variable "heartbeat_transformation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -43,9 +43,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # bgp_availability detector

--- a/modules/integration_azure-firewall/variables-gen.tf
+++ b/modules/integration_azure-firewall/variables-gen.tf
@@ -43,7 +43,7 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\")."
   type        = string
   default     = "25m"
 }

--- a/modules/integration_azure-firewall/variables-gen.tf
+++ b/modules/integration_azure-firewall/variables-gen.tf
@@ -21,7 +21,7 @@ variable "heartbeat_transformation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -43,9 +43,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # snat_port_utilization detector

--- a/modules/integration_azure-flexible-mysql/variables-gen.tf
+++ b/modules/integration_azure-flexible-mysql/variables-gen.tf
@@ -43,7 +43,7 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\")."
   type        = string
   default     = "25m"
 }

--- a/modules/integration_azure-flexible-mysql/variables-gen.tf
+++ b/modules/integration_azure-flexible-mysql/variables-gen.tf
@@ -21,7 +21,7 @@ variable "heartbeat_transformation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -43,9 +43,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # cpu detector

--- a/modules/integration_azure-flexible-postgresql/variables-gen.tf
+++ b/modules/integration_azure-flexible-postgresql/variables-gen.tf
@@ -43,7 +43,7 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\")."
   type        = string
   default     = "25m"
 }

--- a/modules/integration_azure-flexible-postgresql/variables-gen.tf
+++ b/modules/integration_azure-flexible-postgresql/variables-gen.tf
@@ -21,7 +21,7 @@ variable "heartbeat_transformation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -43,9 +43,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # cpu_usage detector

--- a/modules/integration_azure-functions/variables-gen.tf
+++ b/modules/integration_azure-functions/variables-gen.tf
@@ -43,7 +43,7 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\")."
   type        = string
   default     = "25m"
 }

--- a/modules/integration_azure-functions/variables-gen.tf
+++ b/modules/integration_azure-functions/variables-gen.tf
@@ -21,7 +21,7 @@ variable "heartbeat_transformation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -43,9 +43,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # errors detector

--- a/modules/integration_azure-load-balancer/variables-gen.tf
+++ b/modules/integration_azure-load-balancer/variables-gen.tf
@@ -43,7 +43,7 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\")."
   type        = string
   default     = "25m"
 }

--- a/modules/integration_azure-load-balancer/variables-gen.tf
+++ b/modules/integration_azure-load-balancer/variables-gen.tf
@@ -21,7 +21,7 @@ variable "heartbeat_transformation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -43,8 +43,8 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 

--- a/modules/integration_azure-mariadb/variables-gen.tf
+++ b/modules/integration_azure-mariadb/variables-gen.tf
@@ -43,7 +43,7 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\")."
   type        = string
   default     = "25m"
 }

--- a/modules/integration_azure-mariadb/variables-gen.tf
+++ b/modules/integration_azure-mariadb/variables-gen.tf
@@ -21,7 +21,7 @@ variable "heartbeat_transformation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -43,9 +43,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # cpu detector

--- a/modules/integration_azure-mysql/variables-gen.tf
+++ b/modules/integration_azure-mysql/variables-gen.tf
@@ -43,7 +43,7 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\")."
   type        = string
   default     = "25m"
 }

--- a/modules/integration_azure-mysql/variables-gen.tf
+++ b/modules/integration_azure-mysql/variables-gen.tf
@@ -21,7 +21,7 @@ variable "heartbeat_transformation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -43,9 +43,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # cpu detector

--- a/modules/integration_azure-postgresql/variables-gen.tf
+++ b/modules/integration_azure-postgresql/variables-gen.tf
@@ -43,7 +43,7 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\")."
   type        = string
   default     = "25m"
 }

--- a/modules/integration_azure-postgresql/variables-gen.tf
+++ b/modules/integration_azure-postgresql/variables-gen.tf
@@ -21,7 +21,7 @@ variable "heartbeat_transformation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -43,9 +43,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # cpu_usage detector

--- a/modules/integration_azure-redis/variables-gen.tf
+++ b/modules/integration_azure-redis/variables-gen.tf
@@ -43,7 +43,7 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\")."
   type        = string
   default     = "25m"
 }

--- a/modules/integration_azure-redis/variables-gen.tf
+++ b/modules/integration_azure-redis/variables-gen.tf
@@ -21,7 +21,7 @@ variable "heartbeat_transformation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -43,9 +43,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # evicted_keys detector

--- a/modules/integration_azure-service-bus/variables-gen.tf
+++ b/modules/integration_azure-service-bus/variables-gen.tf
@@ -43,7 +43,7 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\")."
   type        = string
   default     = "25m"
 }

--- a/modules/integration_azure-service-bus/variables-gen.tf
+++ b/modules/integration_azure-service-bus/variables-gen.tf
@@ -21,7 +21,7 @@ variable "heartbeat_transformation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -43,9 +43,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # deadlettered_messages detector

--- a/modules/integration_azure-sql-database/variables-gen.tf
+++ b/modules/integration_azure-sql-database/variables-gen.tf
@@ -43,7 +43,7 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\")."
   type        = string
   default     = "25m"
 }

--- a/modules/integration_azure-sql-database/variables-gen.tf
+++ b/modules/integration_azure-sql-database/variables-gen.tf
@@ -21,7 +21,7 @@ variable "heartbeat_transformation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -43,9 +43,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # cpu detector

--- a/modules/integration_azure-sql-elastic-pool/variables-gen.tf
+++ b/modules/integration_azure-sql-elastic-pool/variables-gen.tf
@@ -43,7 +43,7 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\")."
   type        = string
   default     = "25m"
 }

--- a/modules/integration_azure-sql-elastic-pool/variables-gen.tf
+++ b/modules/integration_azure-sql-elastic-pool/variables-gen.tf
@@ -21,7 +21,7 @@ variable "heartbeat_transformation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -43,9 +43,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # cpu detector

--- a/modules/integration_azure-stream-analytics/variables-gen.tf
+++ b/modules/integration_azure-stream-analytics/variables-gen.tf
@@ -43,7 +43,7 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\")."
   type        = string
   default     = "25m"
 }

--- a/modules/integration_azure-stream-analytics/variables-gen.tf
+++ b/modules/integration_azure-stream-analytics/variables-gen.tf
@@ -21,7 +21,7 @@ variable "heartbeat_transformation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -43,9 +43,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # su_utilization detector

--- a/modules/integration_azure-virtual-machine-scaleset/variables-gen.tf
+++ b/modules/integration_azure-virtual-machine-scaleset/variables-gen.tf
@@ -43,7 +43,7 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\")."
   type        = string
   default     = "25m"
 }

--- a/modules/integration_azure-virtual-machine-scaleset/variables-gen.tf
+++ b/modules/integration_azure-virtual-machine-scaleset/variables-gen.tf
@@ -21,7 +21,7 @@ variable "heartbeat_transformation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -43,8 +43,8 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 

--- a/modules/integration_azure-virtual-machine/variables-gen.tf
+++ b/modules/integration_azure-virtual-machine/variables-gen.tf
@@ -43,7 +43,7 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\")."
   type        = string
   default     = "25m"
 }

--- a/modules/integration_azure-virtual-machine/variables-gen.tf
+++ b/modules/integration_azure-virtual-machine/variables-gen.tf
@@ -21,7 +21,7 @@ variable "heartbeat_transformation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -43,9 +43,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # cpu detector

--- a/modules/integration_gcp-cloud-sql-common/variables-gen.tf
+++ b/modules/integration_gcp-cloud-sql-common/variables-gen.tf
@@ -43,7 +43,7 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\")."
   type        = string
   default     = "25m"
 }

--- a/modules/integration_gcp-cloud-sql-common/variables-gen.tf
+++ b/modules/integration_gcp-cloud-sql-common/variables-gen.tf
@@ -21,7 +21,7 @@ variable "heartbeat_transformation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -43,9 +43,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # cpu_utilization detector

--- a/modules/integration_gcp-compute-engine/detectors-gen.tf
+++ b/modules/integration_gcp-compute-engine/detectors-gen.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
-    signal = data('instance/cpu/usage_time', filter=%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
+    signal = data('instance/cpu/usage_time', filter=%{if var.heartbeat_exclude_not_running_vm}${local.not_running_vm_filters} and %{endif}${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 

--- a/modules/integration_gcp-compute-engine/detectors-gen.tf
+++ b/modules/integration_gcp-compute-engine/detectors-gen.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
-    signal = data('instance/cpu/usage_time', filter=${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
+    signal = data('instance/cpu/usage_time', filter=%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 

--- a/modules/integration_gcp-compute-engine/variables-gen.tf
+++ b/modules/integration_gcp-compute-engine/variables-gen.tf
@@ -49,7 +49,7 @@ variable "heartbeat_exclude_not_running_vm" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if \"heartbeat_exclude_not_running_vm\" is true"
   type        = string
   default     = "25m"
 }

--- a/modules/integration_gcp-compute-engine/variables-gen.tf
+++ b/modules/integration_gcp-compute-engine/variables-gen.tf
@@ -21,7 +21,7 @@ variable "heartbeat_transformation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -42,10 +42,16 @@ variable "heartbeat_disabled" {
   default     = null
 }
 
+variable "heartbeat_exclude_not_running_vm" {
+  description = "Don’t send alerts if associated VM is stopped or stopping (metadata provided by cloud provider integration). Can be useful for ephemeral infrastructure (such as auto scaling groups) as VM will be stopped and started regularly. Note that timeframe must be at least 25 minutes for the metadata to be available to the detector."
+  type        = bool
+  default     = true
+}
+
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # cpu_utilization detector

--- a/modules/integration_gcp-memorystore-redis/variables-gen.tf
+++ b/modules/integration_gcp-memorystore-redis/variables-gen.tf
@@ -15,7 +15,7 @@ variable "heartbeat_aggregation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -37,9 +37,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # blocked_over_connected_clients_ratio detector

--- a/modules/integration_gcp-memorystore-redis/variables-gen.tf
+++ b/modules/integration_gcp-memorystore-redis/variables-gen.tf
@@ -37,7 +37,7 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\")."
   type        = string
   default     = "25m"
 }

--- a/modules/integration_gcp-pubsub-subscription/variables-gen.tf
+++ b/modules/integration_gcp-pubsub-subscription/variables-gen.tf
@@ -43,7 +43,7 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\")."
   type        = string
   default     = "25m"
 }

--- a/modules/integration_gcp-pubsub-subscription/variables-gen.tf
+++ b/modules/integration_gcp-pubsub-subscription/variables-gen.tf
@@ -21,7 +21,7 @@ variable "heartbeat_transformation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -43,9 +43,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # oldest_unacked_message detector

--- a/modules/integration_newrelic-apm/variables-gen.tf
+++ b/modules/integration_newrelic-apm/variables-gen.tf
@@ -43,7 +43,7 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\")."
   type        = string
   default     = "25m"
 }

--- a/modules/integration_newrelic-apm/variables-gen.tf
+++ b/modules/integration_newrelic-apm/variables-gen.tf
@@ -21,7 +21,7 @@ variable "heartbeat_transformation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -43,9 +43,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # error_rate detector

--- a/modules/otel-collector_kubernetes-common/detectors-gen.tf
+++ b/modules/otel-collector_kubernetes-common/detectors-gen.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
-    signal = data('k8s.node.condition_ready', filter=%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
+    signal = data('k8s.node.condition_ready', filter=%{if var.heartbeat_exclude_not_running_vm}${local.not_running_vm_filters} and %{endif}${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 

--- a/modules/otel-collector_kubernetes-common/detectors-gen.tf
+++ b/modules/otel-collector_kubernetes-common/detectors-gen.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
-    signal = data('k8s.node.condition_ready', filter=${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
+    signal = data('k8s.node.condition_ready', filter=%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 

--- a/modules/otel-collector_kubernetes-common/variables-gen.tf
+++ b/modules/otel-collector_kubernetes-common/variables-gen.tf
@@ -43,7 +43,7 @@ variable "heartbeat_exclude_not_running_vm" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if \"heartbeat_exclude_not_running_vm\" is true"
   type        = string
   default     = "25m"
 }

--- a/modules/otel-collector_kubernetes-common/variables-gen.tf
+++ b/modules/otel-collector_kubernetes-common/variables-gen.tf
@@ -15,7 +15,7 @@ variable "heartbeat_aggregation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -36,10 +36,16 @@ variable "heartbeat_disabled" {
   default     = null
 }
 
+variable "heartbeat_exclude_not_running_vm" {
+  description = "Don’t send alerts if associated VM is stopped or stopping (metadata provided by cloud provider integration). Can be useful for ephemeral infrastructure (such as auto scaling groups) as VM will be stopped and started regularly. Note that timeframe must be at least 25 minutes for the metadata to be available to the detector."
+  type        = bool
+  default     = true
+}
+
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # hpa_capacity detector

--- a/modules/prometheus-exporter_active-directory/detectors-gen.tf
+++ b/modules/prometheus-exporter_active-directory/detectors-gen.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
-    signal = data('windows_ad_replication_sync_requests_total', filter=${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
+    signal = data('windows_ad_replication_sync_requests_total', filter=%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 

--- a/modules/prometheus-exporter_active-directory/detectors-gen.tf
+++ b/modules/prometheus-exporter_active-directory/detectors-gen.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
-    signal = data('windows_ad_replication_sync_requests_total', filter=%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
+    signal = data('windows_ad_replication_sync_requests_total', filter=%{if var.heartbeat_exclude_not_running_vm}${local.not_running_vm_filters} and %{endif}${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 

--- a/modules/prometheus-exporter_active-directory/variables-gen.tf
+++ b/modules/prometheus-exporter_active-directory/variables-gen.tf
@@ -21,7 +21,7 @@ variable "heartbeat_transformation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -42,10 +42,16 @@ variable "heartbeat_disabled" {
   default     = null
 }
 
+variable "heartbeat_exclude_not_running_vm" {
+  description = "Don’t send alerts if associated VM is stopped or stopping (metadata provided by cloud provider integration). Can be useful for ephemeral infrastructure (such as auto scaling groups) as VM will be stopped and started regularly. Note that timeframe must be at least 25 minutes for the metadata to be available to the detector."
+  type        = bool
+  default     = true
+}
+
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # replication_errors detector

--- a/modules/prometheus-exporter_active-directory/variables-gen.tf
+++ b/modules/prometheus-exporter_active-directory/variables-gen.tf
@@ -49,7 +49,7 @@ variable "heartbeat_exclude_not_running_vm" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if \"heartbeat_exclude_not_running_vm\" is true"
   type        = string
   default     = "25m"
 }

--- a/modules/prometheus-exporter_docker-state/detectors-gen.tf
+++ b/modules/prometheus-exporter_docker-state/detectors-gen.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
-    signal = data('container_state_status', filter=%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
+    signal = data('container_state_status', filter=%{if var.heartbeat_exclude_not_running_vm}${local.not_running_vm_filters} and %{endif}${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 

--- a/modules/prometheus-exporter_docker-state/detectors-gen.tf
+++ b/modules/prometheus-exporter_docker-state/detectors-gen.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
-    signal = data('container_state_status', filter=${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
+    signal = data('container_state_status', filter=%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 

--- a/modules/prometheus-exporter_docker-state/variables-gen.tf
+++ b/modules/prometheus-exporter_docker-state/variables-gen.tf
@@ -15,7 +15,7 @@ variable "heartbeat_aggregation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -36,10 +36,16 @@ variable "heartbeat_disabled" {
   default     = null
 }
 
+variable "heartbeat_exclude_not_running_vm" {
+  description = "Don’t send alerts if associated VM is stopped or stopping (metadata provided by cloud provider integration). Can be useful for ephemeral infrastructure (such as auto scaling groups) as VM will be stopped and started regularly. Note that timeframe must be at least 25 minutes for the metadata to be available to the detector."
+  type        = bool
+  default     = true
+}
+
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # state_health_status detector

--- a/modules/prometheus-exporter_docker-state/variables-gen.tf
+++ b/modules/prometheus-exporter_docker-state/variables-gen.tf
@@ -43,7 +43,7 @@ variable "heartbeat_exclude_not_running_vm" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if \"heartbeat_exclude_not_running_vm\" is true"
   type        = string
   default     = "25m"
 }

--- a/modules/prometheus-exporter_kong/detectors-gen.tf
+++ b/modules/prometheus-exporter_kong/detectors-gen.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
-    signal = data('kong_datastore_reachable', filter=${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
+    signal = data('kong_datastore_reachable', filter=%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 

--- a/modules/prometheus-exporter_kong/detectors-gen.tf
+++ b/modules/prometheus-exporter_kong/detectors-gen.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
-    signal = data('kong_datastore_reachable', filter=%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
+    signal = data('kong_datastore_reachable', filter=%{if var.heartbeat_exclude_not_running_vm}${local.not_running_vm_filters} and %{endif}${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 

--- a/modules/prometheus-exporter_kong/variables-gen.tf
+++ b/modules/prometheus-exporter_kong/variables-gen.tf
@@ -49,7 +49,7 @@ variable "heartbeat_exclude_not_running_vm" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if \"heartbeat_exclude_not_running_vm\" is true"
   type        = string
   default     = "25m"
 }

--- a/modules/prometheus-exporter_kong/variables-gen.tf
+++ b/modules/prometheus-exporter_kong/variables-gen.tf
@@ -21,7 +21,7 @@ variable "heartbeat_transformation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -42,10 +42,16 @@ variable "heartbeat_disabled" {
   default     = null
 }
 
+variable "heartbeat_exclude_not_running_vm" {
+  description = "Don’t send alerts if associated VM is stopped or stopping (metadata provided by cloud provider integration). Can be useful for ephemeral infrastructure (such as auto scaling groups) as VM will be stopped and started regularly. Note that timeframe must be at least 25 minutes for the metadata to be available to the detector."
+  type        = bool
+  default     = true
+}
+
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # treatment_limit detector

--- a/modules/prometheus-exporter_oracledb/detectors-gen.tf
+++ b/modules/prometheus-exporter_oracledb/detectors-gen.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
-    signal = data('oracledb_up', filter=%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
+    signal = data('oracledb_up', filter=%{if var.heartbeat_exclude_not_running_vm}${local.not_running_vm_filters} and %{endif}${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 

--- a/modules/prometheus-exporter_oracledb/detectors-gen.tf
+++ b/modules/prometheus-exporter_oracledb/detectors-gen.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
-    signal = data('oracledb_up', filter=${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
+    signal = data('oracledb_up', filter=%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 

--- a/modules/prometheus-exporter_oracledb/variables-gen.tf
+++ b/modules/prometheus-exporter_oracledb/variables-gen.tf
@@ -49,7 +49,7 @@ variable "heartbeat_exclude_not_running_vm" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if \"heartbeat_exclude_not_running_vm\" is true"
   type        = string
   default     = "25m"
 }

--- a/modules/prometheus-exporter_oracledb/variables-gen.tf
+++ b/modules/prometheus-exporter_oracledb/variables-gen.tf
@@ -21,7 +21,7 @@ variable "heartbeat_transformation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -42,10 +42,16 @@ variable "heartbeat_disabled" {
   default     = null
 }
 
+variable "heartbeat_exclude_not_running_vm" {
+  description = "Don’t send alerts if associated VM is stopped or stopping (metadata provided by cloud provider integration). Can be useful for ephemeral infrastructure (such as auto scaling groups) as VM will be stopped and started regularly. Note that timeframe must be at least 25 minutes for the metadata to be available to the detector."
+  type        = bool
+  default     = true
+}
+
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # dbisdown detector

--- a/modules/prometheus-exporter_squid/detectors-gen.tf
+++ b/modules/prometheus-exporter_squid/detectors-gen.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
-    signal = data('squid_up', filter=%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
+    signal = data('squid_up', filter=%{if var.heartbeat_exclude_not_running_vm}${local.not_running_vm_filters} and %{endif}${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 

--- a/modules/prometheus-exporter_squid/detectors-gen.tf
+++ b/modules/prometheus-exporter_squid/detectors-gen.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
-    signal = data('squid_up', filter=${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
+    signal = data('squid_up', filter=%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 

--- a/modules/prometheus-exporter_squid/variables-gen.tf
+++ b/modules/prometheus-exporter_squid/variables-gen.tf
@@ -49,7 +49,7 @@ variable "heartbeat_exclude_not_running_vm" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if \"heartbeat_exclude_not_running_vm\" is true"
   type        = string
   default     = "25m"
 }

--- a/modules/prometheus-exporter_squid/variables-gen.tf
+++ b/modules/prometheus-exporter_squid/variables-gen.tf
@@ -21,7 +21,7 @@ variable "heartbeat_transformation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -42,10 +42,16 @@ variable "heartbeat_disabled" {
   default     = null
 }
 
+variable "heartbeat_exclude_not_running_vm" {
+  description = "Don’t send alerts if associated VM is stopped or stopping (metadata provided by cloud provider integration). Can be useful for ephemeral infrastructure (such as auto scaling groups) as VM will be stopped and started regularly. Note that timeframe must be at least 25 minutes for the metadata to be available to the detector."
+  type        = bool
+  default     = true
+}
+
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # status detector

--- a/modules/prometheus-exporter_varnish/detectors-gen.tf
+++ b/modules/prometheus-exporter_varnish/detectors-gen.tf
@@ -8,7 +8,7 @@ resource "signalfx_detector" "heartbeat" {
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     base_filtering = filter('system.type', 'prometheus-exporter')
-    signal = data('varnish_main_threads', filter=%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }base_filtering and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
+    signal = data('varnish_main_threads', filter=%{if var.heartbeat_exclude_not_running_vm}${local.not_running_vm_filters} and %{endif}base_filtering and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 

--- a/modules/prometheus-exporter_varnish/detectors-gen.tf
+++ b/modules/prometheus-exporter_varnish/detectors-gen.tf
@@ -8,7 +8,7 @@ resource "signalfx_detector" "heartbeat" {
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     base_filtering = filter('system.type', 'prometheus-exporter')
-    signal = data('varnish_main_threads', filter=${local.not_running_vm_filters} and base_filtering and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
+    signal = data('varnish_main_threads', filter=%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }base_filtering and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 

--- a/modules/prometheus-exporter_varnish/variables-gen.tf
+++ b/modules/prometheus-exporter_varnish/variables-gen.tf
@@ -43,7 +43,7 @@ variable "heartbeat_exclude_not_running_vm" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if \"heartbeat_exclude_not_running_vm\" is true"
   type        = string
   default     = "25m"
 }

--- a/modules/prometheus-exporter_varnish/variables-gen.tf
+++ b/modules/prometheus-exporter_varnish/variables-gen.tf
@@ -15,7 +15,7 @@ variable "heartbeat_aggregation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -36,10 +36,16 @@ variable "heartbeat_disabled" {
   default     = null
 }
 
+variable "heartbeat_exclude_not_running_vm" {
+  description = "Don’t send alerts if associated VM is stopped or stopping (metadata provided by cloud provider integration). Can be useful for ephemeral infrastructure (such as auto scaling groups) as VM will be stopped and started regularly. Note that timeframe must be at least 25 minutes for the metadata to be available to the detector."
+  type        = bool
+  default     = true
+}
+
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # backend_failed detector

--- a/modules/prometheus-exporter_wallix-bastion/detectors-gen.tf
+++ b/modules/prometheus-exporter_wallix-bastion/detectors-gen.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
-    signal = data('wallix_bastion_up', filter=%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
+    signal = data('wallix_bastion_up', filter=%{if var.heartbeat_exclude_not_running_vm}${local.not_running_vm_filters} and %{endif}${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 

--- a/modules/prometheus-exporter_wallix-bastion/detectors-gen.tf
+++ b/modules/prometheus-exporter_wallix-bastion/detectors-gen.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
-    signal = data('wallix_bastion_up', filter=${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
+    signal = data('wallix_bastion_up', filter=%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 

--- a/modules/prometheus-exporter_wallix-bastion/variables-gen.tf
+++ b/modules/prometheus-exporter_wallix-bastion/variables-gen.tf
@@ -49,7 +49,7 @@ variable "heartbeat_exclude_not_running_vm" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if \"heartbeat_exclude_not_running_vm\" is true"
   type        = string
   default     = "25m"
 }

--- a/modules/prometheus-exporter_wallix-bastion/variables-gen.tf
+++ b/modules/prometheus-exporter_wallix-bastion/variables-gen.tf
@@ -21,7 +21,7 @@ variable "heartbeat_transformation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -42,10 +42,16 @@ variable "heartbeat_disabled" {
   default     = null
 }
 
+variable "heartbeat_exclude_not_running_vm" {
+  description = "Don’t send alerts if associated VM is stopped or stopping (metadata provided by cloud provider integration). Can be useful for ephemeral infrastructure (such as auto scaling groups) as VM will be stopped and started regularly. Note that timeframe must be at least 25 minutes for the metadata to be available to the detector."
+  type        = bool
+  default     = true
+}
+
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # status detector

--- a/modules/smart-agent_apache/detectors-gen.tf
+++ b/modules/smart-agent_apache/detectors-gen.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
-    signal = data('apache_connections', filter=%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
+    signal = data('apache_connections', filter=%{if var.heartbeat_exclude_not_running_vm}${local.not_running_vm_filters} and %{endif}${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 

--- a/modules/smart-agent_apache/detectors-gen.tf
+++ b/modules/smart-agent_apache/detectors-gen.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
-    signal = data('apache_connections', filter=${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
+    signal = data('apache_connections', filter=%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 

--- a/modules/smart-agent_apache/variables-gen.tf
+++ b/modules/smart-agent_apache/variables-gen.tf
@@ -43,7 +43,7 @@ variable "heartbeat_exclude_not_running_vm" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if \"heartbeat_exclude_not_running_vm\" is true"
   type        = string
   default     = "25m"
 }

--- a/modules/smart-agent_apache/variables-gen.tf
+++ b/modules/smart-agent_apache/variables-gen.tf
@@ -15,7 +15,7 @@ variable "heartbeat_aggregation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -36,10 +36,16 @@ variable "heartbeat_disabled" {
   default     = null
 }
 
+variable "heartbeat_exclude_not_running_vm" {
+  description = "Don’t send alerts if associated VM is stopped or stopping (metadata provided by cloud provider integration). Can be useful for ephemeral infrastructure (such as auto scaling groups) as VM will be stopped and started regularly. Note that timeframe must be at least 25 minutes for the metadata to be available to the detector."
+  type        = bool
+  default     = true
+}
+
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # busy_workers detector

--- a/modules/smart-agent_cassandra/detectors-gen.tf
+++ b/modules/smart-agent_cassandra/detectors-gen.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
-    signal = data('counter.cassandra.Storage.Load.Count', filter=${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
+    signal = data('counter.cassandra.Storage.Load.Count', filter=%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 

--- a/modules/smart-agent_cassandra/detectors-gen.tf
+++ b/modules/smart-agent_cassandra/detectors-gen.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
-    signal = data('counter.cassandra.Storage.Load.Count', filter=%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
+    signal = data('counter.cassandra.Storage.Load.Count', filter=%{if var.heartbeat_exclude_not_running_vm}${local.not_running_vm_filters} and %{endif}${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 

--- a/modules/smart-agent_cassandra/variables-gen.tf
+++ b/modules/smart-agent_cassandra/variables-gen.tf
@@ -49,7 +49,7 @@ variable "heartbeat_exclude_not_running_vm" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if \"heartbeat_exclude_not_running_vm\" is true"
   type        = string
   default     = "25m"
 }

--- a/modules/smart-agent_cassandra/variables-gen.tf
+++ b/modules/smart-agent_cassandra/variables-gen.tf
@@ -21,7 +21,7 @@ variable "heartbeat_transformation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -42,10 +42,16 @@ variable "heartbeat_disabled" {
   default     = null
 }
 
+variable "heartbeat_exclude_not_running_vm" {
+  description = "Don’t send alerts if associated VM is stopped or stopping (metadata provided by cloud provider integration). Can be useful for ephemeral infrastructure (such as auto scaling groups) as VM will be stopped and started regularly. Note that timeframe must be at least 25 minutes for the metadata to be available to the detector."
+  type        = bool
+  default     = true
+}
+
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # read_latency_99th_percentile detector

--- a/modules/smart-agent_couchbase/detectors-gen.tf
+++ b/modules/smart-agent_couchbase/detectors-gen.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
-    signal = data('gauge.bucket.op.mem_used', filter=${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
+    signal = data('gauge.bucket.op.mem_used', filter=%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 

--- a/modules/smart-agent_couchbase/detectors-gen.tf
+++ b/modules/smart-agent_couchbase/detectors-gen.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
-    signal = data('gauge.bucket.op.mem_used', filter=%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
+    signal = data('gauge.bucket.op.mem_used', filter=%{if var.heartbeat_exclude_not_running_vm}${local.not_running_vm_filters} and %{endif}${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 

--- a/modules/smart-agent_couchbase/variables-gen.tf
+++ b/modules/smart-agent_couchbase/variables-gen.tf
@@ -15,7 +15,7 @@ variable "heartbeat_aggregation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -36,10 +36,16 @@ variable "heartbeat_disabled" {
   default     = null
 }
 
+variable "heartbeat_exclude_not_running_vm" {
+  description = "Don’t send alerts if associated VM is stopped or stopping (metadata provided by cloud provider integration). Can be useful for ephemeral infrastructure (such as auto scaling groups) as VM will be stopped and started regularly. Note that timeframe must be at least 25 minutes for the metadata to be available to the detector."
+  type        = bool
+  default     = true
+}
+
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # memory_used detector

--- a/modules/smart-agent_couchbase/variables-gen.tf
+++ b/modules/smart-agent_couchbase/variables-gen.tf
@@ -43,7 +43,7 @@ variable "heartbeat_exclude_not_running_vm" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if \"heartbeat_exclude_not_running_vm\" is true"
   type        = string
   default     = "25m"
 }

--- a/modules/smart-agent_dns/detectors-gen.tf
+++ b/modules/smart-agent_dns/detectors-gen.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
-    signal = data('dns.result_code', filter=${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
+    signal = data('dns.result_code', filter=%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 

--- a/modules/smart-agent_dns/detectors-gen.tf
+++ b/modules/smart-agent_dns/detectors-gen.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
-    signal = data('dns.result_code', filter=%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
+    signal = data('dns.result_code', filter=%{if var.heartbeat_exclude_not_running_vm}${local.not_running_vm_filters} and %{endif}${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 

--- a/modules/smart-agent_dns/variables-gen.tf
+++ b/modules/smart-agent_dns/variables-gen.tf
@@ -49,7 +49,7 @@ variable "heartbeat_exclude_not_running_vm" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if \"heartbeat_exclude_not_running_vm\" is true"
   type        = string
   default     = "25m"
 }

--- a/modules/smart-agent_dns/variables-gen.tf
+++ b/modules/smart-agent_dns/variables-gen.tf
@@ -21,7 +21,7 @@ variable "heartbeat_transformation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -42,10 +42,16 @@ variable "heartbeat_disabled" {
   default     = null
 }
 
+variable "heartbeat_exclude_not_running_vm" {
+  description = "Don’t send alerts if associated VM is stopped or stopping (metadata provided by cloud provider integration). Can be useful for ephemeral infrastructure (such as auto scaling groups) as VM will be stopped and started regularly. Note that timeframe must be at least 25 minutes for the metadata to be available to the detector."
+  type        = bool
+  default     = true
+}
+
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # dns_query_time detector

--- a/modules/smart-agent_docker/detectors-gen.tf
+++ b/modules/smart-agent_docker/detectors-gen.tf
@@ -8,7 +8,7 @@ resource "signalfx_detector" "heartbeat" {
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     base_filtering = filter('plugin', 'docker')
-    signal = data('cpu.usage.system', filter=${local.not_running_vm_filters} and base_filtering and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
+    signal = data('cpu.usage.system', filter=%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }base_filtering and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 

--- a/modules/smart-agent_docker/detectors-gen.tf
+++ b/modules/smart-agent_docker/detectors-gen.tf
@@ -8,7 +8,7 @@ resource "signalfx_detector" "heartbeat" {
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     base_filtering = filter('plugin', 'docker')
-    signal = data('cpu.usage.system', filter=%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }base_filtering and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
+    signal = data('cpu.usage.system', filter=%{if var.heartbeat_exclude_not_running_vm}${local.not_running_vm_filters} and %{endif}base_filtering and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 

--- a/modules/smart-agent_docker/variables-gen.tf
+++ b/modules/smart-agent_docker/variables-gen.tf
@@ -49,7 +49,7 @@ variable "heartbeat_exclude_not_running_vm" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if \"heartbeat_exclude_not_running_vm\" is true"
   type        = string
   default     = "25m"
 }

--- a/modules/smart-agent_docker/variables-gen.tf
+++ b/modules/smart-agent_docker/variables-gen.tf
@@ -21,7 +21,7 @@ variable "heartbeat_transformation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -42,10 +42,16 @@ variable "heartbeat_disabled" {
   default     = null
 }
 
+variable "heartbeat_exclude_not_running_vm" {
+  description = "Don’t send alerts if associated VM is stopped or stopping (metadata provided by cloud provider integration). Can be useful for ephemeral infrastructure (such as auto scaling groups) as VM will be stopped and started regularly. Note that timeframe must be at least 25 minutes for the metadata to be available to the detector."
+  type        = bool
+  default     = true
+}
+
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # cpu detector

--- a/modules/smart-agent_elasticsearch/detectors-gen.tf
+++ b/modules/smart-agent_elasticsearch/detectors-gen.tf
@@ -8,7 +8,7 @@ resource "signalfx_detector" "heartbeat" {
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     base_filtering = filter('plugin', 'elasticsearch')
-    signal = data('elasticsearch.cluster.number-of-nodes', filter=${local.not_running_vm_filters} and base_filtering and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
+    signal = data('elasticsearch.cluster.number-of-nodes', filter=%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }base_filtering and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 

--- a/modules/smart-agent_elasticsearch/detectors-gen.tf
+++ b/modules/smart-agent_elasticsearch/detectors-gen.tf
@@ -8,7 +8,7 @@ resource "signalfx_detector" "heartbeat" {
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     base_filtering = filter('plugin', 'elasticsearch')
-    signal = data('elasticsearch.cluster.number-of-nodes', filter=%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }base_filtering and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
+    signal = data('elasticsearch.cluster.number-of-nodes', filter=%{if var.heartbeat_exclude_not_running_vm}${local.not_running_vm_filters} and %{endif}base_filtering and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 

--- a/modules/smart-agent_elasticsearch/variables-gen.tf
+++ b/modules/smart-agent_elasticsearch/variables-gen.tf
@@ -49,7 +49,7 @@ variable "heartbeat_exclude_not_running_vm" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if \"heartbeat_exclude_not_running_vm\" is true"
   type        = string
   default     = "25m"
 }

--- a/modules/smart-agent_elasticsearch/variables-gen.tf
+++ b/modules/smart-agent_elasticsearch/variables-gen.tf
@@ -21,7 +21,7 @@ variable "heartbeat_transformation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -42,10 +42,16 @@ variable "heartbeat_disabled" {
   default     = null
 }
 
+variable "heartbeat_exclude_not_running_vm" {
+  description = "Don’t send alerts if associated VM is stopped or stopping (metadata provided by cloud provider integration). Can be useful for ephemeral infrastructure (such as auto scaling groups) as VM will be stopped and started regularly. Note that timeframe must be at least 25 minutes for the metadata to be available to the detector."
+  type        = bool
+  default     = true
+}
+
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # cluster_status detector

--- a/modules/smart-agent_genericjmx/detectors-gen.tf
+++ b/modules/smart-agent_genericjmx/detectors-gen.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
-    signal = data('jmx_memory.used', filter=%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
+    signal = data('jmx_memory.used', filter=%{if var.heartbeat_exclude_not_running_vm}${local.not_running_vm_filters} and %{endif}${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 

--- a/modules/smart-agent_genericjmx/detectors-gen.tf
+++ b/modules/smart-agent_genericjmx/detectors-gen.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
-    signal = data('jmx_memory.used', filter=${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
+    signal = data('jmx_memory.used', filter=%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 

--- a/modules/smart-agent_genericjmx/variables-gen.tf
+++ b/modules/smart-agent_genericjmx/variables-gen.tf
@@ -15,7 +15,7 @@ variable "heartbeat_aggregation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -36,10 +36,16 @@ variable "heartbeat_disabled" {
   default     = null
 }
 
+variable "heartbeat_exclude_not_running_vm" {
+  description = "Don’t send alerts if associated VM is stopped or stopping (metadata provided by cloud provider integration). Can be useful for ephemeral infrastructure (such as auto scaling groups) as VM will be stopped and started regularly. Note that timeframe must be at least 25 minutes for the metadata to be available to the detector."
+  type        = bool
+  default     = true
+}
+
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # memory_heap detector

--- a/modules/smart-agent_genericjmx/variables-gen.tf
+++ b/modules/smart-agent_genericjmx/variables-gen.tf
@@ -43,7 +43,7 @@ variable "heartbeat_exclude_not_running_vm" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if \"heartbeat_exclude_not_running_vm\" is true"
   type        = string
   default     = "25m"
 }

--- a/modules/smart-agent_haproxy/detectors-gen.tf
+++ b/modules/smart-agent_haproxy/detectors-gen.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
-    signal = data('haproxy_session_current', filter=%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
+    signal = data('haproxy_session_current', filter=%{if var.heartbeat_exclude_not_running_vm}${local.not_running_vm_filters} and %{endif}${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 

--- a/modules/smart-agent_haproxy/detectors-gen.tf
+++ b/modules/smart-agent_haproxy/detectors-gen.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
-    signal = data('haproxy_session_current', filter=${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
+    signal = data('haproxy_session_current', filter=%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 

--- a/modules/smart-agent_haproxy/variables-gen.tf
+++ b/modules/smart-agent_haproxy/variables-gen.tf
@@ -49,7 +49,7 @@ variable "heartbeat_exclude_not_running_vm" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if \"heartbeat_exclude_not_running_vm\" is true"
   type        = string
   default     = "25m"
 }

--- a/modules/smart-agent_haproxy/variables-gen.tf
+++ b/modules/smart-agent_haproxy/variables-gen.tf
@@ -21,7 +21,7 @@ variable "heartbeat_transformation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -42,10 +42,16 @@ variable "heartbeat_disabled" {
   default     = null
 }
 
+variable "heartbeat_exclude_not_running_vm" {
+  description = "Don’t send alerts if associated VM is stopped or stopping (metadata provided by cloud provider integration). Can be useful for ephemeral infrastructure (such as auto scaling groups) as VM will be stopped and started regularly. Note that timeframe must be at least 25 minutes for the metadata to be available to the detector."
+  type        = bool
+  default     = true
+}
+
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # server_status detector

--- a/modules/smart-agent_http/detectors-gen.tf
+++ b/modules/smart-agent_http/detectors-gen.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
-    signal = data('http.status_code', filter=%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
+    signal = data('http.status_code', filter=%{if var.heartbeat_exclude_not_running_vm}${local.not_running_vm_filters} and %{endif}${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 

--- a/modules/smart-agent_http/detectors-gen.tf
+++ b/modules/smart-agent_http/detectors-gen.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
-    signal = data('http.status_code', filter=${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
+    signal = data('http.status_code', filter=%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 

--- a/modules/smart-agent_http/variables-gen.tf
+++ b/modules/smart-agent_http/variables-gen.tf
@@ -43,7 +43,7 @@ variable "heartbeat_exclude_not_running_vm" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if \"heartbeat_exclude_not_running_vm\" is true"
   type        = string
   default     = "25m"
 }

--- a/modules/smart-agent_http/variables-gen.tf
+++ b/modules/smart-agent_http/variables-gen.tf
@@ -15,7 +15,7 @@ variable "heartbeat_aggregation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -36,10 +36,16 @@ variable "heartbeat_disabled" {
   default     = null
 }
 
+variable "heartbeat_exclude_not_running_vm" {
+  description = "Don’t send alerts if associated VM is stopped or stopping (metadata provided by cloud provider integration). Can be useful for ephemeral infrastructure (such as auto scaling groups) as VM will be stopped and started regularly. Note that timeframe must be at least 25 minutes for the metadata to be available to the detector."
+  type        = bool
+  default     = true
+}
+
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # http_code_matched detector

--- a/modules/smart-agent_kubernetes-apiserver/detectors-gen.tf
+++ b/modules/smart-agent_kubernetes-apiserver/detectors-gen.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
-    signal = data('apiserver_request_total', filter=${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
+    signal = data('apiserver_request_total', filter=%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 

--- a/modules/smart-agent_kubernetes-apiserver/detectors-gen.tf
+++ b/modules/smart-agent_kubernetes-apiserver/detectors-gen.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
-    signal = data('apiserver_request_total', filter=%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
+    signal = data('apiserver_request_total', filter=%{if var.heartbeat_exclude_not_running_vm}${local.not_running_vm_filters} and %{endif}${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 

--- a/modules/smart-agent_kubernetes-apiserver/variables-gen.tf
+++ b/modules/smart-agent_kubernetes-apiserver/variables-gen.tf
@@ -49,7 +49,7 @@ variable "heartbeat_exclude_not_running_vm" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if \"heartbeat_exclude_not_running_vm\" is true"
   type        = string
   default     = "25m"
 }

--- a/modules/smart-agent_kubernetes-apiserver/variables-gen.tf
+++ b/modules/smart-agent_kubernetes-apiserver/variables-gen.tf
@@ -21,7 +21,7 @@ variable "heartbeat_transformation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -42,9 +42,15 @@ variable "heartbeat_disabled" {
   default     = null
 }
 
+variable "heartbeat_exclude_not_running_vm" {
+  description = "Don’t send alerts if associated VM is stopped or stopping (metadata provided by cloud provider integration). Can be useful for ephemeral infrastructure (such as auto scaling groups) as VM will be stopped and started regularly. Note that timeframe must be at least 25 minutes for the metadata to be available to the detector."
+  type        = bool
+  default     = true
+}
+
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 

--- a/modules/smart-agent_kubernetes-common/detectors-gen.tf
+++ b/modules/smart-agent_kubernetes-common/detectors-gen.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
-    signal = data('kubernetes.node_ready', filter=${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
+    signal = data('kubernetes.node_ready', filter=%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 

--- a/modules/smart-agent_kubernetes-common/detectors-gen.tf
+++ b/modules/smart-agent_kubernetes-common/detectors-gen.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
-    signal = data('kubernetes.node_ready', filter=%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
+    signal = data('kubernetes.node_ready', filter=%{if var.heartbeat_exclude_not_running_vm}${local.not_running_vm_filters} and %{endif}${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 

--- a/modules/smart-agent_kubernetes-common/variables-gen.tf
+++ b/modules/smart-agent_kubernetes-common/variables-gen.tf
@@ -43,7 +43,7 @@ variable "heartbeat_exclude_not_running_vm" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if \"heartbeat_exclude_not_running_vm\" is true"
   type        = string
   default     = "25m"
 }

--- a/modules/smart-agent_kubernetes-common/variables-gen.tf
+++ b/modules/smart-agent_kubernetes-common/variables-gen.tf
@@ -15,7 +15,7 @@ variable "heartbeat_aggregation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -36,10 +36,16 @@ variable "heartbeat_disabled" {
   default     = null
 }
 
+variable "heartbeat_exclude_not_running_vm" {
+  description = "Don’t send alerts if associated VM is stopped or stopping (metadata provided by cloud provider integration). Can be useful for ephemeral infrastructure (such as auto scaling groups) as VM will be stopped and started regularly. Note that timeframe must be at least 25 minutes for the metadata to be available to the detector."
+  type        = bool
+  default     = true
+}
+
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # hpa_capacity detector

--- a/modules/smart-agent_memcached/variables-gen.tf
+++ b/modules/smart-agent_memcached/variables-gen.tf
@@ -43,7 +43,7 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\")."
   type        = string
   default     = "25m"
 }

--- a/modules/smart-agent_memcached/variables-gen.tf
+++ b/modules/smart-agent_memcached/variables-gen.tf
@@ -21,7 +21,7 @@ variable "heartbeat_transformation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -43,9 +43,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # memcached_max_conn detector

--- a/modules/smart-agent_mongodb/variables-gen.tf
+++ b/modules/smart-agent_mongodb/variables-gen.tf
@@ -43,7 +43,7 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\")."
   type        = string
   default     = "25m"
 }

--- a/modules/smart-agent_mongodb/variables-gen.tf
+++ b/modules/smart-agent_mongodb/variables-gen.tf
@@ -21,7 +21,7 @@ variable "heartbeat_transformation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -43,9 +43,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # page_faults detector

--- a/modules/smart-agent_mysql/detectors-gen.tf
+++ b/modules/smart-agent_mysql/detectors-gen.tf
@@ -8,7 +8,7 @@ resource "signalfx_detector" "heartbeat" {
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     base_filtering = filter('plugin', 'mysql')
-    signal = data('mysql_octets.rx', filter=${local.not_running_vm_filters} and base_filtering and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
+    signal = data('mysql_octets.rx', filter=%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }base_filtering and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 

--- a/modules/smart-agent_mysql/detectors-gen.tf
+++ b/modules/smart-agent_mysql/detectors-gen.tf
@@ -8,7 +8,7 @@ resource "signalfx_detector" "heartbeat" {
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     base_filtering = filter('plugin', 'mysql')
-    signal = data('mysql_octets.rx', filter=%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }base_filtering and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
+    signal = data('mysql_octets.rx', filter=%{if var.heartbeat_exclude_not_running_vm}${local.not_running_vm_filters} and %{endif}base_filtering and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 

--- a/modules/smart-agent_mysql/variables-gen.tf
+++ b/modules/smart-agent_mysql/variables-gen.tf
@@ -21,7 +21,7 @@ variable "heartbeat_transformation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -42,10 +42,16 @@ variable "heartbeat_disabled" {
   default     = null
 }
 
+variable "heartbeat_exclude_not_running_vm" {
+  description = "Don’t send alerts if associated VM is stopped or stopping (metadata provided by cloud provider integration). Can be useful for ephemeral infrastructure (such as auto scaling groups) as VM will be stopped and started regularly. Note that timeframe must be at least 25 minutes for the metadata to be available to the detector."
+  type        = bool
+  default     = true
+}
+
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # mysql_connections detector

--- a/modules/smart-agent_mysql/variables-gen.tf
+++ b/modules/smart-agent_mysql/variables-gen.tf
@@ -49,7 +49,7 @@ variable "heartbeat_exclude_not_running_vm" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if \"heartbeat_exclude_not_running_vm\" is true"
   type        = string
   default     = "25m"
 }

--- a/modules/smart-agent_nginx/detectors-gen.tf
+++ b/modules/smart-agent_nginx/detectors-gen.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
-    signal = data('nginx_connections.reading', filter=${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
+    signal = data('nginx_connections.reading', filter=%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 

--- a/modules/smart-agent_nginx/detectors-gen.tf
+++ b/modules/smart-agent_nginx/detectors-gen.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
-    signal = data('nginx_connections.reading', filter=%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
+    signal = data('nginx_connections.reading', filter=%{if var.heartbeat_exclude_not_running_vm}${local.not_running_vm_filters} and %{endif}${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 

--- a/modules/smart-agent_nginx/variables-gen.tf
+++ b/modules/smart-agent_nginx/variables-gen.tf
@@ -49,7 +49,7 @@ variable "heartbeat_exclude_not_running_vm" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if \"heartbeat_exclude_not_running_vm\" is true"
   type        = string
   default     = "25m"
 }

--- a/modules/smart-agent_nginx/variables-gen.tf
+++ b/modules/smart-agent_nginx/variables-gen.tf
@@ -21,7 +21,7 @@ variable "heartbeat_transformation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -42,10 +42,16 @@ variable "heartbeat_disabled" {
   default     = null
 }
 
+variable "heartbeat_exclude_not_running_vm" {
+  description = "Don’t send alerts if associated VM is stopped or stopping (metadata provided by cloud provider integration). Can be useful for ephemeral infrastructure (such as auto scaling groups) as VM will be stopped and started regularly. Note that timeframe must be at least 25 minutes for the metadata to be available to the detector."
+  type        = bool
+  default     = true
+}
+
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # dropped_connections detector

--- a/modules/smart-agent_ntp/detectors-gen.tf
+++ b/modules/smart-agent_ntp/detectors-gen.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
-    signal = data('ntp.offset_seconds', filter=${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
+    signal = data('ntp.offset_seconds', filter=%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 

--- a/modules/smart-agent_ntp/detectors-gen.tf
+++ b/modules/smart-agent_ntp/detectors-gen.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
-    signal = data('ntp.offset_seconds', filter=%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
+    signal = data('ntp.offset_seconds', filter=%{if var.heartbeat_exclude_not_running_vm}${local.not_running_vm_filters} and %{endif}${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 

--- a/modules/smart-agent_ntp/variables-gen.tf
+++ b/modules/smart-agent_ntp/variables-gen.tf
@@ -21,7 +21,7 @@ variable "heartbeat_transformation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -42,8 +42,14 @@ variable "heartbeat_disabled" {
   default     = null
 }
 
+variable "heartbeat_exclude_not_running_vm" {
+  description = "Don’t send alerts if associated VM is stopped or stopping (metadata provided by cloud provider integration). Can be useful for ephemeral infrastructure (such as auto scaling groups) as VM will be stopped and started regularly. Note that timeframe must be at least 25 minutes for the metadata to be available to the detector."
+  type        = bool
+  default     = true
+}
+
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
   default     = "12h"
 }

--- a/modules/smart-agent_ntp/variables-gen.tf
+++ b/modules/smart-agent_ntp/variables-gen.tf
@@ -49,7 +49,7 @@ variable "heartbeat_exclude_not_running_vm" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if \"heartbeat_exclude_not_running_vm\" is true"
   type        = string
   default     = "12h"
 }

--- a/modules/smart-agent_php-fpm/detectors-gen.tf
+++ b/modules/smart-agent_php-fpm/detectors-gen.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
-    signal = data('phpfpm_requests.accepted', filter=%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
+    signal = data('phpfpm_requests.accepted', filter=%{if var.heartbeat_exclude_not_running_vm}${local.not_running_vm_filters} and %{endif}${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 

--- a/modules/smart-agent_php-fpm/detectors-gen.tf
+++ b/modules/smart-agent_php-fpm/detectors-gen.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
-    signal = data('phpfpm_requests.accepted', filter=${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
+    signal = data('phpfpm_requests.accepted', filter=%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 

--- a/modules/smart-agent_php-fpm/variables-gen.tf
+++ b/modules/smart-agent_php-fpm/variables-gen.tf
@@ -49,7 +49,7 @@ variable "heartbeat_exclude_not_running_vm" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if \"heartbeat_exclude_not_running_vm\" is true"
   type        = string
   default     = "25m"
 }

--- a/modules/smart-agent_php-fpm/variables-gen.tf
+++ b/modules/smart-agent_php-fpm/variables-gen.tf
@@ -21,7 +21,7 @@ variable "heartbeat_transformation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -42,10 +42,16 @@ variable "heartbeat_disabled" {
   default     = null
 }
 
+variable "heartbeat_exclude_not_running_vm" {
+  description = "Don’t send alerts if associated VM is stopped or stopping (metadata provided by cloud provider integration). Can be useful for ephemeral infrastructure (such as auto scaling groups) as VM will be stopped and started regularly. Note that timeframe must be at least 25 minutes for the metadata to be available to the detector."
+  type        = bool
+  default     = true
+}
+
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # php_fpm_connect_idle detector

--- a/modules/smart-agent_postgresql/detectors-gen.tf
+++ b/modules/smart-agent_postgresql/detectors-gen.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
-    signal = data('postgres_database_size', filter=%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
+    signal = data('postgres_database_size', filter=%{if var.heartbeat_exclude_not_running_vm}${local.not_running_vm_filters} and %{endif}${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 

--- a/modules/smart-agent_postgresql/detectors-gen.tf
+++ b/modules/smart-agent_postgresql/detectors-gen.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
-    signal = data('postgres_database_size', filter=${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
+    signal = data('postgres_database_size', filter=%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 

--- a/modules/smart-agent_postgresql/variables-gen.tf
+++ b/modules/smart-agent_postgresql/variables-gen.tf
@@ -49,7 +49,7 @@ variable "heartbeat_exclude_not_running_vm" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if \"heartbeat_exclude_not_running_vm\" is true"
   type        = string
   default     = "25m"
 }

--- a/modules/smart-agent_postgresql/variables-gen.tf
+++ b/modules/smart-agent_postgresql/variables-gen.tf
@@ -21,7 +21,7 @@ variable "heartbeat_transformation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -42,10 +42,16 @@ variable "heartbeat_disabled" {
   default     = null
 }
 
+variable "heartbeat_exclude_not_running_vm" {
+  description = "Don’t send alerts if associated VM is stopped or stopping (metadata provided by cloud provider integration). Can be useful for ephemeral infrastructure (such as auto scaling groups) as VM will be stopped and started regularly. Note that timeframe must be at least 25 minutes for the metadata to be available to the detector."
+  type        = bool
+  default     = true
+}
+
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # deadlocks detector

--- a/modules/smart-agent_rabbitmq-node/detectors-gen.tf
+++ b/modules/smart-agent_rabbitmq-node/detectors-gen.tf
@@ -8,7 +8,7 @@ resource "signalfx_detector" "heartbeat" {
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     base_filtering = filter('plugin', 'rabbitmq')
-    signal = data('gauge.node.uptime', filter=${local.not_running_vm_filters} and base_filtering and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
+    signal = data('gauge.node.uptime', filter=%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }base_filtering and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 

--- a/modules/smart-agent_rabbitmq-node/detectors-gen.tf
+++ b/modules/smart-agent_rabbitmq-node/detectors-gen.tf
@@ -8,7 +8,7 @@ resource "signalfx_detector" "heartbeat" {
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     base_filtering = filter('plugin', 'rabbitmq')
-    signal = data('gauge.node.uptime', filter=%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }base_filtering and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
+    signal = data('gauge.node.uptime', filter=%{if var.heartbeat_exclude_not_running_vm}${local.not_running_vm_filters} and %{endif}base_filtering and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 

--- a/modules/smart-agent_rabbitmq-node/variables-gen.tf
+++ b/modules/smart-agent_rabbitmq-node/variables-gen.tf
@@ -49,7 +49,7 @@ variable "heartbeat_exclude_not_running_vm" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if \"heartbeat_exclude_not_running_vm\" is true"
   type        = string
   default     = "25m"
 }

--- a/modules/smart-agent_rabbitmq-node/variables-gen.tf
+++ b/modules/smart-agent_rabbitmq-node/variables-gen.tf
@@ -21,7 +21,7 @@ variable "heartbeat_transformation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -42,10 +42,16 @@ variable "heartbeat_disabled" {
   default     = null
 }
 
+variable "heartbeat_exclude_not_running_vm" {
+  description = "Don’t send alerts if associated VM is stopped or stopping (metadata provided by cloud provider integration). Can be useful for ephemeral infrastructure (such as auto scaling groups) as VM will be stopped and started regularly. Note that timeframe must be at least 25 minutes for the metadata to be available to the detector."
+  type        = bool
+  default     = true
+}
+
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # file_descriptors detector

--- a/modules/smart-agent_redis/detectors-gen.tf
+++ b/modules/smart-agent_redis/detectors-gen.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
-    signal = data('${var.use_otel_receiver ? "redis.memory.used" : "bytes.used_memory"}', filter=${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
+    signal = data('${var.use_otel_receiver ? "redis.memory.used" : "bytes.used_memory"}', filter=%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 

--- a/modules/smart-agent_redis/detectors-gen.tf
+++ b/modules/smart-agent_redis/detectors-gen.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
-    signal = data('${var.use_otel_receiver ? "redis.memory.used" : "bytes.used_memory"}', filter=%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
+    signal = data('${var.use_otel_receiver ? "redis.memory.used" : "bytes.used_memory"}', filter=%{if var.heartbeat_exclude_not_running_vm}${local.not_running_vm_filters} and %{endif}${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 

--- a/modules/smart-agent_redis/variables-gen.tf
+++ b/modules/smart-agent_redis/variables-gen.tf
@@ -43,7 +43,7 @@ variable "heartbeat_exclude_not_running_vm" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if \"heartbeat_exclude_not_running_vm\" is true"
   type        = string
   default     = "25m"
 }

--- a/modules/smart-agent_redis/variables-gen.tf
+++ b/modules/smart-agent_redis/variables-gen.tf
@@ -15,7 +15,7 @@ variable "heartbeat_aggregation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -36,10 +36,16 @@ variable "heartbeat_disabled" {
   default     = null
 }
 
+variable "heartbeat_exclude_not_running_vm" {
+  description = "Don’t send alerts if associated VM is stopped or stopping (metadata provided by cloud provider integration). Can be useful for ephemeral infrastructure (such as auto scaling groups) as VM will be stopped and started regularly. Note that timeframe must be at least 25 minutes for the metadata to be available to the detector."
+  type        = bool
+  default     = true
+}
+
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # evicted_keys_change_rate detector

--- a/modules/smart-agent_solr/detectors-gen.tf
+++ b/modules/smart-agent_solr/detectors-gen.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
-    signal = data('counter.solr.http_requests', filter=${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
+    signal = data('counter.solr.http_requests', filter=%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 

--- a/modules/smart-agent_solr/detectors-gen.tf
+++ b/modules/smart-agent_solr/detectors-gen.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
-    signal = data('counter.solr.http_requests', filter=%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
+    signal = data('counter.solr.http_requests', filter=%{if var.heartbeat_exclude_not_running_vm}${local.not_running_vm_filters} and %{endif}${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 

--- a/modules/smart-agent_solr/variables-gen.tf
+++ b/modules/smart-agent_solr/variables-gen.tf
@@ -49,7 +49,7 @@ variable "heartbeat_exclude_not_running_vm" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if \"heartbeat_exclude_not_running_vm\" is true"
   type        = string
   default     = "25m"
 }

--- a/modules/smart-agent_solr/variables-gen.tf
+++ b/modules/smart-agent_solr/variables-gen.tf
@@ -21,7 +21,7 @@ variable "heartbeat_transformation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -42,10 +42,16 @@ variable "heartbeat_disabled" {
   default     = null
 }
 
+variable "heartbeat_exclude_not_running_vm" {
+  description = "Don’t send alerts if associated VM is stopped or stopping (metadata provided by cloud provider integration). Can be useful for ephemeral infrastructure (such as auto scaling groups) as VM will be stopped and started regularly. Note that timeframe must be at least 25 minutes for the metadata to be available to the detector."
+  type        = bool
+  default     = true
+}
+
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # errors detector

--- a/modules/smart-agent_supervisor/detectors-gen.tf
+++ b/modules/smart-agent_supervisor/detectors-gen.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
-    signal = data('supervisor.state', filter=${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
+    signal = data('supervisor.state', filter=%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 

--- a/modules/smart-agent_supervisor/detectors-gen.tf
+++ b/modules/smart-agent_supervisor/detectors-gen.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
-    signal = data('supervisor.state', filter=%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
+    signal = data('supervisor.state', filter=%{if var.heartbeat_exclude_not_running_vm}${local.not_running_vm_filters} and %{endif}${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 

--- a/modules/smart-agent_supervisor/variables-gen.tf
+++ b/modules/smart-agent_supervisor/variables-gen.tf
@@ -49,7 +49,7 @@ variable "heartbeat_exclude_not_running_vm" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if \"heartbeat_exclude_not_running_vm\" is true"
   type        = string
   default     = "25m"
 }

--- a/modules/smart-agent_supervisor/variables-gen.tf
+++ b/modules/smart-agent_supervisor/variables-gen.tf
@@ -21,7 +21,7 @@ variable "heartbeat_transformation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -42,10 +42,16 @@ variable "heartbeat_disabled" {
   default     = null
 }
 
+variable "heartbeat_exclude_not_running_vm" {
+  description = "Don’t send alerts if associated VM is stopped or stopping (metadata provided by cloud provider integration). Can be useful for ephemeral infrastructure (such as auto scaling groups) as VM will be stopped and started regularly. Note that timeframe must be at least 25 minutes for the metadata to be available to the detector."
+  type        = bool
+  default     = true
+}
+
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # process_state detector

--- a/modules/smart-agent_system-common/detectors-gen.tf
+++ b/modules/smart-agent_system-common/detectors-gen.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
-    signal = data('cpu.utilization', filter=%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
+    signal = data('cpu.utilization', filter=%{if var.heartbeat_exclude_not_running_vm}${local.not_running_vm_filters} and %{endif}${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 

--- a/modules/smart-agent_system-common/detectors-gen.tf
+++ b/modules/smart-agent_system-common/detectors-gen.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
-    signal = data('cpu.utilization', filter=${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
+    signal = data('cpu.utilization', filter=%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 

--- a/modules/smart-agent_system-common/variables-gen.tf
+++ b/modules/smart-agent_system-common/variables-gen.tf
@@ -43,7 +43,7 @@ variable "heartbeat_exclude_not_running_vm" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if \"heartbeat_exclude_not_running_vm\" is true"
   type        = string
   default     = "25m"
 }

--- a/modules/smart-agent_system-common/variables-gen.tf
+++ b/modules/smart-agent_system-common/variables-gen.tf
@@ -15,7 +15,7 @@ variable "heartbeat_aggregation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -36,10 +36,16 @@ variable "heartbeat_disabled" {
   default     = null
 }
 
+variable "heartbeat_exclude_not_running_vm" {
+  description = "Don’t send alerts if associated VM is stopped or stopping (metadata provided by cloud provider integration). Can be useful for ephemeral infrastructure (such as auto scaling groups) as VM will be stopped and started regularly. Note that timeframe must be at least 25 minutes for the metadata to be available to the detector."
+  type        = bool
+  default     = true
+}
+
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # cpu detector

--- a/modules/smart-agent_systemd-timers/detectors-gen.tf
+++ b/modules/smart-agent_systemd-timers/detectors-gen.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
-    signal = data('gauge.substate.failed', filter=%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
+    signal = data('gauge.substate.failed', filter=%{if var.heartbeat_exclude_not_running_vm}${local.not_running_vm_filters} and %{endif}${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('MINOR')
 EOF
 

--- a/modules/smart-agent_systemd-timers/detectors-gen.tf
+++ b/modules/smart-agent_systemd-timers/detectors-gen.tf
@@ -7,7 +7,7 @@ resource "signalfx_detector" "heartbeat" {
 
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
-    signal = data('gauge.substate.failed', filter=${local.not_running_vm_filters} and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
+    signal = data('gauge.substate.failed', filter=%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }${module.filtering.signalflow})${var.heartbeat_aggregation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('MINOR')
 EOF
 

--- a/modules/smart-agent_systemd-timers/variables-gen.tf
+++ b/modules/smart-agent_systemd-timers/variables-gen.tf
@@ -43,7 +43,7 @@ variable "heartbeat_exclude_not_running_vm" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if \"heartbeat_exclude_not_running_vm\" is true"
   type        = string
   default     = "25m"
 }

--- a/modules/smart-agent_systemd-timers/variables-gen.tf
+++ b/modules/smart-agent_systemd-timers/variables-gen.tf
@@ -15,7 +15,7 @@ variable "heartbeat_aggregation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -36,10 +36,16 @@ variable "heartbeat_disabled" {
   default     = true
 }
 
+variable "heartbeat_exclude_not_running_vm" {
+  description = "Don’t send alerts if associated VM is stopped or stopping (metadata provided by cloud provider integration). Can be useful for ephemeral infrastructure (such as auto scaling groups) as VM will be stopped and started regularly. Note that timeframe must be at least 25 minutes for the metadata to be available to the detector."
+  type        = bool
+  default     = true
+}
+
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # execution_delay detector

--- a/modules/smart-agent_tomcat/variables-gen.tf
+++ b/modules/smart-agent_tomcat/variables-gen.tf
@@ -43,7 +43,7 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\")."
   type        = string
   default     = "25m"
 }

--- a/modules/smart-agent_tomcat/variables-gen.tf
+++ b/modules/smart-agent_tomcat/variables-gen.tf
@@ -21,7 +21,7 @@ variable "heartbeat_transformation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -43,9 +43,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # average_processing_time detector

--- a/modules/smart-agent_varnish/variables-gen.tf
+++ b/modules/smart-agent_varnish/variables-gen.tf
@@ -43,7 +43,7 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\")."
   type        = string
   default     = "25m"
 }

--- a/modules/smart-agent_varnish/variables-gen.tf
+++ b/modules/smart-agent_varnish/variables-gen.tf
@@ -21,7 +21,7 @@ variable "heartbeat_transformation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -43,9 +43,9 @@ variable "heartbeat_disabled" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # backend_failed detector

--- a/modules/smart-agent_zookeeper/detectors-gen.tf
+++ b/modules/smart-agent_zookeeper/detectors-gen.tf
@@ -8,7 +8,7 @@ resource "signalfx_detector" "heartbeat" {
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     base_filtering = filter('plugin', 'zookeeper')
-    signal = data('gauge.zk_max_file_descriptor_count', filter=%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }base_filtering and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
+    signal = data('gauge.zk_max_file_descriptor_count', filter=%{if var.heartbeat_exclude_not_running_vm}${local.not_running_vm_filters} and %{endif}base_filtering and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 

--- a/modules/smart-agent_zookeeper/detectors-gen.tf
+++ b/modules/smart-agent_zookeeper/detectors-gen.tf
@@ -8,7 +8,7 @@ resource "signalfx_detector" "heartbeat" {
   program_text = <<-EOF
     from signalfx.detectors.not_reporting import not_reporting
     base_filtering = filter('plugin', 'zookeeper')
-    signal = data('gauge.zk_max_file_descriptor_count', filter=${local.not_running_vm_filters} and base_filtering and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
+    signal = data('gauge.zk_max_file_descriptor_count', filter=%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }base_filtering and ${module.filtering.signalflow})${var.heartbeat_aggregation_function}${var.heartbeat_transformation_function}.publish('signal')
     not_reporting.detector(stream=signal, resource_identifier=None, duration='${var.heartbeat_timeframe}', auto_resolve_after='${local.heartbeat_auto_resolve_after}').publish('CRIT')
 EOF
 

--- a/modules/smart-agent_zookeeper/variables-gen.tf
+++ b/modules/smart-agent_zookeeper/variables-gen.tf
@@ -49,7 +49,7 @@ variable "heartbeat_exclude_not_running_vm" {
 }
 
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if \"heartbeat_exclude_not_running_vm\" is true"
   type        = string
   default     = "25m"
 }

--- a/modules/smart-agent_zookeeper/variables-gen.tf
+++ b/modules/smart-agent_zookeeper/variables-gen.tf
@@ -21,7 +21,7 @@ variable "heartbeat_transformation_function" {
 variable "heartbeat_max_delay" {
   description = "Enforce max delay for heartbeat detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = 900
+  default     = null
 }
 
 variable "heartbeat_tip" {
@@ -42,10 +42,16 @@ variable "heartbeat_disabled" {
   default     = null
 }
 
+variable "heartbeat_exclude_not_running_vm" {
+  description = "Don’t send alerts if associated VM is stopped or stopping (metadata provided by cloud provider integration). Can be useful for ephemeral infrastructure (such as auto scaling groups) as VM will be stopped and started regularly. Note that timeframe must be at least 25 minutes for the metadata to be available to the detector."
+  type        = bool
+  default     = true
+}
+
 variable "heartbeat_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "10m"
+  default     = "25m"
 }
 
 # zookeeper_health detector

--- a/scripts/templates/detector.tf.j2
+++ b/scripts/templates/detector.tf.j2
@@ -48,7 +48,7 @@ resource "signalfx_detector" "{{ id }}" {
 
     {%- for key, signal in signals.items() -%}
       {%- if 'metric' in signal %}
-    {{ key }} = data('{{ signal.metric }}', filter={%- if exclude_not_running_vm is defined and exclude_not_running_vm -%}${local.not_running_vm_filters} and {% endif -%}{%- if filtering is defined and filtering -%}{{ filtering_variable }} {{ filtering_operator | default('and') }} {% endif -%}{%- if signal.filter is defined and signal.filter is string -%}{{ signal.filter }} and {% endif -%}${module.filtering.signalflow}{%- if signal.rollup is defined -%}, rollup='{{ signal.rollup }}'{% endif -%}{%- if signal.extrapolation is defined and signal.extrapolation -%}, extrapolation='{{ signal.extrapolation }}'{% endif -%})
+    {{ key }} = data('{{ signal.metric }}', filter={%- if exclude_not_running_vm is defined and exclude_not_running_vm -%}%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }{% endif -%}{%- if filtering is defined and filtering -%}{{ filtering_variable }} {{ filtering_operator | default('and') }} {% endif -%}{%- if signal.filter is defined and signal.filter is string -%}{{ signal.filter }} and {% endif -%}${module.filtering.signalflow}{%- if signal.rollup is defined -%}, rollup='{{ signal.rollup }}'{% endif -%}{%- if signal.extrapolation is defined and signal.extrapolation -%}, extrapolation='{{ signal.extrapolation }}'{% endif -%})
         {%- if aggregation | default(true) %}${var.{{ id }}_aggregation_function}{%- endif %}
         {%- if transformation | default(true) %}${var.{{ id }}_transformation_function}{%- endif %}
       {%- endif -%}

--- a/scripts/templates/detector.tf.j2
+++ b/scripts/templates/detector.tf.j2
@@ -48,7 +48,7 @@ resource "signalfx_detector" "{{ id }}" {
 
     {%- for key, signal in signals.items() -%}
       {%- if 'metric' in signal %}
-    {{ key }} = data('{{ signal.metric }}', filter={%- if exclude_not_running_vm is defined and exclude_not_running_vm -%}%{ if var.heartbeat_exclude_not_running_vm }${local.not_running_vm_filters} and %{ endif }{% endif -%}{%- if filtering is defined and filtering -%}{{ filtering_variable }} {{ filtering_operator | default('and') }} {% endif -%}{%- if signal.filter is defined and signal.filter is string -%}{{ signal.filter }} and {% endif -%}${module.filtering.signalflow}{%- if signal.rollup is defined -%}, rollup='{{ signal.rollup }}'{% endif -%}{%- if signal.extrapolation is defined and signal.extrapolation -%}, extrapolation='{{ signal.extrapolation }}'{% endif -%})
+    {{ key }} = data('{{ signal.metric }}', filter={%- if exclude_not_running_vm is defined and exclude_not_running_vm -%}%{if var.heartbeat_exclude_not_running_vm}${local.not_running_vm_filters} and %{endif}{% endif -%}{%- if filtering is defined and filtering -%}{{ filtering_variable }} {{ filtering_operator | default('and') }} {% endif -%}{%- if signal.filter is defined and signal.filter is string -%}{{ signal.filter }} and {% endif -%}${module.filtering.signalflow}{%- if signal.rollup is defined -%}, rollup='{{ signal.rollup }}'{% endif -%}{%- if signal.extrapolation is defined and signal.extrapolation -%}, extrapolation='{{ signal.extrapolation }}'{% endif -%})
         {%- if aggregation | default(true) %}${var.{{ id }}_aggregation_function}{%- endif %}
         {%- if transformation | default(true) %}${var.{{ id }}_transformation_function}{%- endif %}
       {%- endif -%}

--- a/scripts/templates/variables.tf.j2
+++ b/scripts/templates/variables.tf.j2
@@ -85,7 +85,7 @@ variable "{{ id }}_exclude_not_running_vm" {
 {% endif -%}
 
 variable "{{ id }}_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\").{% if exclude_not_running_vm is defined and exclude_not_running_vm %} Must be at least \"25m\" if \"{{ id }}_exclude_not_running_vm\" is true{% endif %}"
   type        = string
   default     = "{{ duration|default("25m") }}"
 }

--- a/scripts/templates/variables.tf.j2
+++ b/scripts/templates/variables.tf.j2
@@ -39,7 +39,7 @@ variable "{{ id }}_transformation_function" {
 variable "{{ id }}_max_delay" {
   description = "Enforce max delay for {{ id }} detector (use \"0\" or \"null\" for \"Auto\")"
   type        = number
-  default     = {% if max_delay is number %}{{ max_delay }}{% else %}{% if type == 'heartbeat' %}900{% else %}null{% endif %}{% endif %}
+  default     = {% if max_delay is number %}{{ max_delay }}{% else %}null{% endif %}
 }
 
 variable "{{ id }}_tip" {
@@ -75,10 +75,19 @@ variable "{{ id }}_disabled_{{ severity }}" {
 {% endif -%}
 
 {% if type == 'heartbeat' -%}
+{% if exclude_not_running_vm is defined and exclude_not_running_vm -%}
+variable "{{ id }}_exclude_not_running_vm" {
+  description = "Don’t send alerts if associated VM is stopped or stopping (metadata provided by cloud provider integration). Can be useful for ephemeral infrastructure (such as auto scaling groups) as VM will be stopped and started regularly. Note that timeframe must be at least 25 minutes for the metadata to be available to the detector."
+  type        = bool
+  default     = true
+}
+
+{% endif -%}
+
 variable "{{ id }}_timeframe" {
-  description = "Timeframe for heartbeat detector (i.e. \"10m\")"
+  description = "Timeframe for heartbeat detector (i.e. \"25m\"). Must be at least \"25m\" if exclude_not_running_vm is true"
   type        = string
-  default     = "{{ duration|default("10m") }}"
+  default     = "{{ duration|default("25m") }}"
 }
 
 {% else -%}


### PR DESCRIPTION
In order to support ephemeral infrastructures a filter was added to exclude stopping and stopped VMs
The filter needs at least 25 minutes for vm state to be available, so a `maxDelay` of `15m` was added on top of the `10m` of `lasting`

Problem is this `maxDelay` is confusing and might not be enough if data is really delayed, so moving to a lasting of 25m (and reverting `maxDelay` to `auto`) should help a lot.
Furthermore a variable `heartbeat_exclude_not_running_vm` is added in order to switch off the filtering if not needed.