### PR TITLE
fix: elasticsearch: remove useless transformations

### DIFF
--- a/modules/integration_aws-elasticsearch/conf/01-jvm-memory-pressure.yaml
+++ b/modules/integration_aws-elasticsearch/conf/01-jvm-memory-pressure.yaml
@@ -1,7 +1,6 @@
 module: AWS Elasticsearch
 name: JVM Memory Pressure
 
-transformation: ".min(over='15m')"
 aggregation: true
 filtering: "filter('namespace', 'AWS/ES') and filter('stat', 'upper') and filter('NodeId', '*')"
 value_unit: "%"
@@ -15,7 +14,9 @@ rules:
   critical:
     threshold: 90
     comparator: ">"
+    lasting_duration: "15m"
   major:
     threshold: 80
     comparator: ">"
     dependency: critical
+    lasting_duration: "15m"

--- a/modules/integration_aws-elasticsearch/conf/05-cluster-status.yaml
+++ b/modules/integration_aws-elasticsearch/conf/05-cluster-status.yaml
@@ -1,7 +1,6 @@
 module: AWS Elasticsearch
 name: Cluster status
 
-aggregation: ".min(over='15m')"
 filtering: "filter('namespace', 'AWS/ES') and filter('stat', 'upper')"
 
 signals:
@@ -18,8 +17,10 @@ rules:
     comparator: ">="
     description: "is red"
     signal: red
+    lasting_duration: "15m"
   major:
     threshold: 1
     comparator: ">="
     description: "is yellow"
     signal: yellow
+    lasting_duration: "15m"

--- a/modules/integration_aws-elasticsearch/conf/08-cluster-cpu.yaml
+++ b/modules/integration_aws-elasticsearch/conf/08-cluster-cpu.yaml
@@ -2,7 +2,6 @@ module: AWS Elasticsearch
 id: "cluster_cpu"
 name: "CPU utilization"
 
-transformation: ".min(over='45m')"
 aggregation: ""
 filtering: "filter('namespace', 'AWS/ES') and filter('stat', 'upper') and filter('NodeId', '*')"
 
@@ -20,6 +19,8 @@ rules:
     threshold: 80
     comparator: ">"
     dependency: critical
+    lasting_duration: "45m"
   critical:
     threshold: 90
     comparator: ">"
+    lasting_duration: "45m"

--- a/modules/integration_aws-elasticsearch/conf/09-master-cpu.yaml
+++ b/modules/integration_aws-elasticsearch/conf/09-master-cpu.yaml
@@ -2,7 +2,6 @@ module: AWS Elasticsearch
 id: "master_cpu"
 name: "Master CPU utilization"
 
-transformation: ".min(over='20m')"
 aggregation: ""
 filtering: "filter('namespace', 'AWS/ES') and filter('stat', 'upper') and filter('NodeId', '*')"
 
@@ -15,6 +14,8 @@ rules:
     threshold: 60
     comparator: ">"
     dependency: critical
+    lasting_duration: "20m"
   critical:
     threshold: 70
     comparator: ">"
+    lasting_duration: "20m"

--- a/modules/integration_aws-elasticsearch/variables-gen.tf
+++ b/modules/integration_aws-elasticsearch/variables-gen.tf
@@ -59,7 +59,7 @@ variable "jvm_memory_pressure_aggregation_function" {
 variable "jvm_memory_pressure_transformation_function" {
   description = "Transformation function for jvm_memory_pressure detector (i.e. \".mean(over='5m')\")"
   type        = string
-  default     = ".min(over='15m')"
+  default     = ""
 }
 
 variable "jvm_memory_pressure_max_delay" {
@@ -109,7 +109,7 @@ variable "jvm_memory_pressure_threshold_critical" {
 variable "jvm_memory_pressure_lasting_duration_critical" {
   description = "Minimum duration that conditions must be true before raising alert"
   type        = string
-  default     = null
+  default     = "15m"
 }
 
 variable "jvm_memory_pressure_at_least_percentage_critical" {
@@ -126,7 +126,7 @@ variable "jvm_memory_pressure_threshold_major" {
 variable "jvm_memory_pressure_lasting_duration_major" {
   description = "Minimum duration that conditions must be true before raising alert"
   type        = string
-  default     = null
+  default     = "15m"
 }
 
 variable "jvm_memory_pressure_at_least_percentage_major" {
@@ -467,7 +467,7 @@ variable "cluster_status_notifications" {
 variable "cluster_status_aggregation_function" {
   description = "Aggregation function and group by for cluster_status detector (i.e. \".mean(by=['host'])\")"
   type        = string
-  default     = ".min(over='15m')"
+  default     = ""
 }
 
 variable "cluster_status_transformation_function" {
@@ -521,7 +521,7 @@ variable "cluster_status_threshold_critical" {
 variable "cluster_status_lasting_duration_critical" {
   description = "Minimum duration that conditions must be true before raising alert"
   type        = string
-  default     = null
+  default     = "15m"
 }
 
 variable "cluster_status_at_least_percentage_critical" {
@@ -538,7 +538,7 @@ variable "cluster_status_threshold_major" {
 variable "cluster_status_lasting_duration_major" {
   description = "Minimum duration that conditions must be true before raising alert"
   type        = string
-  default     = null
+  default     = "15m"
 }
 
 variable "cluster_status_at_least_percentage_major" {
@@ -725,7 +725,7 @@ variable "cluster_cpu_notifications" {
 variable "cluster_cpu_transformation_function" {
   description = "Transformation function for cluster_cpu detector (i.e. \".mean(over='5m')\")"
   type        = string
-  default     = ".min(over='45m')"
+  default     = ""
 }
 
 variable "cluster_cpu_max_delay" {
@@ -773,7 +773,7 @@ variable "cluster_cpu_threshold_major" {
 variable "cluster_cpu_lasting_duration_major" {
   description = "Minimum duration that conditions must be true before raising alert"
   type        = string
-  default     = null
+  default     = "45m"
 }
 
 variable "cluster_cpu_at_least_percentage_major" {
@@ -790,7 +790,7 @@ variable "cluster_cpu_threshold_critical" {
 variable "cluster_cpu_lasting_duration_critical" {
   description = "Minimum duration that conditions must be true before raising alert"
   type        = string
-  default     = null
+  default     = "45m"
 }
 
 variable "cluster_cpu_at_least_percentage_critical" {
@@ -809,7 +809,7 @@ variable "master_cpu_notifications" {
 variable "master_cpu_transformation_function" {
   description = "Transformation function for master_cpu detector (i.e. \".mean(over='5m')\")"
   type        = string
-  default     = ".min(over='20m')"
+  default     = ""
 }
 
 variable "master_cpu_max_delay" {
@@ -857,7 +857,7 @@ variable "master_cpu_threshold_major" {
 variable "master_cpu_lasting_duration_major" {
   description = "Minimum duration that conditions must be true before raising alert"
   type        = string
-  default     = null
+  default     = "20m"
 }
 
 variable "master_cpu_at_least_percentage_major" {
@@ -874,7 +874,7 @@ variable "master_cpu_threshold_critical" {
 variable "master_cpu_lasting_duration_critical" {
   description = "Minimum duration that conditions must be true before raising alert"
   type        = string
-  default     = null
+  default     = "20m"
 }
 
 variable "master_cpu_at_least_percentage_critical" {


### PR DESCRIPTION
Use lasting instead of transformation functions, similar to #546 #522 #520