### PR TITLE
feat: new cognitive services module

### DIFF
--- a/docs/severity.md
+++ b/docs/severity.md
@@ -41,6 +41,7 @@
 - [integration_azure-azure-search](#integration_azure-azure-search)
 - [integration_azure-backup](#integration_azure-backup)
 - [integration_azure-cdn](#integration_azure-cdn)
+- [integration_azure-cognitive-services](#integration_azure-cognitive-services)
 - [integration_azure-container-apps](#integration_azure-container-apps)
 - [integration_azure-container-instance](#integration_azure-container-instance)
 - [integration_azure-cosmos-db](#integration_azure-cosmos-db)
@@ -489,6 +490,13 @@
 |---|---|---|---|---|---|
 |Azure CDN latency|X|X|-|-|-|
 |Azure CDN origin health|X|X|-|-|-|
+
+
+## integration_azure-cognitive-services
+
+|Detector|Critical|Major|Minor|Warning|Info|
+|---|---|---|---|---|---|
+|Azure Cognitive Services success rate|-|X|-|-|-|
 
 
 ## integration_azure-container-apps

--- a/modules/integration_azure-cognitive-services/README.md
+++ b/modules/integration_azure-cognitive-services/README.md
@@ -1,0 +1,105 @@
+# AZURE-COGNITIVE-SERVICES SignalFx detectors
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+:link: **Contents**
+
+- [How to use this module?](#how-to-use-this-module)
+- [What are the available detectors in this module?](#what-are-the-available-detectors-in-this-module)
+- [How to collect required metrics?](#how-to-collect-required-metrics)
+  - [Metrics](#metrics)
+- [Related documentation](#related-documentation)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## How to use this module?
+
+This directory defines a [Terraform](https://www.terraform.io/)
+[module](https://www.terraform.io/language/modules/syntax) you can use in your
+existing [stack](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#stack) by adding a
+`module` configuration and setting its `source` parameter to URL of this folder:
+
+```hcl
+module "signalfx-detectors-integration-azure-cognitive-services" {
+  source = "github.com/claranet/terraform-signalfx-detectors.git//modules/integration_azure-cognitive-services?ref={revision}"
+
+  environment   = var.environment
+  notifications = local.notifications
+}
+```
+
+Note the following parameters:
+
+* `source`: Use this parameter to specify the URL of the module. The double slash (`//`) is intentional  and required.
+  Terraform uses it to specify subfolders within a Git repo (see [module
+  sources](https://www.terraform.io/language/modules/sources)). The `ref` parameter specifies a specific Git tag in
+  this repository. It is recommended to use the latest "pinned" version in place of `{revision}`. Avoid using a branch
+  like `master` except for testing purpose. Note that every modules in this repository are available on the Terraform
+  [registry](https://registry.terraform.io/modules/claranet/detectors/signalfx) and we recommend using it as source
+  instead of `git` which is more flexible but less future-proof.
+
+* `environment`: Use this parameter to specify the
+  [environment](https://github.com/claranet/terraform-signalfx-detectors/wiki/Getting-started#environment) used by this
+  instance of the module.
+  Its value will be added to the `prefixes` list at the start of the [detector
+  name](https://github.com/claranet/terraform-signalfx-detectors/wiki/Templating#example).
+  In general, it will also be used in the `filtering` internal sub-module to [apply
+  filters](https://github.com/claranet/terraform-signalfx-detectors/wiki/Guidance#filtering) based on our default
+  [tagging convention](https://github.com/claranet/terraform-signalfx-detectors/wiki/Tagging-convention) by default.
+
+* `notifications`: Use this parameter to define where alerts should be sent depending on their severity. It consists
+  of a Terraform [object](https://www.terraform.io/language/expressions/type-constraints#object) where each key represents an available
+  [detector rule severity](https://docs.splunk.com/observability/alerts-detectors-notifications/create-detectors-for-alerts.html#severity)
+  and its value is a list of recipients. Every recipients must respect the [detector notification
+  format](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector#notification-format).
+  Check the [notification binding](https://github.com/claranet/terraform-signalfx-detectors/wiki/Notifications-binding)
+  documentation to understand the recommended role of each severity.
+
+These 3 parameters along with all variables defined in [common-variables.tf](common-variables.tf) are common to all
+[modules](../) in this repository. Other variables, specific to this module, are available in
+[variables-gen.tf](variables-gen.tf).
+In general, the default configuration "works" but all of these Terraform
+[variables](https://www.terraform.io/language/values/variables) make it possible to
+customize the detectors behavior to better fit your needs.
+
+Most of them represent usual tips and rules detailed in the
+[guidance](https://github.com/claranet/terraform-signalfx-detectors/wiki/Guidance) documentation and listed in the
+common [variables](https://github.com/claranet/terraform-signalfx-detectors/wiki/Variables) dedicated documentation.
+
+Feel free to explore the [wiki](https://github.com/claranet/terraform-signalfx-detectors/wiki) for more information about
+general usage of this repository.
+
+## What are the available detectors in this module?
+
+This module creates the following SignalFx detectors which could contain one or multiple alerting rules:
+
+|Detector|Critical|Major|Minor|Warning|Info|
+|---|---|---|---|---|---|
+|Azure Cognitive Services success rate|-|X|-|-|-|
+
+## How to collect required metrics?
+
+This module deploys detectors using metrics reported by the
+[Azure integration](https://docs.splunk.com/Observability/gdi/get-data-in/connect/azure/azure.html) configurable
+with [this Terraform module](https://github.com/claranet/terraform-signalfx-integrations/tree/master/cloud/azure).
+
+
+Check the [Related documentation](#related-documentation) section for more detailed and specific information about this module dependencies.
+
+
+
+### Metrics
+
+
+Here is the list of required metrics for detectors in this module.
+
+* `SuccessRate`
+
+
+
+
+## Related documentation
+
+* [Terraform SignalFx provider](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs)
+* [Terraform SignalFx detector](https://registry.terraform.io/providers/splunk-terraform/signalfx/latest/docs/resources/detector)
+* [Splunk Observability integrations](https://docs.splunk.com/Observability/gdi/get-data-in/integrations.html)

--- a/modules/integration_azure-cognitive-services/common-filters.tf
+++ b/modules/integration_azure-cognitive-services/common-filters.tf
@@ -1,0 +1,1 @@
+../../common/module/filters-integration-azure.tf

--- a/modules/integration_azure-cognitive-services/common-locals.tf
+++ b/modules/integration_azure-cognitive-services/common-locals.tf
@@ -1,0 +1,1 @@
+../../common/module/locals.tf

--- a/modules/integration_azure-cognitive-services/common-modules.tf
+++ b/modules/integration_azure-cognitive-services/common-modules.tf
@@ -1,0 +1,1 @@
+../../common/module/modules.tf

--- a/modules/integration_azure-cognitive-services/common-variables.tf
+++ b/modules/integration_azure-cognitive-services/common-variables.tf
@@ -1,0 +1,1 @@
+../../common/module/variables.tf

--- a/modules/integration_azure-cognitive-services/common-versions.tf
+++ b/modules/integration_azure-cognitive-services/common-versions.tf
@@ -1,0 +1,1 @@
+../../common/module/versions.tf

--- a/modules/integration_azure-cognitive-services/conf/00-successrate.yaml
+++ b/modules/integration_azure-cognitive-services/conf/00-successrate.yaml
@@ -1,0 +1,17 @@
+---
+module: "Azure Cognitive Services"
+name: "success rate"
+filtering: "filter('resource_type', 'Microsoft.CognitiveServices/accounts') and filter('primary_aggregation_type', 'true')"
+aggregation: ".sum(by=['ratelimitkey', 'azure_resource_name', 'azure_resource_group_name', 'azure_region'])"
+
+signals:
+  signal:
+    metric: SuccessRate
+    extrapolation: last_value
+
+rules:
+  major:
+    threshold: 10
+    comparator: "<"
+    lasting_duration: '60m'
+

--- a/modules/integration_azure-cognitive-services/conf/readme.yaml
+++ b/modules/integration_azure-cognitive-services/conf/readme.yaml
@@ -1,0 +1,3 @@
+documentations:
+
+source_doc:

--- a/modules/integration_azure-cognitive-services/detectors-gen.tf
+++ b/modules/integration_azure-cognitive-services/detectors-gen.tf
@@ -1,0 +1,28 @@
+resource "signalfx_detector" "success_rate" {
+  name = format("%s %s", local.detector_name_prefix, "Azure Cognitive Services success rate")
+
+  authorized_writer_teams = var.authorized_writer_teams
+  teams                   = try(coalescelist(var.teams, var.authorized_writer_teams), null)
+  tags                    = compact(concat(local.common_tags, local.tags, var.extra_tags))
+
+  program_text = <<-EOF
+    base_filtering = filter('resource_type', 'Microsoft.CognitiveServices/accounts') and filter('primary_aggregation_type', 'true')
+    signal = data('SuccessRate', filter=base_filtering and ${module.filtering.signalflow}, extrapolation='last_value')${var.success_rate_aggregation_function}${var.success_rate_transformation_function}.publish('signal')
+    detect(when(signal < ${var.success_rate_threshold_major}%{if var.success_rate_lasting_duration_major != null}, lasting='${var.success_rate_lasting_duration_major}', at_least=${var.success_rate_at_least_percentage_major}%{endif})).publish('MAJOR')
+EOF
+
+  rule {
+    description           = "is too low < ${var.success_rate_threshold_major}"
+    severity              = "Major"
+    detect_label          = "MAJOR"
+    disabled              = coalesce(var.success_rate_disabled, var.detectors_disabled)
+    notifications         = try(coalescelist(lookup(var.success_rate_notifications, "major", []), var.notifications.major), null)
+    runbook_url           = try(coalesce(var.success_rate_runbook_url, var.runbook_url), "")
+    tip                   = var.success_rate_tip
+    parameterized_subject = var.message_subject == "" ? local.rule_subject : var.message_subject
+    parameterized_body    = var.message_body == "" ? local.rule_body : var.message_body
+  }
+
+  max_delay = var.success_rate_max_delay
+}
+

--- a/modules/integration_azure-cognitive-services/outputs.tf
+++ b/modules/integration_azure-cognitive-services/outputs.tf
@@ -1,0 +1,5 @@
+output "success_rate" {
+  description = "Detector resource for success_rate"
+  value       = signalfx_detector.success_rate
+}
+

--- a/modules/integration_azure-cognitive-services/tags.tf
+++ b/modules/integration_azure-cognitive-services/tags.tf
@@ -1,0 +1,4 @@
+locals {
+  tags = ["integration", "azure-cognitive-services"]
+}
+

--- a/modules/integration_azure-cognitive-services/variables-gen.tf
+++ b/modules/integration_azure-cognitive-services/variables-gen.tf
@@ -1,0 +1,61 @@
+# success_rate detector
+
+variable "success_rate_notifications" {
+  description = "Notification recipients list per severity overridden for success_rate detector"
+  type        = map(list(string))
+  default     = {}
+}
+
+variable "success_rate_aggregation_function" {
+  description = "Aggregation function and group by for success_rate detector (i.e. \".mean(by=['host'])\")"
+  type        = string
+  default     = ".sum(by=['ratelimitkey', 'azure_resource_name', 'azure_resource_group_name', 'azure_region'])"
+}
+
+variable "success_rate_transformation_function" {
+  description = "Transformation function for success_rate detector (i.e. \".mean(over='5m')\")"
+  type        = string
+  default     = ""
+}
+
+variable "success_rate_max_delay" {
+  description = "Enforce max delay for success_rate detector (use \"0\" or \"null\" for \"Auto\")"
+  type        = number
+  default     = null
+}
+
+variable "success_rate_tip" {
+  description = "Suggested first course of action or any note useful for incident handling"
+  type        = string
+  default     = ""
+}
+
+variable "success_rate_runbook_url" {
+  description = "URL like SignalFx dashboard or wiki page which can help to troubleshoot the incident cause"
+  type        = string
+  default     = ""
+}
+
+variable "success_rate_disabled" {
+  description = "Disable all alerting rules for success_rate detector"
+  type        = bool
+  default     = null
+}
+
+variable "success_rate_threshold_major" {
+  description = "Major threshold for success_rate detector"
+  type        = number
+  default     = 10
+}
+
+variable "success_rate_lasting_duration_major" {
+  description = "Minimum duration that conditions must be true before raising alert"
+  type        = string
+  default     = "60m"
+}
+
+variable "success_rate_at_least_percentage_major" {
+  description = "Percentage of lasting that conditions must be true before raising alert (>= 0.0 and <= 1.0)"
+  type        = number
+  default     = 1
+}


### PR DESCRIPTION
Add a new module for Azure cognitive services

there is no heartbeat function, because we only get metrics when requests are made to the services (so this would give lots of false positives)

as a start , it includes a monitoring of the sucess rate of the service . 

extrapolation is set at `last_value` to fill periods without metrics.

default critical threshold is set below 10% success rate for one hour. No major threshold