### PR TITLE
fix(memcached): hit ratio signal formula

### DIFF
--- a/modules/integration_aws-elasticache-memcached/conf/02-hit-ratio.yaml
+++ b/modules/integration_aws-elasticache-memcached/conf/02-hit-ratio.yaml
@@ -16,7 +16,7 @@ signals:
     extrapolation: zero
     rollup: sum
   signal:
-    formula: (hits/(hits+misses)).scale(100).fill(value=0)
+    formula: (hits/(hits+misses)).fill(value=1).scale(100)
 rules:
   major:
     threshold: 60

--- a/modules/integration_aws-elasticache-memcached/detectors-gen.tf
+++ b/modules/integration_aws-elasticache-memcached/detectors-gen.tf
@@ -60,7 +60,7 @@ resource "signalfx_detector" "hit_ratio" {
     base_filtering = filter('namespace', 'AWS/ElastiCache') and filter('CacheNodeId', '*') and filter('stat', 'mean')
     hits = data('GetHits', filter=base_filtering and ${module.filtering.signalflow}, rollup='sum', extrapolation='zero')${var.hit_ratio_aggregation_function}${var.hit_ratio_transformation_function}
     misses = data('GetMisses', filter=base_filtering and ${module.filtering.signalflow}, rollup='sum', extrapolation='zero')${var.hit_ratio_aggregation_function}${var.hit_ratio_transformation_function}
-    signal = (hits/(hits+misses)).scale(100).fill(value=0).publish('signal')
+    signal = (hits/(hits+misses)).fill(value=1).scale(100).publish('signal')
     detect(when(signal < ${var.hit_ratio_threshold_major}%{if var.hit_ratio_lasting_duration_major != null}, lasting='${var.hit_ratio_lasting_duration_major}', at_least=${var.hit_ratio_at_least_percentage_major}%{endif})).publish('MAJOR')
     detect(when(signal < ${var.hit_ratio_threshold_minor}%{if var.hit_ratio_lasting_duration_minor != null}, lasting='${var.hit_ratio_lasting_duration_minor}', at_least=${var.hit_ratio_at_least_percentage_minor}%{endif}) and (not when(signal < ${var.hit_ratio_threshold_major}%{if var.hit_ratio_lasting_duration_major != null}, lasting='${var.hit_ratio_lasting_duration_major}', at_least=${var.hit_ratio_at_least_percentage_major}%{endif}))).publish('MINOR')
 EOF


### PR DESCRIPTION
Replaced .scale(100).fill(value=0) with .fill(value=1).scale(100) in the memcached cache hit ratio signal computation to align behavior with the Redis cache hit ratio. This ensures missing data points are filled with 1 instead of 0, preventing unnecessary alarms triggered by metric gaps, especially during nighttime periods with sparse AWS telemetry data.