### PR TITLE
SNAT ports: add resource name in mean

### DIFF
--- a/modules/integration_azure-firewall/conf/01-snat.yaml
+++ b/modules/integration_azure-firewall/conf/01-snat.yaml
@@ -3,7 +3,7 @@ module: Azure firewall
 name: "SNAT Port Utilization"
 
 transformation: true
-aggregation: ".mean(by=['protocol', 'azure_resource_name'])"
+aggregation: ".mean(by=['protocol', 'azure_resource_name', 'azure_resource_group_name', 'azure_region'])"
 
 filtering: "filter('resource_type', 'Microsoft.Network/azureFirewalls') and filter('primary_aggregation_type', 'true')"
 

--- a/modules/integration_azure-firewall/conf/01-snat.yaml
+++ b/modules/integration_azure-firewall/conf/01-snat.yaml
@@ -3,7 +3,7 @@ module: Azure firewall
 name: "SNAT Port Utilization"
 
 transformation: true
-aggregation: ".mean(by=['protocol'])"
+aggregation: ".mean(by=['protocol', 'azure_resource_name'])"
 
 filtering: "filter('resource_type', 'Microsoft.Network/azureFirewalls') and filter('primary_aggregation_type', 'true')"
 

--- a/modules/integration_azure-firewall/variables-gen.tf
+++ b/modules/integration_azure-firewall/variables-gen.tf
@@ -59,7 +59,7 @@ variable "snat_port_utilization_notifications" {
 variable "snat_port_utilization_aggregation_function" {
   description = "Aggregation function and group by for snat_port_utilization detector (i.e. \".mean(by=['host'])\")"
   type        = string
-  default     = ".mean(by=['protocol'])"
+  default     = ".mean(by=['protocol', 'azure_resource_name'])"
 }
 
 variable "snat_port_utilization_transformation_function" {

--- a/modules/integration_azure-firewall/variables-gen.tf
+++ b/modules/integration_azure-firewall/variables-gen.tf
@@ -59,7 +59,7 @@ variable "snat_port_utilization_notifications" {
 variable "snat_port_utilization_aggregation_function" {
   description = "Aggregation function and group by for snat_port_utilization detector (i.e. \".mean(by=['host'])\")"
   type        = string
-  default     = ".mean(by=['protocol', 'azure_resource_name'])"
+  default     = ".mean(by=['protocol', 'azure_resource_name', 'azure_resource_group_name', 'azure_region'])"
 }
 
 variable "snat_port_utilization_transformation_function" {


### PR DESCRIPTION
Hi, 

azure_resource_name is used by some monitoring tools to populate useful fields used by run teams. I simply added this field to the mean function