### PR TITLE
Disable Azure Key Vault API latency detector by default

### DIFF
--- a/modules/integration_azure-key-vault/conf/02-api-latency.yaml
+++ b/modules/integration_azure-key-vault/conf/02-api-latency.yaml
@@ -15,9 +15,11 @@ rules:
     threshold: 500
     comparator: ">"
     lasting_duration: '1h'
+    disabled: true
   minor:
     threshold: 500
     comparator: ">"
     lasting_duration: '30m'
     dependency: major
+    disabled: true
 ...

--- a/modules/integration_azure-key-vault/variables-gen.tf
+++ b/modules/integration_azure-key-vault/variables-gen.tf
@@ -135,13 +135,13 @@ variable "api_latency_disabled" {
 variable "api_latency_disabled_major" {
   description = "Disable major alerting rule for api_latency detector"
   type        = bool
-  default     = null
+  default     = true
 }
 
 variable "api_latency_disabled_minor" {
   description = "Disable minor alerting rule for api_latency detector"
   type        = bool
-  default     = null
+  default     = true
 }
 
 variable "api_latency_threshold_major" {


### PR DESCRIPTION
We don't think this detector is useful for the run. We propose to deactivate it by default. 